### PR TITLE
Fix share popover z-index

### DIFF
--- a/web/app/components/sidebar.hbs
+++ b/web/app/components/sidebar.hbs
@@ -20,7 +20,7 @@
       </ul>
     </nav>
   {{else}}
-    <header class="relative flex flex-col space-y-2">
+    <header class="relative flex flex-col space-y-2 z-10">
       <ul class="flex w-full items-center justify-between list-none">
         <X::HdsTab
           @label="Back to Dashboard"


### PR DESCRIPTION
Increases the sidebarHeader z-index so the "share" popover sits above scrollable content.

#### Current:

![](https://user-images.githubusercontent.com/754957/215801835-c72d0868-766c-47d5-95c9-54e389825499.png)

#### Revised:

![](https://user-images.githubusercontent.com/754957/215802181-ececfafd-2c52-47f4-b79d-aafbe41c7b52.png)
