### PR TITLE
Add share button to condensed sidebar

### DIFF
--- a/web/app/components/document/index.hbs
+++ b/web/app/components/document/index.hbs
@@ -1,5 +1,5 @@
 <div class="flex flex-1 p-4 space-x-4 max-h-screen">
-  <Sidebar
+  <Document::Sidebar
     @profile={{this.authenticatedUser.info}}
     @document={{@document}}
     @deleteDraft={{this.deleteDraft}}

--- a/web/app/components/document/share-button.hbs
+++ b/web/app/components/document/share-button.hbs
@@ -1,0 +1,9 @@
+<Hds::Dropdown @listPosition="left" as |dd|>
+  <dd.ToggleIcon ...attributes @icon="share" @text="share" @hasChevron={{false}} />
+  <dd.CopyItem
+    @text="{{this.shortLinkBaseURL}}/{{lowercase @document.docType}}/{{lowercase
+      @document.docNumber
+    }}"
+    @copyItemTitle="Copy URL"
+  />
+</Hds::Dropdown>

--- a/web/app/components/document/share-button.hbs
+++ b/web/app/components/document/share-button.hbs
@@ -1,5 +1,11 @@
 <Hds::Dropdown @listPosition="left" as |dd|>
-  <dd.ToggleIcon ...attributes @icon="share" @text="share" @hasChevron={{false}} />
+  <dd.ToggleIcon
+    {{! There's no 16px version of the ToggleIcon so we approximate it. }}
+    class={{if @isDownscaled "scale-[80%]"}}
+    @icon="share"
+    @text="share"
+    @hasChevron={{false}}
+  />
   <dd.CopyItem
     @text="{{this.shortLinkBaseURL}}/{{lowercase @document.docType}}/{{lowercase
       @document.docNumber

--- a/web/app/components/document/share-button.ts
+++ b/web/app/components/document/share-button.ts
@@ -1,0 +1,18 @@
+import { inject as service } from "@ember/service";
+import Component from "@glimmer/component";
+import ConfigService from "hermes/services/config";
+import { HermesDocument } from "hermes/types/document";
+
+interface DocumentShareButtonComponentSignature {
+  Args: {
+    document: HermesDocument;
+  };
+}
+
+export default class DocumentShareButtonComponent extends Component<DocumentShareButtonComponentSignature> {
+  @service('config') declare configSvc: ConfigService;
+
+  protected get shortLinkBaseURL() {
+    return this.configSvc.config.short_link_base_url;
+  }
+}

--- a/web/app/components/document/share-button.ts
+++ b/web/app/components/document/share-button.ts
@@ -6,6 +6,7 @@ import { HermesDocument } from "hermes/types/document";
 interface DocumentShareButtonComponentSignature {
   Args: {
     document: HermesDocument;
+    isDownscaled?: boolean;
   };
 }
 

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -17,6 +17,9 @@
             <FlightIcon @name="external-link" />
           </a>
         </div>
+        {{#if this.shareButtonIsShown}}
+          <Document::ShareButton @document={{@document}} class="scale-[80%]" />
+        {{/if}}
       </ul>
     </nav>
   {{else}}
@@ -38,15 +41,7 @@
       <ul class="flex w-full items-center justify-end space-x-1 pr-1 list-none">
 
         {{#if this.shareButtonIsShown}}
-          <Hds::Dropdown @listPosition="left" as |dd|>
-            <dd.ToggleIcon @icon="share" @text="share" @hasChevron={{false}} />
-            <dd.CopyItem
-              @text="{{this.shortLinkBaseURL}}/{{lowercase
-                @document.docType
-              }}/{{lowercase @document.docNumber}}"
-              @copyItemTitle="Copy URL"
-            />
-          </Hds::Dropdown>
+          <Document::ShareButton @document={{@document}} />
         {{/if}}
 
         <a

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -18,7 +18,10 @@
           </a>
         </div>
         {{#if this.shareButtonIsShown}}
-          <Document::ShareButton @document={{@document}} class="scale-[80%]" />
+          <Document::ShareButton
+            @document={{@document}}
+            @isDownscaled={{true}}
+          />
         {{/if}}
       </div>
     </nav>

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -1,7 +1,7 @@
 <aside class="sidebar {{if this.isCollapsed 'w-8' 'w-64'}}">
   {{#if this.isCollapsed}}
     <nav class="relative flex flex-col space-y-2">
-      <ul class="flex flex-col items-center space-y-3 list-none">
+      <div class="flex flex-col items-center space-y-3">
         <X::HdsTab
           @label="Expand"
           @icon="sidebar-show"
@@ -20,11 +20,11 @@
         {{#if this.shareButtonIsShown}}
           <Document::ShareButton @document={{@document}} class="scale-[80%]" />
         {{/if}}
-      </ul>
+      </div>
     </nav>
   {{else}}
     <header class="relative flex flex-col space-y-2 z-10">
-      <ul class="flex w-full items-center justify-between list-none">
+      <div class="flex w-full items-center justify-between">
         <X::HdsTab
           @label="Back to Dashboard"
           @icon="arrow-left"
@@ -36,9 +36,9 @@
           @iconOnly="true"
           @action={{this.collapseSidebar}}
         />
-      </ul>
+      </div>
 
-      <ul class="flex w-full items-center justify-end space-x-1 pr-1 list-none">
+      <div class="flex w-full items-center justify-end space-x-1 pr-1">
 
         {{#if this.shareButtonIsShown}}
           <Document::ShareButton @document={{@document}} />
@@ -51,7 +51,7 @@
         >
           <FlightIcon @name="external-link" class="relative ml-0.5 mt-0.5" />
         </a>
-      </ul>
+      </div>
 
       {{#let (get-product-id @document.product) as |productIcon|}}
         {{#if productIcon}}

--- a/web/app/components/document/sidebar.js
+++ b/web/app/components/document/sidebar.js
@@ -6,8 +6,7 @@ import { inject as service } from "@ember/service";
 import { task } from "ember-concurrency";
 import { dasherize } from "@ember/string";
 
-export default class Sidebar extends Component {
-  @service("config") configSvc;
+export default class DocumentSidebar extends Component {
   @service("fetch") fetchSvc;
   @service router;
   @service session;
@@ -202,9 +201,6 @@ export default class Sidebar extends Component {
     }
   }
 
-  get shortLinkBaseURL() {
-    return this.configSvc.config.short_link_base_url;
-  }
 
   @action refreshRoute() {
     // We force refresh due to a bug with `refreshModel: true`


### PR DESCRIPTION
Component-izes the share widget and adds it to the condensed sidebar.

<img width="62" alt="CleanShot 2023-02-10 at 12 50 25@2x" src="https://user-images.githubusercontent.com/754957/218161583-a1568f24-b092-4c16-acf2-e8a2e174768d.png">

Plus some light housekeeping.