### PR TITLE
Save target url in SessionStorage for post-auth redirect; Add EmberSimpleAuth types

### DIFF
--- a/web/app/controllers/authenticate.ts
+++ b/web/app/controllers/authenticate.ts
@@ -1,9 +1,10 @@
 import Controller from "@ember/controller";
 import { inject as service } from "@ember/service";
 import { action } from "@ember/object";
+import SessionService from "hermes/services/session";
 
 export default class AuthenticateController extends Controller {
-  @service declare session: any;
+  @service declare session: SessionService;
 
   protected get currentYear(): number {
     return new Date().getFullYear();
@@ -11,7 +12,6 @@ export default class AuthenticateController extends Controller {
 
   @action protected authenticate(): void {
     this.session.authenticate("authenticator:torii", "google-oauth2-bearer");
-
   }
 }
 

--- a/web/app/controllers/authenticate.ts
+++ b/web/app/controllers/authenticate.ts
@@ -1,14 +1,9 @@
 import Controller from "@ember/controller";
 import { inject as service } from "@ember/service";
 import { action } from "@ember/object";
-import RouterService from "@ember/routing/router-service";
-import Transition from "@ember/routing/transition";
 
 export default class AuthenticateController extends Controller {
-  @service declare router: RouterService;
   @service declare session: any;
-
-  previousTransition: Transition | null = null;
 
   protected get currentYear(): number {
     return new Date().getFullYear();
@@ -17,18 +12,6 @@ export default class AuthenticateController extends Controller {
   @action protected authenticate(): void {
     this.session.authenticate("authenticator:torii", "google-oauth2-bearer");
 
-    // Capture the previousTransition locally if it exists
-    let _previousTransition = this.previousTransition;
-
-    if (_previousTransition) {
-      // Clear the previousTransition class property
-      this.previousTransition = null;
-
-      // Retry the initial transition
-      _previousTransition.retry();
-    } else {
-      this.router.transitionTo("authenticated.dashboard");
-    }
   }
 }
 

--- a/web/app/routes/authenticate.ts
+++ b/web/app/routes/authenticate.ts
@@ -1,8 +1,9 @@
 import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
+import SessionService from "hermes/services/session";
 
 export default class AuthenticateRoute extends Route {
-  @service declare session: any;
+  @service declare session: SessionService;
 
   beforeModel() {
     this.session.prohibitAuthentication("/");

--- a/web/app/routes/authenticated.ts
+++ b/web/app/routes/authenticated.ts
@@ -1,24 +1,38 @@
 import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
 import AuthenticatedUserService from "hermes/services/authenticated-user";
-import Transition from "@ember/routing/transition";
+import window from "ember-window-mock";
+import SessionService from "hermes/services/session";
 
 export default class AuthenticatedRoute extends Route {
-  @service declare session: any;
+  @service declare session: SessionService;
   @service declare authenticatedUser: AuthenticatedUserService;
 
   async afterModel(): Promise<void> {
-    // Load user info
     await this.authenticatedUser.loadInfo.perform();
   }
 
   async beforeModel(transition: any): Promise<void> {
-    let target = sessionStorage.getItem(this.session.SESSION_STORAGE_KEY);
-    if (transition.to.name != "authenticated.index" && !target) {
-      // apparently transition.intent is private or at least not documented so typing
-      // fails on this line
+    // If the user isn't authenticated, transition to the auth screen
+    let requireAuthentication = this.session.requireAuthentication(
+      transition,
+      "authenticate"
+    );
+
+    let target = window.sessionStorage.getItem(
+      this.session.SESSION_STORAGE_KEY
+    );
+    if (
+      !target &&
+      !requireAuthentication &&
+      transition.to.name != "authenticated"
+    ) {
       // ember-simple-auth uses this value to set cookies when fastboot is enabled: https://github.com/mainmatter/ember-simple-auth/blob/a7e583cf4d04d6ebc96b198a8fa6dde7445abf0e/packages/ember-simple-auth/addon/-internals/routing.js#L12
-      sessionStorage.setItem(this.session.SESSION_STORAGE_KEY, transition.intent.url);
+
+      window.sessionStorage.setItem(
+        this.session.SESSION_STORAGE_KEY,
+        transition.intent.url
+      );
     }
   }
 }

--- a/web/app/routes/authenticated.ts
+++ b/web/app/routes/authenticated.ts
@@ -1,34 +1,24 @@
 import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
-import ConfigService from "hermes/services/config";
-import AuthenticateController from "hermes/controllers/authenticate";
 import AuthenticatedUserService from "hermes/services/authenticated-user";
 import Transition from "@ember/routing/transition";
 
 export default class AuthenticatedRoute extends Route {
   @service declare session: any;
   @service declare authenticatedUser: AuthenticatedUserService;
-  @service("config") declare configSvc: ConfigService;
 
   async afterModel(): Promise<void> {
     // Load user info
     await this.authenticatedUser.loadInfo.perform();
   }
 
-  async beforeModel(transition: Transition): Promise<void> {
-    // Check if the request requires authentication and if so, preserve the URL
-    let requireAuthentication = this.session.requireAuthentication(
-      transition,
-      "authenticate"
-    );
-
-    if (!requireAuthentication && transition.to.name != "authenticated.index") {
-      let authenticateController = this.controllerFor(
-        "authenticate"
-      ) as AuthenticateController;
-
-      // Set previous transition to preserve URL
-      authenticateController.previousTransition = transition;
+  async beforeModel(transition: any): Promise<void> {
+    let target = sessionStorage.getItem(this.session.SESSION_STORAGE_KEY);
+    if (transition.to.name != "authenticated.index" && !target) {
+      // apparently transition.intent is private or at least not documented so typing
+      // fails on this line
+      // ember-simple-auth uses this value to set cookies when fastboot is enabled: https://github.com/mainmatter/ember-simple-auth/blob/a7e583cf4d04d6ebc96b198a8fa6dde7445abf0e/packages/ember-simple-auth/addon/-internals/routing.js#L12
+      sessionStorage.setItem(this.session.SESSION_STORAGE_KEY, transition.intent.url);
     }
   }
 }

--- a/web/app/services/algolia.ts
+++ b/web/app/services/algolia.ts
@@ -15,6 +15,7 @@ import { assert } from "@ember/debug";
 import ConfigService from "./config";
 import { FacetOption, FacetRecord, FacetRecords } from "hermes/types/facets";
 import FetchService from "./fetch";
+import SessionService from "./session";
 
 export const HITS_PER_PAGE = 12;
 export const MAX_VALUES_PER_FACET = 100;
@@ -26,9 +27,9 @@ export type AlgoliaFacetsObject = NonNullable<SearchResponse["facets"]>;
 export default class AlgoliaService extends Service {
   @service("config") declare configSvc: ConfigService;
   @service("fetch") declare fetchSvc: FetchService;
+  @service declare session: SessionService;
   @service declare authenticatedUser: AuthenticatedUserService;
-  // TODO: use actual type.
-  @service session: any;
+
 
   /**
    * A shorthand getter for the authenticatedUser's email.

--- a/web/app/services/authenticated-user.ts
+++ b/web/app/services/authenticated-user.ts
@@ -5,6 +5,7 @@ import Store from "@ember-data/store";
 import { assert } from "@ember/debug";
 import { task } from "ember-concurrency";
 import FetchService from "hermes/services/fetch";
+import SessionService from "./session";
 
 export interface AuthenticatedUser {
   email: string;
@@ -25,8 +26,8 @@ enum SubscriptionType {
 
 export default class AuthenticatedUserService extends Service {
   @service("fetch") declare fetchSvc: FetchService;
+  @service declare session: SessionService;
   @service declare store: Store;
-  @service declare session: any;
 
   @tracked subscriptions: Subscription[] | null = null;
   @tracked private _info: AuthenticatedUser | null = null;

--- a/web/app/services/session.ts
+++ b/web/app/services/session.ts
@@ -1,20 +1,19 @@
-// @ts-nocheck
-// TODO: Type this file. - really just the ESA session
-
-import ESASession from 'ember-simple-auth/services/session';
 import { inject as service } from "@ember/service";
 import RouterService from "@ember/routing/router-service";
+import EmberSimpleAuthSessionService from "ember-simple-auth/services/session";
+import window from "ember-window-mock";
 
-export default class SessionService extends ESASession {
-  
+export default class SessionService extends EmberSimpleAuthSessionService {
   @service declare router: RouterService;
-  readonly SESSION_STORAGE_KEY: string = 'hermes.redirectTarget';
 
-   // ember-simple-auth's only uses a cookie to track redirect target if you're using fastboot, otherwise it keeps track of the redirect target as a parameter on the session service. See the source here: https://github.com/mainmatter/ember-simple-auth/blob/a7e583cf4d04d6ebc96b198a8fa6dde7445abf0e/packages/ember-simple-auth/addon/-internals/routing.js#L33-L50
+  readonly SESSION_STORAGE_KEY: string = "hermes.redirectTarget";
+
+  // ember-simple-auth only uses a cookie to track redirect target if you're using fastboot, otherwise it keeps track of the redirect target as a parameter on the session service. See the source here: https://github.com/mainmatter/ember-simple-auth/blob/a7e583cf4d04d6ebc96b198a8fa6dde7445abf0e/packages/ember-simple-auth/addon/-internals/routing.js#L33-L50
   //
-  // Because we redirect as part of the authentication flow, the parameter storing the transtion gets reset. Instead, we keep track of the redirectTarget in browser sessionStorage and override the handleAuthentication method as recommended by ember-simple-auth.
+  // Because we redirect as part of the authentication flow, the parameter storing the transition gets reset. Instead, we keep track of the redirectTarget in browser sessionStorage and override the handleAuthentication method as recommended by ember-simple-auth.
+
   handleAuthentication(routeAfterAuthentication: string) {
-    let redirectTarget = sessionStorage.getItem(this.SESSION_STORAGE_KEY);
+    let redirectTarget = window.sessionStorage.getItem(this.SESSION_STORAGE_KEY);
     let transition;
 
     if (redirectTarget) {
@@ -23,7 +22,7 @@ export default class SessionService extends ESASession {
       transition = this.router.transitionTo(routeAfterAuthentication);
     }
     transition.followRedirects().then(() => {
-      sessionStorage.removeItem(this.SESSION_STORAGE_KEY);
+      window.sessionStorage.removeItem(this.SESSION_STORAGE_KEY);
     });
   }
 }

--- a/web/app/services/session.ts
+++ b/web/app/services/session.ts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+// TODO: Type this file. - really just the ESA session
+
+import ESASession from 'ember-simple-auth/services/session';
+import { inject as service } from "@ember/service";
+import RouterService from "@ember/routing/router-service";
+
+export default class SessionService extends ESASession {
+  
+  @service declare router: RouterService;
+  readonly SESSION_STORAGE_KEY: string = 'hermes.redirectTarget';
+
+   // ember-simple-auth's only uses a cookie to track redirect target if you're using fastboot, otherwise it keeps track of the redirect target as a parameter on the session service. See the source here: https://github.com/mainmatter/ember-simple-auth/blob/a7e583cf4d04d6ebc96b198a8fa6dde7445abf0e/packages/ember-simple-auth/addon/-internals/routing.js#L33-L50
+  //
+  // Because we redirect as part of the authentication flow, the parameter storing the transtion gets reset. Instead, we keep track of the redirectTarget in browser sessionStorage and override the handleAuthentication method as recommended by ember-simple-auth.
+  handleAuthentication(routeAfterAuthentication: string) {
+    let redirectTarget = sessionStorage.getItem(this.SESSION_STORAGE_KEY);
+    let transition;
+
+    if (redirectTarget) {
+      transition = this.router.transitionTo(redirectTarget);
+    } else {
+      transition = this.router.transitionTo(routeAfterAuthentication);
+    }
+    transition.followRedirects().then(() => {
+      sessionStorage.removeItem(this.SESSION_STORAGE_KEY);
+    });
+  }
+}

--- a/web/types/ember-simple-auth/services/session.d.ts
+++ b/web/types/ember-simple-auth/services/session.d.ts
@@ -1,0 +1,25 @@
+// Reference: https://github.com/mainmatter/ember-simple-auth/blob/master/packages/ember-simple-auth/addon/services/session.js
+
+import Service from "@ember/service";
+import Evented from "@ember/object/evented";
+import Transition from "@ember/routing/transition";
+
+export interface Data {
+  authenticated: {
+    access_token: string;
+  };
+}
+
+declare module "ember-simple-auth/services/session" {
+  export default class EmberSimpleAuthSessionService extends Service.extend(Evented) {
+    data: Data;
+    setup: () => void;
+    authenticate(...args: any[]): RSVP.Promise;
+    invalidate(...args: any): RSVP.Promise;
+    requireAuthentication(
+      transition: Transition,
+      routeOrCallback: string | function
+    ): RSVP.Promise;
+    prohibitAuthentication(routeOrCallback: string | function): RSVP.Promise;
+  }
+}


### PR DESCRIPTION
Ember-simple-auth tracks the current transition in a service, but if you do a full redirect for authentication, that value isn't persisted anywhere.

This PR removes some code that I believe was trying to duplicate the ember-simple-auth functionality. It also adds an alternate method for maintaining the target url that uses the browser's SessionStorage API which does survive redirects.

The result of this is: if you're following a link from an email and aren't authenticated, you should get redirected to the target link after completing authentication.