### PR TITLE
Sidebar: Remove unnecessary `{{else}}` block

### DIFF
--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -276,21 +276,6 @@
               />
             </:editing>
           </EditableField>
-        {{else}}
-          {{#if this.approvers.length}}
-            <ol class="person-list">
-              {{#each this.approvers as |approver|}}
-                <li>
-                  <Person
-                    @imgURL={{approver.imgURL}}
-                    @email={{approver.email}}
-                  />
-                </li>
-              {{/each}}
-            </ol>
-          {{else}}
-            <em>No approvers</em>
-          {{/if}}
         {{/if}}
       </div>
 


### PR DESCRIPTION
Deletes an `{{else}}` block that I should have removed in #48

You'll notice that the part I removed is already being handled by the `<:default>` block.