### PR TITLE
Remove unnecessary headers from AuthenticatedUserService

### DIFF
--- a/web/app/services/authenticated-user.ts
+++ b/web/app/services/authenticated-user.ts
@@ -54,11 +54,9 @@ export default class AuthenticatedUserService extends Service {
   /**
    * The headers to use in POST requests to the subscriptions endpoint.
    */
-  private get subscriptionsPostHeaders() {
+  private get subscriptionsPostHeader() {
     return {
       "Content-Type": "application/json",
-      "Hermes-Google-Access-Token":
-        this.session.data.authenticated.access_token,
     };
   }
 
@@ -79,10 +77,6 @@ export default class AuthenticatedUserService extends Service {
     try {
       let response = await this.fetchSvc.fetch("/api/v1/me/subscriptions", {
         method: "GET",
-        headers: {
-          "Hermes-Google-Access-Token":
-            this.session.data.authenticated.access_token,
-        },
       });
       let subscriptions: string[] = await response.json();
 
@@ -128,7 +122,7 @@ export default class AuthenticatedUserService extends Service {
       try {
         await this.fetchSvc.fetch(`/api/v1/me/subscriptions`, {
           method: "POST",
-          headers: this.subscriptionsPostHeaders,
+          headers: this.subscriptionsPostHeader,
           body: this.subscriptionsPostBody,
         });
       } catch (e: unknown) {
@@ -167,7 +161,7 @@ export default class AuthenticatedUserService extends Service {
       try {
         await this.fetchSvc.fetch("/api/v1/me/subscriptions", {
           method: "POST",
-          headers: this.subscriptionsPostHeaders,
+          headers: this.subscriptionsPostHeader,
           body: this.subscriptionsPostBody,
         });
       } catch (e: unknown) {

--- a/web/app/services/authenticated-user.ts
+++ b/web/app/services/authenticated-user.ts
@@ -54,7 +54,7 @@ export default class AuthenticatedUserService extends Service {
   /**
    * The headers to use in POST requests to the subscriptions endpoint.
    */
-  private get subscriptionsPostHeader() {
+  private get subscriptionsPostHeaders() {
     return {
       "Content-Type": "application/json",
     };
@@ -122,7 +122,7 @@ export default class AuthenticatedUserService extends Service {
       try {
         await this.fetchSvc.fetch(`/api/v1/me/subscriptions`, {
           method: "POST",
-          headers: this.subscriptionsPostHeader,
+          headers: this.subscriptionsPostHeaders,
           body: this.subscriptionsPostBody,
         });
       } catch (e: unknown) {
@@ -161,7 +161,7 @@ export default class AuthenticatedUserService extends Service {
       try {
         await this.fetchSvc.fetch("/api/v1/me/subscriptions", {
           method: "POST",
-          headers: this.subscriptionsPostHeader,
+          headers: this.subscriptionsPostHeaders,
           body: this.subscriptionsPostBody,
         });
       } catch (e: unknown) {


### PR DESCRIPTION
Removes redundant headers from a couple fetch calls. We automatically append this header to every back-end call.

See https://github.com/hashicorp-forge/hermes/pull/80#pullrequestreview-1337569654 for context