### PR TITLE
Include `page:1` in filterLink queryParams

### DIFF
--- a/web/app/components/header/active-filter-list-item.ts
+++ b/web/app/components/header/active-filter-list-item.ts
@@ -18,11 +18,14 @@ export default class HeaderActiveFilterListItemComponent extends Component<Heade
    * I.e., the ActiveFiltersService index minus the current filter.
    */
   get query() {
-    return Object.fromEntries(
-      Object.entries(this.activeFilters.index).map(([key, value]) => [
-        key,
-        value.filter((filter) => filter !== this.args.filter),
-      ])
-    );
+    return {
+      ...Object.fromEntries(
+        Object.entries(this.activeFilters.index).map(([key, value]) => [
+          key,
+          value.filter((filter) => filter !== this.args.filter),
+        ])
+      ),
+      page: 1,
+    };
   }
 }

--- a/web/app/components/header/active-filter-list.ts
+++ b/web/app/components/header/active-filter-list.ts
@@ -26,5 +26,6 @@ export default class HeaderActiveFilterListComponent extends Component<HeaderAct
     owners: [],
     product: [],
     status: [],
+    page: 1,
   };
 }

--- a/web/app/helpers/get-facet-query-hash.ts
+++ b/web/app/helpers/get-facet-query-hash.ts
@@ -52,6 +52,7 @@ export default class GetFacetQueryHashHelper extends Helper {
           ...(this.activeFilters.index[translatedFacetName] || []),
           clickedFilter,
         ],
+        page: 1,
       };
     }
   }


### PR DESCRIPTION
Includes `page: 1` in filterLink queryParams so that toggling filters effectively creates a new search.

In general, I think this is the expected behavior, but it's worth calling out that it resolves a particularly frustrating use case: Say you're on page 5 of results and you filter by owner. And say the owner has only enough matches for 1 page. Currently by keeping users on page 5, they see a no-data screen and have to manually click page 1. WELL NO MAS, BABY.