### PR TITLE
Move `SESSION_STORAGE_KEY` out of SessionService

### DIFF
--- a/web/app/routes/authenticated.ts
+++ b/web/app/routes/authenticated.ts
@@ -2,7 +2,7 @@ import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
 import AuthenticatedUserService from "hermes/services/authenticated-user";
 import window from "ember-window-mock";
-import SessionService from "hermes/services/session";
+import SessionService, { SESSION_STORAGE_KEY } from "hermes/services/session";
 
 export default class AuthenticatedRoute extends Route {
   @service declare session: SessionService;
@@ -19,9 +19,7 @@ export default class AuthenticatedRoute extends Route {
       "authenticate"
     );
 
-    let target = window.sessionStorage.getItem(
-      this.session.SESSION_STORAGE_KEY
-    );
+    let target = window.sessionStorage.getItem(SESSION_STORAGE_KEY);
 
     if (
       !target &&
@@ -30,10 +28,7 @@ export default class AuthenticatedRoute extends Route {
     ) {
       // ember-simple-auth uses this value to set cookies when fastboot is enabled: https://github.com/mainmatter/ember-simple-auth/blob/a7e583cf4d04d6ebc96b198a8fa6dde7445abf0e/packages/ember-simple-auth/addon/-internals/routing.js#L12
 
-      window.sessionStorage.setItem(
-        this.session.SESSION_STORAGE_KEY,
-        transition.intent.url
-      );
+      window.sessionStorage.setItem(SESSION_STORAGE_KEY, transition.intent.url);
     }
   }
 }

--- a/web/app/services/session.ts
+++ b/web/app/services/session.ts
@@ -3,19 +3,17 @@ import RouterService from "@ember/routing/router-service";
 import EmberSimpleAuthSessionService from "ember-simple-auth/services/session";
 import window from "ember-window-mock";
 
+export const SESSION_STORAGE_KEY = "hermes.redirectTarget";
+
 export default class SessionService extends EmberSimpleAuthSessionService {
   @service declare router: RouterService;
-
-  readonly SESSION_STORAGE_KEY: string = "hermes.redirectTarget";
 
   // ember-simple-auth only uses a cookie to track redirect target if you're using fastboot, otherwise it keeps track of the redirect target as a parameter on the session service. See the source here: https://github.com/mainmatter/ember-simple-auth/blob/a7e583cf4d04d6ebc96b198a8fa6dde7445abf0e/packages/ember-simple-auth/addon/-internals/routing.js#L33-L50
   //
   // Because we redirect as part of the authentication flow, the parameter storing the transition gets reset. Instead, we keep track of the redirectTarget in browser sessionStorage and override the handleAuthentication method as recommended by ember-simple-auth.
 
   handleAuthentication(routeAfterAuthentication: string) {
-    let redirectTarget = window.sessionStorage.getItem(
-      this.SESSION_STORAGE_KEY
-    );
+    let redirectTarget = window.sessionStorage.getItem(SESSION_STORAGE_KEY);
     let transition;
 
     if (redirectTarget) {
@@ -26,7 +24,7 @@ export default class SessionService extends EmberSimpleAuthSessionService {
       );
     }
     transition.followRedirects().then(() => {
-      window.sessionStorage.removeItem(this.SESSION_STORAGE_KEY);
+      window.sessionStorage.removeItem(SESSION_STORAGE_KEY);
     });
   }
 }


### PR DESCRIPTION
Moves the `SESSION_STORAGE_KEY` variable out of the SessionService, where it was sometimes `undefined`.

<img width="367" alt="CleanShot 2023-03-09 at 19 50 09@2x" src="https://user-images.githubusercontent.com/754957/224348600-b71fbebe-b465-4e91-9f26-7dfa9efe9105.png">


**My maybe-crazy theory:**
Because SessionService extends EmberSimpleAuthSessionService, there are cases where `this.session` refers only to the base class. In the `authenticated` route, `this.session.requireAuthentication` works because it's part of the base class, while `SESSION_STOAGE_KEY` may come up `undefined` because it's not.

Either way, I haven't seen the `undefined`s since making this change.