### PR TITLE
Require build-ui before building Go binary.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build: build-ui
 	CGO_ENABLED=0 go build -o ./hermes ./cmd/hermes
 
 .PHONY: bin
-bin:
+bin: build-ui
 	CGO_ENABLED=0 go build -o ./hermes ./cmd/hermes
 
 .PHONY: bin/linux


### PR DESCRIPTION
The Go binary embeds the web UI at compile time. For `make bin` to succeed, the web UI must already have been build. As a result, a fresh install of the repo fails with `make dev`. With this change, the web UI is always rebuilt before the Go binary is built, ensuring the Go server has the latest version of the web UI. This fixes `make dev`.