### PR TITLE
Remove unnecessary transition args

### DIFF
--- a/web/app/components/sidebar.js
+++ b/web/app/components/sidebar.js
@@ -202,7 +202,7 @@ export default class Sidebar extends Component {
     }
   }
 
-  get shortLinkBaseURL() {    
+  get shortLinkBaseURL() {
     return this.configSvc.config.short_link_base_url;
   }
 
@@ -274,7 +274,7 @@ export default class Sidebar extends Component {
         extendedTimeout: 1000,
       });
 
-      this.router.transitionTo("authenticated.document", this.docID, {
+      this.router.transitionTo({
         queryParams: { draft: false },
       });
 
@@ -282,7 +282,6 @@ export default class Sidebar extends Component {
     } catch (err) {
       this.showModalError("Error creating review", err);
     }
-
     this.refreshRoute();
   }
 


### PR DESCRIPTION
Removes self-referential route information from the `requestReview` task. To transition queryParams without changing routes we can just write:

```
this.router.transitionTo({queryParams: { draft: false }});
```

Source:
[Ember `transitionTo` docs](https://guides.emberjs.com/release/routing/query-params/#toc_transitionto)