### PR TITLE
Update test context names

### DIFF
--- a/web/tests/acceptance/authenticate-test.ts
+++ b/web/tests/acceptance/authenticate-test.ts
@@ -1,17 +1,16 @@
 import { visit } from "@ember/test-helpers";
 import { setupApplicationTest } from "ember-qunit";
 import { module, test } from "qunit";
-import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
 
-interface AllRouteContext extends MirageTestContext {}
+interface AuthenticateRouteTestContext extends MirageTestContext {}
 
 module("Acceptance | authenticate", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test("the page title is correct", async function (this: AllRouteContext, assert) {
+  test("the page title is correct", async function (this: AuthenticateRouteTestContext, assert) {
     await visit("/authenticate");
     assert.equal(getPageTitle(), "Authenticate | Hermes");
   });

--- a/web/tests/acceptance/authenticated/all-test.ts
+++ b/web/tests/acceptance/authenticated/all-test.ts
@@ -5,7 +5,7 @@ import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
 
-interface AllRouteContext extends MirageTestContext {}
+interface AuthenticatedAllRouteTestContext extends MirageTestContext {}
 
 module("Acceptance | authenticated/all", function (hooks) {
   setupApplicationTest(hooks);
@@ -15,7 +15,7 @@ module("Acceptance | authenticated/all", function (hooks) {
     authenticateSession({});
   });
 
-  test("the page title is correct", async function (this: AllRouteContext, assert) {
+  test("the page title is correct", async function (this: AuthenticatedAllRouteTestContext, assert) {
     await visit("/all");
     assert.equal(getPageTitle(), "All Docs | Hermes");
   });

--- a/web/tests/acceptance/authenticated/document-test.ts
+++ b/web/tests/acceptance/authenticated/document-test.ts
@@ -5,7 +5,7 @@ import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
 
-interface AllRouteContext extends MirageTestContext {}
+interface AuthenticatedDocumentRouteTestContext extends MirageTestContext {}
 
 module("Acceptance | authenticated/document", function (hooks) {
   setupApplicationTest(hooks);
@@ -15,13 +15,13 @@ module("Acceptance | authenticated/document", function (hooks) {
     authenticateSession({});
   });
 
-  test("the page title is correct (published doc)", async function (this: AllRouteContext, assert) {
+  test("the page title is correct (published doc)", async function (this: AuthenticatedDocumentRouteTestContext, assert) {
     this.server.create("document", { objectID: 1, title: "Test Document" });
     await visit("/document/1");
     assert.equal(getPageTitle(), "Test Document | Hermes");
   });
 
-  test("the page title is correct (draft)", async function (this: AllRouteContext, assert) {
+  test("the page title is correct (draft)", async function (this: AuthenticatedDocumentRouteTestContext, assert) {
     this.server.create("document", {
       objectID: 1,
       title: "Test Document",

--- a/web/tests/acceptance/authenticated/drafts-test.ts
+++ b/web/tests/acceptance/authenticated/drafts-test.ts
@@ -5,7 +5,7 @@ import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
 
-interface AllRouteContext extends MirageTestContext {}
+interface AuthenticatedDraftRouteTestContext extends MirageTestContext {}
 
 module("Acceptance | authenticated/drafts", function (hooks) {
   setupApplicationTest(hooks);
@@ -15,7 +15,7 @@ module("Acceptance | authenticated/drafts", function (hooks) {
     authenticateSession({});
   });
 
-  test("the page title is correct", async function (this: AllRouteContext, assert) {
+  test("the page title is correct", async function (this: AuthenticatedDraftRouteTestContext, assert) {
     await visit("/drafts");
     assert.equal(getPageTitle(), "My Drafts | Hermes");
   });

--- a/web/tests/acceptance/authenticated/my-test.ts
+++ b/web/tests/acceptance/authenticated/my-test.ts
@@ -5,7 +5,7 @@ import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
 
-interface AllRouteContext extends MirageTestContext {}
+interface AuthenticatedMyRouteTestContext extends MirageTestContext {}
 
 module("Acceptance | authenticated/my", function (hooks) {
   setupApplicationTest(hooks);
@@ -15,7 +15,7 @@ module("Acceptance | authenticated/my", function (hooks) {
     authenticateSession({});
   });
 
-  test("the page title is correct", async function (this: AllRouteContext, assert) {
+  test("the page title is correct", async function (this: AuthenticatedMyRouteTestContext, assert) {
     await visit("/my");
     assert.equal(getPageTitle(), "My Docs | Hermes");
   });

--- a/web/tests/acceptance/authenticated/new/index-test.ts
+++ b/web/tests/acceptance/authenticated/new/index-test.ts
@@ -5,7 +5,7 @@ import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
 
-interface AllRouteContext extends MirageTestContext {}
+interface AuthenticatedNewRouteTestContext extends MirageTestContext {}
 
 module("Acceptance | authenticated/new", function (hooks) {
   setupApplicationTest(hooks);
@@ -15,7 +15,7 @@ module("Acceptance | authenticated/new", function (hooks) {
     authenticateSession({});
   });
 
-  test("the page title is correct", async function (this: AllRouteContext, assert) {
+  test("the page title is correct", async function (this: AuthenticatedNewRouteTestContext, assert) {
     await visit("/new");
     await waitFor("h1");
     assert.equal(getPageTitle(), "New Doc | Hermes");

--- a/web/tests/acceptance/authenticated/results-test.ts
+++ b/web/tests/acceptance/authenticated/results-test.ts
@@ -5,7 +5,7 @@ import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
 
-interface AllRouteContext extends MirageTestContext {}
+interface AuthenticatedResultsRouteTestContext extends MirageTestContext {}
 
 module("Acceptance | authenticated/results", function (hooks) {
   setupApplicationTest(hooks);
@@ -15,7 +15,7 @@ module("Acceptance | authenticated/results", function (hooks) {
     authenticateSession({});
   });
 
-  test("the page title is correct", async function (this: AllRouteContext, assert) {
+  test("the page title is correct", async function (this: AuthenticatedResultsRouteTestContext, assert) {
     await visit("/results");
     assert.equal(getPageTitle(), "Search Results | Hermes");
   });

--- a/web/tests/acceptance/authenticated/settings-test.ts
+++ b/web/tests/acceptance/authenticated/settings-test.ts
@@ -5,7 +5,7 @@ import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
 
-interface AllRouteContext extends MirageTestContext {}
+interface AuthenticatedSettingsRouteTestContext extends MirageTestContext {}
 
 module("Acceptance | authenticated/settings", function (hooks) {
   setupApplicationTest(hooks);
@@ -15,7 +15,7 @@ module("Acceptance | authenticated/settings", function (hooks) {
     authenticateSession({});
   });
 
-  test("the page title is correct", async function (this: AllRouteContext, assert) {
+  test("the page title is correct", async function (this: AuthenticatedSettingsRouteTestContext, assert) {
     await visit("/settings");
     assert.equal(getPageTitle(), "Email Notifications | Hermes");
   });


### PR DESCRIPTION
Updates the names of the acceptance test contexts.

Currently they're all (mistakenly) `AllRouteContext` which is fine for now but may cause us problems later.