### PR TITLE
Sidebar: Show CustomField data to non-owners

### DIFF
--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -319,17 +319,15 @@
             <small class="hds-typography-body-100 hds-foreground-faint">
               {{attributes.displayName}}
             </small>
-            {{#if this.isOwner}}
-              <CustomEditableField
-                @document={{@document}}
-                @field={{field}}
-                @attributes={{attributes}}
-                @onChange={{perform this.save field}}
-                @updateFieldValue={{this.updateCustomFieldValue}}
-                @loading={{this.save.isRunning}}
-                @disabled={{this.editingIsDisabled}}
-              />
-            {{/if}}
+            <CustomEditableField
+              @document={{@document}}
+              @field={{field}}
+              @attributes={{attributes}}
+              @onChange={{perform this.save field}}
+              @updateFieldValue={{this.updateCustomFieldValue}}
+              @loading={{this.save.isRunning}}
+              @disabled={{or this.editingIsDisabled (not this.isOwner)}}
+            />
           </div>
         {{/if}}
       {{/each-in}}
@@ -621,7 +619,6 @@
                 @onChange={{this.updateApprovers}}
                 @disabled={{this.requestReview.isRunning}}
                 class="mb-0"
-
               />
             </F.Control>
             <F.Label>Add approvers</F.Label>


### PR DESCRIPTION
Fixes a template-logic bug where non-owners weren't seeing customEditableField data.