### PR TITLE
show document title in the HTML page title

### DIFF
--- a/web/app/templates/authenticated/document.hbs
+++ b/web/app/templates/authenticated/document.hbs
@@ -1,3 +1,3 @@
-{{page-title (or this.document.title "Document")}}
+{{page-title (or @model.doc.title "Document")}}
 {{set-body-class "bg-color-page-faint"}}
 <Document @document={{@model.doc}} @docType={{@model.docType}} />


### PR DESCRIPTION
I noticed with multiple tabs open, I was only ever getting "Document" in the page title. This should show the document's actual title instead.