### PR TITLE
Add missing yarn dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Example shared drive organization
 
 - Go 1.18
 - Node.js 14
+- Yarn ~3.3.0 ([install with corepack](https://yarnpkg.com/getting-started/install))
 
 ### Configuration File
 


### PR DESCRIPTION
Following the current instructions in the README (`make build`) will result in a failure due to missing `yarn` dependency, which is needed to build the web component.