### PR TITLE
Fix NaN issue in Latest Updates timestamps

### DIFF
--- a/web/app/components/dashboard/latest-updates.ts
+++ b/web/app/components/dashboard/latest-updates.ts
@@ -86,8 +86,10 @@ export default class DashboardLatestUpdatesComponent extends Component<Dashboard
       .then((result: SearchResponse<unknown>) => {
         // Add modifiedAgo for each doc.
         for (const hit of result.hits as HermesDocument[]) {
-          const modifiedAgo = new Date(hit.modifiedTime * 1000);
-          hit.modifiedAgo = `Modified ${timeAgo(modifiedAgo)}`;
+          if (hit.modifiedTime) {
+            const modifiedAgo = new Date(hit.modifiedTime * 1000);
+            hit.modifiedAgo = `Modified ${timeAgo(modifiedAgo)}`;
+          }
         }
         return result.hits;
       });


### PR DESCRIPTION
Fixes an issue where databases with fewer than 4 New/In Review/Published docs could see NaN labels in the Latest Updates tiles.

Long term, we will avoid this by set a `modifiedDate` attribute on doc creation.