### PR TITLE
Fix search results; improve product-link logic on results screen

### DIFF
--- a/web/app/components/header/search.hbs
+++ b/web/app/components/header/search.hbs
@@ -30,7 +30,7 @@
             >
               <LinkTo
                 @route="authenticated.results"
-                @query={{hash q=this.query}}
+                @query={{hash q=this.query page=1}}
                 class="hds-dropdown-list-item--interactive"
               >
                 <FlightIcon @name="search" class="mr-1.5" />

--- a/web/app/components/results/index.hbs
+++ b/web/app/components/results/index.hbs
@@ -1,9 +1,7 @@
 <section class="flex flex-col items-center flex-1 min-h-full">
   <div class="x-container">
-
-    {{#let (get (get @results.hits 0) "product") as |product|}}
-      {{#if product}}
-        <div class="flex flex-col items-start w-full pb-10">
+      {{#if (and this.firstPageIsShown this.queryIsProductName)}}
+        <div class="flex flex-col items-start w-full pb-10" data-test-results-product-link>
           <Hds::Card::Container
             @level="mid"
             @hasBorder="true"
@@ -11,25 +9,24 @@
             class="flex flex-col items-start space-y-3 pt-4 px-4 pb-3"
           >
             <Hds::Badge
-              @text={{product}}
-              @icon={{or (get-product-id product) "folder"}}
+              @text={{this.capitalizedQuery}}
+              @icon={{or (get-product-id @query) "folder"}}
             />
+            {{log @query}}
             <Hds::Link::Standalone
-              @text="View all {{product}} documents"
+              @text="View all {{this.capitalizedQuery}} documents"
               @icon="arrow-right-circle"
               @iconPosition="trailing"
               @route="authenticated.all"
-              @query={{hash product=(array product)}}
+              @query={{hash product=(array this.capitalizedQuery)}}
             />
           </Hds::Card::Container>
         </div>
       {{/if}}
-    {{/let}}
 
     <h1
       class="hds-typography-display-300 hds-font-weight-semibold hds-foreground-strong"
     >{{@results.nbHits}} documents matching “{{@query}}”</h1>
-
     <div class="flex flex-col space-y-12 w-full py-10">
       <div class="tile-list">
         {{#each @results.hits as |doc index|}}

--- a/web/app/components/results/index.hbs
+++ b/web/app/components/results/index.hbs
@@ -12,7 +12,6 @@
               @text={{this.capitalizedQuery}}
               @icon={{or (get-product-id @query) "folder"}}
             />
-            {{log @query}}
             <Hds::Link::Standalone
               @text="View all {{this.capitalizedQuery}} documents"
               @icon="arrow-right-circle"

--- a/web/app/components/results/index.ts
+++ b/web/app/components/results/index.ts
@@ -1,11 +1,33 @@
 import Component from "@glimmer/component";
 import { SearchResponse } from "@algolia/client-search";
+import { HermesDocument } from "hermes/types/document";
+import { capitalize } from "@ember/string";
 
 interface ResultsIndexComponentSignature {
   Args: {
-    results?: SearchResponse;
+    results: SearchResponse;
     query: string;
   };
 }
 
-export default class ResultsIndexComponent extends Component<ResultsIndexComponentSignature> {}
+export default class ResultsIndexComponent extends Component<ResultsIndexComponentSignature> {
+  get firstPageIsShown(): boolean {
+    return this.args.results.page === 0;
+  }
+
+  get lowercasedQuery(): string {
+    return this.args.query.toLowerCase();
+  }
+
+  get capitalizedQuery(): string {
+    return capitalize(this.lowercasedQuery);
+  }
+
+  get queryIsProductName(): boolean {
+    let hits = this.args.results?.hits as HermesDocument[];
+    // Assume at least one of the first 12 hits is a product match for the query.
+    return hits.some(
+      (hit) => hit.product?.toLowerCase() === this.lowercasedQuery
+    );
+  }
+}

--- a/web/app/routes/authenticated/results.ts
+++ b/web/app/routes/authenticated/results.ts
@@ -25,6 +25,9 @@ export default class ResultsRoute extends Route {
     status: {
       refreshModel: true,
     },
+    q: {
+      refreshModel: true,
+    }
   };
 
   async model(params: ResultsRouteParams) {

--- a/web/app/services/algolia.ts
+++ b/web/app/services/algolia.ts
@@ -289,9 +289,10 @@ export default class AlgoliaService extends Service {
       params: AlgoliaSearchParams,
       userIsOwner = false
     ): Promise<FacetRecords | undefined> => {
+      let query = params["q"] || "";
       try {
         let facetFilters = userIsOwner ? [`owners:${this.userEmail}`] : [];
-        let algoliaFacets = await this.searchIndex.perform(searchIndex, "", {
+        let algoliaFacets = await this.searchIndex.perform(searchIndex, query, {
           facetFilters: facetFilters,
           facets: FACET_NAMES,
           hitsPerPage: HITS_PER_PAGE,
@@ -335,8 +336,10 @@ export default class AlgoliaService extends Service {
       params: AlgoliaSearchParams,
       userIsOwner = false
     ): Promise<SearchResponse | unknown> => {
+      let query = params["q"] || "";
+
       try {
-        return await this.searchIndex.perform(searchIndex, "", {
+        return await this.searchIndex.perform(searchIndex, query, {
           facetFilters: this.buildFacetFilters(params, userIsOwner),
           facets: FACET_NAMES,
           hitsPerPage: HITS_PER_PAGE,

--- a/web/tests/integration/components/results/index-test.ts
+++ b/web/tests/integration/components/results/index-test.ts
@@ -1,0 +1,59 @@
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+import { render, rerender } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+
+module("Integration | Component | results", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("it conditionally shows a product link", async function (assert) {
+    let hits = [{ product: "Consul" }, { product: "Terraform" }];
+
+    this.set("results", {
+      page: 0,
+      hits: hits,
+    });
+
+    this.set("query", "teRRaForM");
+
+    await render(hbs`
+      <Results::Index @results={{this.results}} @query={{this.query}} />
+    `);
+
+    assert
+      .dom("[data-test-results-product-link]")
+      .exists(
+        "Product link is shown when query matches a product name of the first 12 hits"
+      );
+
+    assert
+      .dom(".hds-badge__text")
+      .hasText(
+        "Terraform",
+        "Product name is shown in badge, properly capitalized"
+      );
+    assert
+      .dom("[data-test-results-product-link] a")
+      .hasText("View all Terraform documents")
+      .hasAttribute("href", "/all?product=%5B%22Terraform%22%5D");
+
+    this.set("query", "engineering");
+    assert
+      .dom("[data-test-results-product-link]")
+      .doesNotExist(
+        "only shown when query matches a product name of the first 12 hits"
+      );
+
+    this.set("query", "consul");
+    assert.dom("[data-test-results-product-link]").exists();
+
+    this.set("results", {
+      page: 1,
+      hits: hits,
+    });
+
+    assert
+      .dom("[data-test-results-product-link]")
+      .doesNotExist("only shown on first page of results");
+  });
+});


### PR DESCRIPTION
- Fixes a search-results bug that prevented queries from reaching the AlgoliaService
- Fixes a bug where the pageNumber wouldn't reset when starting a new query
- Fixes a bug where searching from the results page wouldn't refresh the results
- Makes it so the "View all PRODUCT documents →" link only appears 1) on the first page; and 2) when queries match a product. Our current approach of showing the product associated with the first result is often inaccurate, and it's confusing to see it change on every screen.
