### PR TITLE
Remove unused Algolia function

### DIFF
--- a/web/app/services/algolia.ts
+++ b/web/app/services/algolia.ts
@@ -13,7 +13,11 @@ import {
 } from "@algolia/client-search";
 import { assert } from "@ember/debug";
 import ConfigService from "./config";
-import { FacetDropdownObjectDetails, FacetRecord, FacetRecords } from "hermes/types/facets";
+import {
+  FacetDropdownObjectDetails,
+  FacetRecord,
+  FacetRecords,
+} from "hermes/types/facets";
 import FetchService from "./fetch";
 import SessionService from "./session";
 
@@ -29,7 +33,6 @@ export default class AlgoliaService extends Service {
   @service("fetch") declare fetchSvc: FetchService;
   @service declare session: SessionService;
   @service declare authenticatedUser: AuthenticatedUserService;
-
 
   /**
    * A shorthand getter for the authenticatedUser's email.
@@ -231,36 +234,6 @@ export default class AlgoliaService extends Service {
     return facetFilters;
   }
 
-  /**
-   * Returns an object of a given index and objectID.
-   * Used in the footer to show the date of the last full index.
-   */
-  getSearchIndexObject = task(
-    async (
-      indexName: string,
-      objectID: string
-    ): Promise<ObjectWithObjectID | undefined> => {
-      /**
-       * e.g., indexName = "hermes-staging"
-       * e.g., objectID = "LastFullIndex"
-       */
-      try {
-        let index: SearchIndex = this.client.initIndex(indexName);
-        return index.getObject(objectID).then(
-          (result) =>
-            /**
-             * e.g., result = {
-             *  lastFullIndexTime: "1995-01-06T20:58:17.59404Z",
-             *  objectID: "LastFullIndex",
-             * };
-             */
-            result
-        );
-      } catch (e: unknown) {
-        console.error(e);
-      }
-    }
-  );
   /**
    * Returns a search response for a given query and params.
    * Restarts with every search input keystroke.


### PR DESCRIPTION
Removes an unused function from the Algolia service.

We used to call this function in the footer but that's no longer the case.