### PR TITLE
Bugfix: Add json transformation on new doc form

### DIFF
--- a/web/app/components/new/doc-form.ts
+++ b/web/app/components/new/doc-form.ts
@@ -200,19 +200,21 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
     this.docIsBeingCreated = true;
 
     try {
-      const doc = await this.fetchSvc.fetch("/api/v1/drafts", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          contributors: this.getEmails(this.contributors),
-          docType: this.args.docType,
-          owner: this.authenticatedUser.info.email,
-          product: this.productArea,
-          productAbbreviation: this.productAbbreviation,
-          summary: cleanString(this.summary),
-          title: cleanString(this.title),
-        }),
-      });
+      const doc = await this.fetchSvc
+        .fetch("/api/v1/drafts", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            contributors: this.getEmails(this.contributors),
+            docType: this.args.docType,
+            owner: this.authenticatedUser.info.email,
+            product: this.productArea,
+            productAbbreviation: this.productAbbreviation,
+            summary: cleanString(this.summary),
+            title: cleanString(this.title),
+          }),
+        })
+        .then((response) => response.json());
 
       // Wait for document to be available.
       await timeout(AWAIT_DOC_DELAY);


### PR DESCRIPTION
Adds missing `then((response) => response.json()` transformation to the new doc form.

Bug mistakenly introduced in #21 