### PR TITLE
Improve RequestReviewModal Buttons and Inputs

### DIFF
--- a/web/app/components/inputs/people-select.hbs
+++ b/web/app/components/inputs/people-select.hbs
@@ -10,6 +10,7 @@
   @onChange={{@onChange}}
   @onInput={{this.onInput}}
   @onClose={{this.onClose}}
+  @disabled={{@disabled}}
   @selectedItemComponent={{component "multiselect/user-email-image-chip"}}
   ...attributes
   as |value|

--- a/web/app/components/sidebar.hbs
+++ b/web/app/components/sidebar.hbs
@@ -623,10 +623,12 @@
                 @renderInPlace={{true}}
                 @selected={{this.approvers}}
                 @onChange={{this.updateApprovers}}
+                @disabled={{this.requestReview.isRunning}}
                 class="mb-0"
+
               />
             </F.Control>
-            <F.Label>Request reviews</F.Label>
+            <F.Label>Add approvers</F.Label>
           </Hds::Form::Field>
 
           {{#if @docType.checks.length}}
@@ -635,7 +637,8 @@
               <div class="mt-3.5">
                 <Hds::Form::Checkbox::Field
                   {{on "change" this.onDocTypeCheckboxChange}}
-                  @checked={{this.docTypeCheckboxValue}}
+                  checked={{this.docTypeCheckboxValue}}
+                  disabled={{this.requestReview.isRunning}}
                   required
                   as |F|
                 >


### PR DESCRIPTION
Improves the "Request review" modal. How?

- `docType.checks` checkbox stays checked while the `requestReview` task runs.
- `PeopleSelect` and `docType.checks` checkbox are disabled while the `requestReview` task runs.
- The `PeopleSelect` label more accurately describes its function.