### PR TITLE
Add SessionService types

### DIFF
--- a/web/app/controllers/authenticate.ts
+++ b/web/app/controllers/authenticate.ts
@@ -3,10 +3,11 @@ import { inject as service } from "@ember/service";
 import { action } from "@ember/object";
 import RouterService from "@ember/routing/router-service";
 import Transition from "@ember/routing/transition";
+import SessionService from "ember-simple-auth/session";
 
 export default class AuthenticateController extends Controller {
   @service declare router: RouterService;
-  @service declare session: any;
+  @service declare session: SessionService;
 
   previousTransition: Transition | null = null;
 

--- a/web/app/routes/authenticate.ts
+++ b/web/app/routes/authenticate.ts
@@ -1,8 +1,9 @@
 import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
+import SessionService from "ember-simple-auth/session";
 
 export default class AuthenticateRoute extends Route {
-  @service declare session: any;
+  @service declare session: SessionService;
 
   beforeModel() {
     this.session.prohibitAuthentication("/");

--- a/web/app/routes/authenticated.ts
+++ b/web/app/routes/authenticated.ts
@@ -4,9 +4,10 @@ import ConfigService from "hermes/services/config";
 import AuthenticateController from "hermes/controllers/authenticate";
 import AuthenticatedUserService from "hermes/services/authenticated-user";
 import Transition from "@ember/routing/transition";
+import SessionService from "ember-simple-auth/session";
 
 export default class AuthenticatedRoute extends Route {
-  @service declare session: any;
+  @service declare session: SessionService;
   @service declare authenticatedUser: AuthenticatedUserService;
   @service("config") declare configSvc: ConfigService;
 

--- a/web/app/services/algolia.ts
+++ b/web/app/services/algolia.ts
@@ -15,6 +15,7 @@ import { assert } from "@ember/debug";
 import ConfigService from "./config";
 import { FacetOption, FacetRecord, FacetRecords } from "hermes/types/facets";
 import FetchService from "./fetch";
+import SessionService from "ember-simple-auth/session";
 
 export const HITS_PER_PAGE = 12;
 export const MAX_VALUES_PER_FACET = 100;
@@ -27,8 +28,7 @@ export default class AlgoliaService extends Service {
   @service("config") declare configSvc: ConfigService;
   @service("fetch") declare fetchSvc: FetchService;
   @service declare authenticatedUser: AuthenticatedUserService;
-  // TODO: use actual type.
-  @service session: any;
+  @service declare session: SessionService;
 
   /**
    * A shorthand getter for the authenticatedUser's email.
@@ -62,6 +62,7 @@ export default class AlgoliaService extends Service {
       console.log(
         "Running locally as production environment: Algolia client configured to proxy requests through the Hermes API."
       );
+
       return algoliaSearch("", "", {
         headers: {
           "Hermes-Google-Access-Token":

--- a/web/app/services/authenticated-user.ts
+++ b/web/app/services/authenticated-user.ts
@@ -5,6 +5,7 @@ import Store from "@ember-data/store";
 import { assert } from "@ember/debug";
 import { task } from "ember-concurrency";
 import FetchService from "hermes/services/fetch";
+import SessionService from "ember-simple-auth/session";
 
 export interface AuthenticatedUser {
   email: string;
@@ -26,7 +27,7 @@ enum SubscriptionType {
 export default class AuthenticatedUserService extends Service {
   @service("fetch") declare fetchSvc: FetchService;
   @service declare store: Store;
-  @service declare session: any;
+  @service declare session: SessionService;
 
   @tracked subscriptions: Subscription[] | null = null;
   @tracked private _info: AuthenticatedUser | null = null;

--- a/web/types/ember-simple-auth/session.d.ts
+++ b/web/types/ember-simple-auth/session.d.ts
@@ -1,0 +1,23 @@
+// Reference: https://github.com/mainmatter/ember-simple-auth/blob/master/packages/ember-simple-auth/addon/services/session.js
+
+import Service from "@ember/service";
+import Evented from "@ember/object/evented";
+import Transition from "@ember/routing/transition";
+
+export interface Data {
+  authenticated: {
+    access_token: string;
+  };
+}
+
+export default class SessionService extends Service<Evented> {
+  data: Data;
+  setup: () => void;
+  authenticate(...args: any[]): RSVP.Promise;
+  invalidate(...args: any): RSVP.Promise;
+  requireAuthentication(
+    transition: Transition,
+    routeOrCallback: string | function
+  ): RSVP.Promise;
+  prohibitAuthentication(routeOrCallback: string | function): RSVP.Promise;
+}


### PR DESCRIPTION
Adds types to the `ember-simple-auth` SessionService and replaces uses of `session: any`.