### PR TITLE
Move Mirage `me` response through a factory

### DIFF
--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -125,15 +125,14 @@ export default function (mirageConfig) {
       /**
        * Used by the AuthenticatedUserService to get the user's profile.
        */
-      this.get("https://www.googleapis.com/userinfo/v2/me", () => {
-        return {
-          id: "123456789",
-          email: "user@example.com",
-          name: "User",
-          given_name: "User",
-          picture: "",
-          subscriptions: [],
-        };
+      this.get("https://www.googleapis.com/userinfo/v2/me", (schema) => {
+        // If the test has explicitly set a user, return it.
+        if (schema.mes.first()) {
+          return schema.mes.first().attrs;
+        } else {
+          // Otherwise, create and return a new user.
+          return schema.mes.create().attrs;
+        }
       });
 
       /**

--- a/web/mirage/factories/me.ts
+++ b/web/mirage/factories/me.ts
@@ -1,0 +1,11 @@
+import { Factory } from "miragejs";
+
+export default Factory.extend({
+  id: "123456789",
+  email: "user@example.com",
+  name: "User",
+  given_name: "User",
+  picture: "",
+  subscriptions: [],
+  isLoggedIn: true,
+});

--- a/web/mirage/models/me.ts
+++ b/web/mirage/models/me.ts
@@ -1,0 +1,6 @@
+
+import { Model } from "miragejs";
+
+export default Model.extend({
+  // Required for Mirage, even though it's empty
+});


### PR DESCRIPTION
Changes Mirage's `google/userinfo/v2/me` GET response from a hard coded object to one that's output by a factory.

This will allow us to set or modify `me` properties in our tests, e.g., `this.server.create('me', { isLoggedIn: false })` or `this.server.create('me', { subscriptions: ['Design']})`