### PR TITLE
Add `tooltip` modifier

### DIFF
--- a/web/app/components/editable-field.ts
+++ b/web/app/components/editable-field.ts
@@ -1,9 +1,11 @@
+// @ts-nocheck
+// TODO: Type this file
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { scheduleOnce } from "@ember/runloop";
 
-const FOCUSABLE =
+export const FOCUSABLE =
   'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
 export default class EditableField extends Component {

--- a/web/app/modifiers/tooltip.ts
+++ b/web/app/modifiers/tooltip.ts
@@ -199,12 +199,18 @@ export default class TooltipModifier extends Modifier<TooltipModifierSignature> 
         ],
       }).then(({ x, y, placement, middlewareData }) => {
         assert("tooltip expected", this.tooltip);
-        this.tooltip.setAttribute("data-tooltip-placement", placement);
+
+        /**
+         * Update and set the tooltip's placement attribute
+         * based on the calculated placement (which could differ from
+         * the named argument passed to the modifier)
+         */
+        this.placement = placement;
+        this.tooltip.setAttribute("data-tooltip-placement", this.placement);
 
         /**
          * Position the tooltip
          */
-        assert("tooltip must exist", this.tooltip);
         Object.assign(this.tooltip.style, {
           left: `${x}px`,
           top: `${y}px`,
@@ -215,7 +221,7 @@ export default class TooltipModifier extends Modifier<TooltipModifierSignature> 
          * https://floating-ui.com/docs/arrow#usage
          * https://codesandbox.io/s/mystifying-kare-ee3hmh?file=/src/index.js
          */
-        const basicTooltipPlacement = placement.split("-")[0] as Side;
+        const basicTooltipPlacement = this.placement.split("-")[0] as Side;
         const arrowStaticSide = {
           top: "bottom",
           right: "left",
@@ -228,8 +234,10 @@ export default class TooltipModifier extends Modifier<TooltipModifierSignature> 
           Object.assign(this.arrow.style, {
             left: x != null ? `${x}px` : "",
             top: y != null ? `${y}px` : "",
-            // Ensure the static side gets unset when
-            // flipping to other placements' axes.
+            /**
+             * Ensure the static side gets unset when
+             * flipping to other placements' axes.
+             */
             right: "",
             bottom: "",
             [arrowStaticSide]: `${-this.arrow.offsetWidth / 2}px`,
@@ -273,7 +281,6 @@ export default class TooltipModifier extends Modifier<TooltipModifierSignature> 
       placement?: Placement;
     }
   ) {
-    // check if we're receiving an element and if its the one we're expecting
     this._reference = element;
     this._tooltipText = positional[0];
 
@@ -283,6 +290,9 @@ export default class TooltipModifier extends Modifier<TooltipModifierSignature> 
 
     this._reference.setAttribute("aria-describedby", `tooltip-${this.id}`);
 
+    /**
+     * If the reference isn't inherently focusable, make it focusable.
+     */
     if (!this._reference.matches(FOCUSABLE)) {
       this._reference.setAttribute("tabindex", "0");
     }

--- a/web/app/modifiers/tooltip.ts
+++ b/web/app/modifiers/tooltip.ts
@@ -1,10 +1,11 @@
-import Modifier, { ArgsFor } from "ember-modifier";
+import Modifier from "ember-modifier";
 import { registerDestructor } from "@ember/destroyable";
 import { tracked } from "@glimmer/tracking";
 import { assert } from "@ember/debug";
 import { action } from "@ember/object";
 import {
   Placement,
+  Side,
   arrow,
   autoUpdate,
   computePosition,
@@ -12,10 +13,25 @@ import {
   offset,
   platform,
 } from "@floating-ui/dom";
-
 import { FOCUSABLE } from "hermes/components/editable-field";
 import { guidFor } from "@ember/object/internals";
 import htmlElement from "hermes/utils/html-element";
+
+/**
+ * A modifier that attaches a tooltip to a reference element on hover or focus.
+ *
+ * Example usage:
+ * <div {{tooltip "Go back"}}>
+ *  <FlightIcon @name="arrow-left" />
+ * </div>
+ *
+ * Takes text and an optional named `placement` argument:
+ * {{tooltip "Go back" placement="left-end"}}
+ *
+ * TODO:
+ * - Add `renderInPlace` argument
+ * - Add animation logic
+ */
 
 interface TooltipModifierSignature {
   Args: {
@@ -27,8 +43,17 @@ interface TooltipModifierSignature {
   };
 }
 
+/**
+ * Use the `ember-application` container to ensure a consistent parent element
+ * in tests as well as in the browser.
+ */
 let DOM_PARENT = htmlElement(".ember-application");
 
+/**
+ * The cleanup function that runs when the modifier is destroyed.
+ * Removes the event listeners that were added on `modify`.
+ * Called by the `registerDestructor` function.
+ */
 function cleanup(instance: TooltipModifier) {
   instance.reference.removeEventListener("focusin", instance.showContent);
   instance.reference.removeEventListener("focusout", instance.maybeHideContent);
@@ -41,68 +66,120 @@ function cleanup(instance: TooltipModifier) {
 
 export default class TooltipModifier extends Modifier<TooltipModifierSignature> {
   /**
-   * Register the cleanup function for when the modifier is destroyed.
+   * A unique ID used to associate the reference and the tooltip.
+   * Applied to the reference's `aria-describedby` and the tooltip's `id`.
+   * Ensures the tooltip is read by screen readers.
    */
-  constructor(owner: any, args: ArgsFor<TooltipModifierSignature>) {
-    super(owner, args);
-    registerDestructor(this, cleanup);
-  }
-
   get id() {
     return guidFor(this);
   }
 
-  @tracked _text: string | null = null;
+  /**
+   * The text that is displayed in the tooltip.
+   */
+  @tracked _tooltipText: string | null = null;
+
+  /**
+   * The reference element that the tooltip is attached to.
+   */
   @tracked _reference: Element | null = null;
+
+  /**
+   * The arrow element that is rendered within the tooltip.
+   */
   @tracked _arrow: HTMLElement | null = null;
 
+  /**
+   * The tooltip element that is rendered in the DOM.
+   */
   @tracked tooltip: HTMLElement | null = null;
+
+  /**
+   * The placement of the tooltip relative to the reference element.
+   * Defaults to `top` but can be overridden by invoking the modifier
+   * with a `placement` argument.
+   */
   @tracked placement: Placement = "top";
 
-  get arrow(): HTMLElement {
-    assert("arrow must exist", this._arrow);
-    return this._arrow;
-  }
-
+  /**
+   * An asserted-to-exist reference to the reference element.
+   */
   get reference(): Element {
     assert("reference must exist", this._reference);
     return this._reference;
   }
 
-  get text(): string {
-    assert("text must exist", this._text);
-    return this._text;
+  /**
+   * An asserted-to-exist reference to the tooltip text.
+   */
+  get tooltipText(): string {
+    assert("text must exist", this._tooltipText);
+    return this._tooltipText;
   }
 
+  /**
+   * An asserted-to-exist reference to the tooltip arrow.
+   */
+  get arrow(): HTMLElement {
+    assert("arrow must exist", this._arrow);
+    return this._arrow;
+  }
+
+  /**
+   * The action that runs on mouseenter and focusin.
+   * Creates the tooltip element and adds it to the DOM,
+   * positioned relative to the reference element, as
+   * calculated by the `floating-ui` positioning library.
+   */
   @action showContent() {
+    /**
+     * Do nothing if the tooltip exists, e.g., if the user
+     * hovers a reference that's already focused.
+     */
     if (this.tooltip) {
       return;
     }
 
+    /**
+     * Create the tooltip and set its attributes
+     */
     this.tooltip = document.createElement("div");
     this.tooltip.classList.add("hermes-tooltip");
-    this.tooltip.setAttribute("role", "tooltip");
+    this.tooltip.setAttribute("data-tooltip-placement", this.placement);
     this.tooltip.setAttribute("id", `tooltip-${this.id}`);
+    this.tooltip.setAttribute("role", "tooltip");
 
+    /**
+     * Create the arrow and append it to the tooltip
+     */
     this._arrow = document.createElement("div");
     this._arrow.classList.add("arrow");
-
     this.tooltip.appendChild(this._arrow);
 
+    /**
+     * Create the textElement and append it to the tooltip
+     */
     const textElement = document.createElement("div");
-
+    textElement.textContent = this.tooltipText;
     textElement.classList.add("text");
-    textElement.textContent = this.text;
-
     this.tooltip.appendChild(textElement);
 
+    /**
+     * Append the tooltip to the end of the DOM
+     * TODO: Add the ability to render the tooltip in place
+     */
     DOM_PARENT.appendChild(this.tooltip);
 
+    /**
+     * The function that calculates, and updates the tooltip's position.
+     * Called repeatedly by the `floating-ui` positioning library.
+     */
     let updatePosition = async () => {
       if (!this.tooltip) {
         return;
       }
 
+      // https://floating-ui.com/docs/computePosition
       computePosition(this.reference, this.tooltip, {
         platform: platform,
         placement: this.placement,
@@ -114,44 +191,56 @@ export default class TooltipModifier extends Modifier<TooltipModifierSignature> 
           }),
         ],
       }).then(({ x, y, middlewareData }) => {
+        /**
+         * Position the tooltip
+         */
         assert("tooltip must exist", this.tooltip);
         Object.assign(this.tooltip.style, {
           left: `${x}px`,
           top: `${y}px`,
         });
 
-        // https://floating-ui.com/docs/arrow#usage
+        /**
+         * Position the tooltip
+         *
+         * https://floating-ui.com/docs/arrow#usage
+         * https://codesandbox.io/s/mystifying-kare-ee3hmh?file=/src/index.js
+         */
 
-        const side = this.placement.split("-")[0];
-        assert("side must exist", side);
-
-        const staticSide = {
+        const basicTooltipPlacement = this.placement.split("-")[0] as Side;
+        const arrowStaticSide = {
           top: "bottom",
           right: "left",
           bottom: "top",
           left: "right",
-        }[side];
-        assert("staticSide must exist", staticSide);
+        }[basicTooltipPlacement] as Side;
 
         if (middlewareData.arrow) {
           const { x, y } = middlewareData.arrow;
           Object.assign(this.arrow.style, {
             left: x != null ? `${x}px` : "",
             top: y != null ? `${y}px` : "",
-            [staticSide]: `${-this.arrow.offsetWidth / 2}px`,
+            [arrowStaticSide]: `${-this.arrow.offsetWidth / 2}px`,
             transform: "rotate(45deg)",
           });
         }
       });
     };
 
-    updatePosition();
+    // https://floating-ui.com/docs/autoUpdate
+    autoUpdate(this.reference, this.tooltip, updatePosition);
 
+    // TODO: Investigate whether we need this cleanup
     const cleanup = autoUpdate(this.reference, this.tooltip, updatePosition);
 
     registerDestructor(this, cleanup);
   }
 
+  /**
+   * The function to run on mouseleave and focusout.
+   * Removes the tooltip element from the DOM if it exists
+   * and the reference element is not focused.
+   */
   @action maybeHideContent() {
     if (this.reference.matches(":focus")) {
       return;
@@ -164,8 +253,8 @@ export default class TooltipModifier extends Modifier<TooltipModifierSignature> 
   }
 
   /**
-   * The function that runs when the modified element is shown.
-   * Sets up the event listeners and stores the properties locally.
+   * The function that runs when the modified element is inserted and updated.
+   * Sets up event listeners, local properties and some attributes.
    */
   modify(
     element: Element,
@@ -175,7 +264,7 @@ export default class TooltipModifier extends Modifier<TooltipModifierSignature> 
     }
   ) {
     this._reference = element;
-    this._text = positional[0];
+    this._tooltipText = positional[0];
 
     if (named.placement) {
       this.placement = named.placement;
@@ -191,5 +280,7 @@ export default class TooltipModifier extends Modifier<TooltipModifierSignature> 
     this._reference.addEventListener("mouseenter", this.showContent);
     this._reference.addEventListener("focusout", this.maybeHideContent);
     this._reference.addEventListener("mouseleave", this.maybeHideContent);
+
+    registerDestructor(this, cleanup);
   }
 }

--- a/web/app/modifiers/tooltip.ts
+++ b/web/app/modifiers/tooltip.ts
@@ -1,4 +1,4 @@
-import Modifier from "ember-modifier";
+import Modifier, { ArgsFor } from "ember-modifier";
 import { registerDestructor } from "@ember/destroyable";
 import { tracked } from "@glimmer/tracking";
 import { assert } from "@ember/debug";
@@ -65,6 +65,11 @@ function cleanup(instance: TooltipModifier) {
 }
 
 export default class TooltipModifier extends Modifier<TooltipModifierSignature> {
+  constructor(owner: any, args: ArgsFor<TooltipModifierSignature>) {
+    super(owner, args);
+    registerDestructor(this, cleanup);
+  }
+
   /**
    * A unique ID used to associate the reference and the tooltip.
    * Applied to the reference's `aria-describedby` and the tooltip's `id`.
@@ -263,6 +268,7 @@ export default class TooltipModifier extends Modifier<TooltipModifierSignature> 
       placement?: Placement;
     }
   ) {
+    // check if we're receiving an element and if its the one we're expecting
     this._reference = element;
     this._tooltipText = positional[0];
 
@@ -280,7 +286,5 @@ export default class TooltipModifier extends Modifier<TooltipModifierSignature> 
     this._reference.addEventListener("mouseenter", this.showContent);
     this._reference.addEventListener("focusout", this.maybeHideContent);
     this._reference.addEventListener("mouseleave", this.maybeHideContent);
-
-    registerDestructor(this, cleanup);
   }
 }

--- a/web/app/modifiers/tooltip.ts
+++ b/web/app/modifiers/tooltip.ts
@@ -15,7 +15,7 @@ import {
 
 import { FOCUSABLE } from "hermes/components/editable-field";
 import { guidFor } from "@ember/object/internals";
-import assertedHTMLElement from "hermes/utils/asserted-html-element";
+import htmlElement from "hermes/utils/html-element";
 
 interface TooltipModifierSignature {
   Args: {
@@ -27,7 +27,7 @@ interface TooltipModifierSignature {
   };
 }
 
-let DOM_PARENT = assertedHTMLElement(".ember-application");
+let DOM_PARENT = htmlElement(".ember-application");
 
 function cleanup(instance: TooltipModifier) {
   instance.reference.removeEventListener("focusin", instance.showContent);

--- a/web/app/modifiers/tooltip.ts
+++ b/web/app/modifiers/tooltip.ts
@@ -1,0 +1,192 @@
+import Modifier, { ArgsFor } from "ember-modifier";
+import { registerDestructor } from "@ember/destroyable";
+import { tracked } from "@glimmer/tracking";
+import { assert } from "@ember/debug";
+import { action } from "@ember/object";
+import {
+  Placement,
+  arrow,
+  autoUpdate,
+  computePosition,
+  flip,
+  offset,
+  platform,
+} from "@floating-ui/dom";
+
+import { FOCUSABLE } from "hermes/components/editable-field";
+import { guidFor } from "@ember/object/internals";
+
+interface TooltipModifierSignature {
+  Args: {
+    Element: HTMLElement;
+    Positional: [string];
+    Named: {
+      placement?: Placement;
+    };
+  };
+}
+
+function cleanup(instance: TooltipModifier) {
+  instance.reference.removeEventListener("focusin", instance.showContent);
+  instance.reference.removeEventListener("focusout", instance.maybeHideContent);
+  instance.reference.removeEventListener("mouseenter", instance.showContent);
+  instance.reference.removeEventListener(
+    "mouseleave",
+    instance.maybeHideContent
+  );
+}
+
+export default class TooltipModifier extends Modifier<TooltipModifierSignature> {
+  /**
+   * Register the cleanup function for when the modifier is destroyed.
+   */
+  constructor(owner: any, args: ArgsFor<TooltipModifierSignature>) {
+    super(owner, args);
+    registerDestructor(this, cleanup);
+  }
+
+  get id() {
+    return guidFor(this);
+  }
+
+  @tracked _text: string | null = null;
+  @tracked _reference: Element | null = null;
+  @tracked _tooltip: HTMLElement | null = null;
+  @tracked _arrow: HTMLElement | null = null;
+
+  @tracked placement: Placement = "top";
+
+  get tooltip(): HTMLElement {
+    assert("tooltip must exist", this._tooltip);
+    return this._tooltip;
+  }
+
+  get arrow(): HTMLElement {
+    assert("arrow must exist", this._arrow);
+    return this._arrow;
+  }
+
+  get reference(): Element {
+    assert("reference must exist", this._reference);
+    return this._reference;
+  }
+
+  get text(): string {
+    assert("text must exist", this._text);
+    return this._text;
+  }
+
+  @action showContent() {
+    if (this._tooltip) {
+      return;
+    }
+
+    this._tooltip = document.createElement("div");
+    this._tooltip.classList.add("hermes-tooltip");
+    this._tooltip.setAttribute("role", "tooltip");
+    this._tooltip.setAttribute("id", `tooltip-${this.id}`);
+
+    this._arrow = document.createElement("div");
+    this._arrow.classList.add("arrow");
+
+    this._tooltip.appendChild(this._arrow);
+
+    const textElement = document.createElement("div");
+
+    textElement.classList.add("text");
+    textElement.textContent = this.text;
+
+    this._tooltip.appendChild(textElement);
+
+    document.body.appendChild(this._tooltip);
+
+    let updatePosition = async () => {
+      computePosition(this.reference, this.tooltip, {
+        platform: platform,
+        placement: this.placement,
+        middleware: [
+          offset(8),
+          flip(),
+          arrow({
+            element: this.arrow,
+          }),
+        ],
+      }).then(({ x, y, middlewareData }) => {
+        Object.assign(this.tooltip.style, {
+          left: `${x}px`,
+          top: `${y}px`,
+        });
+
+        // https://floating-ui.com/docs/arrow#usage
+
+        const side = this.placement.split("-")[0];
+        assert("side must exist", side);
+
+        const staticSide = {
+          top: "bottom",
+          right: "left",
+          bottom: "top",
+          left: "right",
+        }[side];
+        assert("staticSide must exist", staticSide);
+
+        if (middlewareData.arrow) {
+          const { x, y } = middlewareData.arrow;
+          Object.assign(this.arrow.style, {
+            left: x != null ? `${x}px` : "",
+            top: y != null ? `${y}px` : "",
+            [staticSide]: `${-this.arrow.offsetWidth / 2}px`,
+            transform: "rotate(45deg)",
+          });
+        }
+      });
+    };
+
+    updatePosition();
+
+    const cleanup = autoUpdate(this.reference, this.tooltip, updatePosition);
+
+    registerDestructor(this, cleanup);
+  }
+
+  @action maybeHideContent() {
+    if (this.reference.matches(":focus")) {
+      return;
+    }
+
+    if (this._tooltip) {
+      this._tooltip.remove();
+      this._tooltip = null;
+    }
+  }
+
+  /**
+   * The function that runs when the modified element is shown.
+   * Sets up the event listeners and stores the properties locally.
+   */
+  modify(
+    element: Element,
+    positional: [string],
+    named: {
+      placement?: Placement;
+    }
+  ) {
+    this._reference = element;
+    this._text = positional[0];
+
+    if (named.placement) {
+      this.placement = named.placement;
+    }
+
+    this._reference.setAttribute("aria-describedby", `tooltip-${this.id}`);
+
+    if (!this._reference.matches(FOCUSABLE)) {
+      this._reference.setAttribute("tabindex", "0");
+    }
+
+    this._reference.addEventListener("focusin", this.showContent);
+    this._reference.addEventListener("mouseenter", this.showContent);
+    this._reference.addEventListener("focusout", this.maybeHideContent);
+    this._reference.addEventListener("mouseleave", this.maybeHideContent);
+  }
+}

--- a/web/app/styles/app.scss
+++ b/web/app/styles/app.scss
@@ -1,5 +1,6 @@
 @use "components/action";
 @use "components/toolbar";
+@use "components/tooltip";
 @use "components/footer";
 @use "components/nav";
 @use "components/x-hds-tab";

--- a/web/app/styles/components/tooltip.scss
+++ b/web/app/styles/components/tooltip.scss
@@ -1,0 +1,11 @@
+.hermes-tooltip {
+  @apply absolute w-max bg-color-foreground-strong rounded py-2 px-2.5 text-color-foreground-high-contrast z-50;
+
+  .arrow {
+    @apply absolute bg-color-foreground-strong h-2.5 w-2.5 -z-10 pointer-events-none;
+  }
+
+  .text {
+    @apply relative;
+  }
+}

--- a/web/app/styles/components/tooltip.scss
+++ b/web/app/styles/components/tooltip.scss
@@ -2,7 +2,7 @@
   @apply absolute w-max bg-color-foreground-strong rounded py-2 px-2.5 text-color-foreground-high-contrast z-50;
 
   .arrow {
-    @apply absolute bg-color-foreground-strong h-2.5 w-2.5 -z-10 pointer-events-none;
+    @apply absolute bg-color-foreground-strong h-2 w-2 -z-10 pointer-events-none;
   }
 
   .text {

--- a/web/app/utils/asserted-html-element.ts
+++ b/web/app/utils/asserted-html-element.ts
@@ -1,0 +1,10 @@
+import { assert } from "@ember/debug";
+
+export default function assertedHTMLElement(selector: string): HTMLElement {
+  const element = document.querySelector(selector);
+  assert(
+    "selector target must be an HTMLElement",
+    element instanceof HTMLElement
+  );
+  return element;
+}

--- a/web/app/utils/html-element.ts
+++ b/web/app/utils/html-element.ts
@@ -1,6 +1,6 @@
 import { assert } from "@ember/debug";
 
-export default function assertedHTMLElement(selector: string): HTMLElement {
+export default function htmlElement(selector: string): HTMLElement {
   const element = document.querySelector(selector);
   assert(
     "selector target must be an HTMLElement",

--- a/web/package.json
+++ b/web/package.json
@@ -118,6 +118,7 @@
   },
   "dependencies": {
     "@csstools/postcss-sass": "^5.0.1",
+    "@floating-ui/dom": "^1.2.4",
     "@hashicorp/design-system-components": "^1.4.0",
     "@hashicorp/ember-flight-icons": "^3.0.2",
     "@types/sinon": "^10.0.13",

--- a/web/tests/integration/modifiers/tooltip-test.ts
+++ b/web/tests/integration/modifiers/tooltip-test.ts
@@ -1,0 +1,82 @@
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+import { render, triggerEvent } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import assertedHTMLElement from "hermes/utils/asserted-html-element";
+
+module("Integration | Modifier | tooltip", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("it renders", async function (assert) {
+    this.set("placement", undefined);
+
+    await render(hbs`
+      <div data-test-div {{tooltip "more information"}}>
+        Hover or focus me
+      </div>
+
+      <button data-test-button {{tooltip "more information"}}>
+        Hover or focus me
+      </button>
+    `);
+
+    assert
+      .dom("div")
+      .hasAttribute(
+        "tabindex",
+        "0",
+        "div is not focusable, so it's given a tabindex of 0"
+      );
+
+    assert
+      .dom("button")
+      .doesNotHaveAttribute(
+        "tabindex",
+        "button is focusable, so it's not given a tabindex"
+      );
+
+    let divTooltipId =
+      assertedHTMLElement("[data-test-div]").getAttribute("aria-describedby");
+
+    let buttonTooltipId =
+      assertedHTMLElement("[data-test-button]").getAttribute(
+        "aria-describedby"
+      );
+
+    assert.dom(".hermes-tooltip").doesNotExist("tooltips hidden by default");
+
+    await triggerEvent("[data-test-div]", "mouseenter");
+
+    assert.dom(".hermes-tooltip").exists("tooltip appears on mouseenter");
+
+    assert.equal(divTooltipId, assertedHTMLElement(".hermes-tooltip").id);
+
+
+    await triggerEvent("[data-test-div]", "mouseleave");
+
+    assert
+      .dom(".hermes-tooltip")
+      .doesNotExist("tooltip disappears on mouseleave");
+
+    await triggerEvent("[data-test-div]", "focusin");
+
+    assert.dom(".hermes-tooltip").exists("tooltip appears on focusin");
+
+    await triggerEvent("[data-test-div]", "focusout");
+
+    assert
+      .dom(".hermes-tooltip")
+      .doesNotExist("tooltip disappears on focusout");
+
+    await triggerEvent("[data-test-button]", "mouseenter");
+
+    assert.dom(".hermes-tooltip").exists();
+    assert.equal(buttonTooltipId, assertedHTMLElement(".hermes-tooltip").id);
+
+    assert.notEqual(
+      divTooltipId,
+      buttonTooltipId,
+      "div and button have unique tooltip ids"
+    );
+  });
+});

--- a/web/tests/integration/modifiers/tooltip-test.ts
+++ b/web/tests/integration/modifiers/tooltip-test.ts
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
 import { render, triggerEvent } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import assertedHTMLElement from "hermes/utils/asserted-html-element";
+import htmlElement from "hermes/utils/html-element";
 
 module("Integration | Modifier | tooltip", function (hooks) {
   setupRenderingTest(hooks);
@@ -36,10 +36,10 @@ module("Integration | Modifier | tooltip", function (hooks) {
       );
 
     let divTooltipId =
-      assertedHTMLElement("[data-test-div]").getAttribute("aria-describedby");
+      htmlElement("[data-test-div]").getAttribute("aria-describedby");
 
     let buttonTooltipId =
-      assertedHTMLElement("[data-test-button]").getAttribute(
+      htmlElement("[data-test-button]").getAttribute(
         "aria-describedby"
       );
 
@@ -49,7 +49,7 @@ module("Integration | Modifier | tooltip", function (hooks) {
 
     assert.dom(".hermes-tooltip").exists("tooltip appears on mouseenter");
 
-    assert.equal(divTooltipId, assertedHTMLElement(".hermes-tooltip").id);
+    assert.equal(divTooltipId, htmlElement(".hermes-tooltip").id);
 
 
     await triggerEvent("[data-test-div]", "mouseleave");
@@ -71,7 +71,7 @@ module("Integration | Modifier | tooltip", function (hooks) {
     await triggerEvent("[data-test-button]", "mouseenter");
 
     assert.dom(".hermes-tooltip").exists();
-    assert.equal(buttonTooltipId, assertedHTMLElement(".hermes-tooltip").id);
+    assert.equal(buttonTooltipId, htmlElement(".hermes-tooltip").id);
 
     assert.notEqual(
       divTooltipId,

--- a/web/tests/integration/modifiers/tooltip-test.ts
+++ b/web/tests/integration/modifiers/tooltip-test.ts
@@ -33,80 +33,78 @@ module("Integration | Modifier | tooltip", function (hooks) {
         "button is focusable, so it's not given a tabindex"
       );
 
-    let divTooltipId =
-      htmlElement("[data-test-div]").getAttribute("aria-describedby");
+    let divTooltipSelector =
+      "#" + htmlElement("[data-test-div]").getAttribute("aria-describedby");
 
-    let buttonTooltipId =
-      htmlElement("[data-test-button]").getAttribute("aria-describedby");
+    let buttonTooltipSelector =
+      "#" + htmlElement("[data-test-button]").getAttribute("aria-describedby");
+
+    assert.notEqual(
+      divTooltipSelector,
+      buttonTooltipSelector,
+      "div and button have unique tooltip ids"
+    );
 
     assert.dom(".hermes-tooltip").doesNotExist("tooltips hidden by default");
 
     await triggerEvent("[data-test-div]", "mouseenter");
 
-    assert.dom(".hermes-tooltip").exists("tooltip appears on mouseenter");
-
-    assert.equal(divTooltipId, htmlElement(".hermes-tooltip").id);
+    assert.dom(divTooltipSelector).exists("tooltip appears on mouseenter");
 
     await triggerEvent("[data-test-div]", "mouseleave");
 
     assert
-      .dom(".hermes-tooltip")
+      .dom(divTooltipSelector)
       .doesNotExist("tooltip disappears on mouseleave");
 
     await triggerEvent("[data-test-div]", "focusin");
 
-    assert.dom(".hermes-tooltip").exists("tooltip appears on focusin");
+    assert.dom(divTooltipSelector).exists("tooltip appears on focusin");
 
     await triggerEvent("[data-test-div]", "focusout");
 
     assert
-      .dom(".hermes-tooltip")
+      .dom(divTooltipSelector)
       .doesNotExist("tooltip disappears on focusout");
 
     await triggerEvent("[data-test-button]", "mouseenter");
 
-    assert.dom(".hermes-tooltip").exists();
-    assert.equal(buttonTooltipId, htmlElement(".hermes-tooltip").id);
-
-    assert.notEqual(
-      divTooltipId,
-      buttonTooltipId,
-      "div and button have unique tooltip ids"
-    );
+    assert.dom(buttonTooltipSelector).exists();
   });
 
   test("it takes a placement argument", async function (assert) {
     await render(hbs`
       <div class="w-full h-full grid place-items-center">
         <div>
-          <div data-test-div-one {{tooltip "more information"}}>
+          <div data-test-one {{tooltip "more information"}}>
             Default ('top')
           </div>
-
-          <div data-test-div-two {{tooltip "more information" placement="left-end"}}>
+          <div data-test-two {{tooltip "more information" placement="left-end"}}>
             Custom ('left-end')
           </div>
-
         </div>
       </div>
     `);
 
-    await triggerEvent("[data-test-div-one]", "mouseenter");
+    let divOneTooltipSelector =
+      "#" + htmlElement("[data-test-one]").getAttribute("aria-describedby");
+    let divTwoTooltipSelector =
+      "#" + htmlElement("[data-test-two]").getAttribute("aria-describedby");
+
+    await triggerEvent("[data-test-one]", "mouseenter");
 
     assert
-      .dom(".hermes-tooltip")
+      .dom(divOneTooltipSelector)
       .hasAttribute(
         "data-tooltip-placement",
         "top",
         "tooltip is placed top by default"
       );
 
-    await triggerEvent("[data-test-div-one]", "mouseleave");
-
-    await triggerEvent("[data-test-div-two]", "mouseenter");
+    await triggerEvent("[data-test-two]", "mouseenter");
 
     assert
-      .dom(".hermes-tooltip")
+      .dom(divTwoTooltipSelector)
       .hasAttribute(
         "data-tooltip-placement",
         "left-end",

--- a/web/tests/integration/modifiers/tooltip-test.ts
+++ b/web/tests/integration/modifiers/tooltip-test.ts
@@ -8,8 +8,6 @@ module("Integration | Modifier | tooltip", function (hooks) {
   setupRenderingTest(hooks);
 
   test("it renders", async function (assert) {
-    this.set("placement", undefined);
-
     await render(hbs`
       <div data-test-div {{tooltip "more information"}}>
         Hover or focus me
@@ -39,9 +37,7 @@ module("Integration | Modifier | tooltip", function (hooks) {
       htmlElement("[data-test-div]").getAttribute("aria-describedby");
 
     let buttonTooltipId =
-      htmlElement("[data-test-button]").getAttribute(
-        "aria-describedby"
-      );
+      htmlElement("[data-test-button]").getAttribute("aria-describedby");
 
     assert.dom(".hermes-tooltip").doesNotExist("tooltips hidden by default");
 
@@ -50,7 +46,6 @@ module("Integration | Modifier | tooltip", function (hooks) {
     assert.dom(".hermes-tooltip").exists("tooltip appears on mouseenter");
 
     assert.equal(divTooltipId, htmlElement(".hermes-tooltip").id);
-
 
     await triggerEvent("[data-test-div]", "mouseleave");
 
@@ -78,5 +73,44 @@ module("Integration | Modifier | tooltip", function (hooks) {
       buttonTooltipId,
       "div and button have unique tooltip ids"
     );
+  });
+
+  test("it takes a placement argument", async function (assert) {
+    await render(hbs`
+      <div class="w-full h-full grid place-items-center">
+        <div>
+          <div data-test-div-one {{tooltip "more information"}}>
+            Default ('top')
+          </div>
+
+          <div data-test-div-two {{tooltip "more information" placement="left-end"}}>
+            Custom ('left-end')
+          </div>
+
+        </div>
+      </div>
+    `);
+
+    await triggerEvent("[data-test-div-one]", "mouseenter");
+
+    assert
+      .dom(".hermes-tooltip")
+      .hasAttribute(
+        "data-tooltip-placement",
+        "top",
+        "tooltip is placed top by default"
+      );
+
+    await triggerEvent("[data-test-div-one]", "mouseleave");
+
+    await triggerEvent("[data-test-div-two]", "mouseenter");
+
+    assert
+      .dom(".hermes-tooltip")
+      .hasAttribute(
+        "data-tooltip-placement",
+        "left-end",
+        "tooltip can be custom placed"
+      );
   });
 });

--- a/web/tests/unit/utils/html-element-test.ts
+++ b/web/tests/unit/utils/html-element-test.ts
@@ -1,0 +1,24 @@
+import htmlElement from "hermes/utils/html-element";
+import { module, test } from "qunit";
+
+module("Unit | Utility | html-element", function () {
+  test("it asserts and returns valid html elements", function (assert) {
+    const div = document.createElement("div");
+    const button = document.createElement("button");
+
+    div.classList.add("html-element-test-div");
+    button.classList.add("html-element-test-button");
+
+    document.body.appendChild(div);
+    document.body.appendChild(button);
+
+    assert.true(htmlElement(".html-element-test-div") instanceof HTMLElement);
+    assert.true(
+      htmlElement(".html-element-test-button") instanceof HTMLElement
+    );
+
+    assert.throws(() => {
+      htmlElement(".hope-for-the-future");
+    }, "throws an error when an element isn't found");
+  });
+});

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1938,6 +1938,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/core@npm:^1.2.3":
+  version: 1.2.4
+  resolution: "@floating-ui/core@npm:1.2.4"
+  checksum: 1c163ea1804e2b0a28fda6e32efed0e242d0db8081fd24aab9d1cbb100f94a558709231c483bf74bf09a9204ea6e7845813d43b5322ceb6ee63285308f68f65b
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.2.4":
+  version: 1.2.4
+  resolution: "@floating-ui/dom@npm:1.2.4"
+  dependencies:
+    "@floating-ui/core": ^1.2.3
+  checksum: 5c24a2e8f04e436390646c8a4431c6cb79e03711fbb0f818b87d613a6be8971bc560a830b702aaa51a0ebc4d0c45deb06f3140c14125dc1ac770365bf66ee903
+  languageName: node
+  linkType: hard
+
 "@gar/promisify@npm:^1.1.3":
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
@@ -10815,6 +10831,7 @@ __metadata:
     "@csstools/postcss-sass": ^5.0.1
     "@ember/optional-features": ^2.0.0
     "@ember/test-helpers": ^2.6.0
+    "@floating-ui/dom": ^1.2.4
     "@glimmer/component": ^1.0.4
     "@glimmer/tracking": ^1.0.4
     "@hashicorp/design-system-components": ^1.4.0


### PR DESCRIPTION
Adds and tests a simple `tooltip` modifier as a way to attach tooltips to HTMLElements. Powered by [Floating UI](https://floating-ui.com)

Includes styles and a helper utility. 

Example usage:

```
<div {{tooltip "Back to dashboard" position="bottom"}}>
  <FlightIcon @name="arrow-left" />
</div>
```