### PR TITLE
Fix docs and facets on `/my` route

### DIFF
--- a/web/app/routes/authenticated/my.ts
+++ b/web/app/routes/authenticated/my.ts
@@ -38,8 +38,8 @@ export default class AuthenticatedMyRoute extends Route {
         : this.configSvc.config.algolia_docs_index_name + "_createdTime_desc";
 
     let [facets, results] = await Promise.all([
-      this.algolia.getFacets.perform(searchIndex, params),
-      this.algolia.getDocResults.perform(searchIndex, params),
+      this.algolia.getFacets.perform(searchIndex, params, true),
+      this.algolia.getDocResults.perform(searchIndex, params, true),
     ]);
 
     this.activeFilters.update(params);


### PR DESCRIPTION
Adds a missing `isOwner` argument to the `my` `model()` hooks that I mistakenly [didn't carry over](https://github.com/hashicorp-forge/hermes/commit/9ab2cba0cddcc9bf4356ead4fca450fce6377534#diff-33690d5aa90e447a8e18e59016a281f8f8119f8d556967d9c4a1d891a9077798) when doing #37. Without this, My Docs is just the same as All Docs. Apologies!