### PR TITLE
Reset MockDates after tests

### DIFF
--- a/web/tests/integration/helpers/get-facet-query-hash-test.ts
+++ b/web/tests/integration/helpers/get-facet-query-hash-test.ts
@@ -2,8 +2,6 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import MockDate from "mockdate";
-import { equal } from "@ember/object/computed";
 import ActiveFiltersService from "hermes/services/active-filters";
 
 module("Integration | Helper | get-facet-query-hash", function (hooks) {

--- a/web/tests/integration/helpers/parse-date-test.ts
+++ b/web/tests/integration/helpers/parse-date-test.ts
@@ -30,5 +30,7 @@ module("Integration | Helper | parse-date", function (hooks) {
       .dom(".long")
       .hasText("25 November 1989", "The long format renders correctly");
     assert.dom(".invalid").hasText("Unknown", "An invalid date returns null");
+
+    MockDate.reset();
   });
 });

--- a/web/tests/unit/utils/parse-date-test.ts
+++ b/web/tests/unit/utils/parse-date-test.ts
@@ -20,5 +20,7 @@ module("Unit | Utility | parse-date", function () {
     assert.equal(parseDate(undefined), null);
     assert.equal(parseDate("628021800000"), null);
     assert.equal(parseDate("4 days ago"), null);
+
+    MockDate.reset();
   });
 });


### PR DESCRIPTION
Adds cleanup code after each use of MockDate.

This isn't affecting us yet because we use the same date in our tests, but this may not always be true. So I'm getting ahead of it.