### PR TITLE
Switch Redirect storage SessionStorage to LocalStorage

### DIFF
--- a/web/app/routes/authenticated.ts
+++ b/web/app/routes/authenticated.ts
@@ -2,7 +2,7 @@ import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
 import AuthenticatedUserService from "hermes/services/authenticated-user";
 import window from "ember-window-mock";
-import SessionService, { SESSION_STORAGE_KEY } from "hermes/services/session";
+import SessionService, { REDIRECT_LOCAL_STORAGE_KEY } from "hermes/services/session";
 
 export default class AuthenticatedRoute extends Route {
   @service declare session: SessionService;
@@ -19,7 +19,7 @@ export default class AuthenticatedRoute extends Route {
       "authenticate"
     );
 
-    let target = window.sessionStorage.getItem(SESSION_STORAGE_KEY);
+    let target = window.localStorage.getItem(REDIRECT_LOCAL_STORAGE_KEY);
 
     if (
       !target &&
@@ -28,7 +28,7 @@ export default class AuthenticatedRoute extends Route {
     ) {
       // ember-simple-auth uses this value to set cookies when fastboot is enabled: https://github.com/mainmatter/ember-simple-auth/blob/a7e583cf4d04d6ebc96b198a8fa6dde7445abf0e/packages/ember-simple-auth/addon/-internals/routing.js#L12
 
-      window.sessionStorage.setItem(SESSION_STORAGE_KEY, transition.intent.url);
+      window.localStorage.setItem(REDIRECT_LOCAL_STORAGE_KEY, transition.intent.url);
     }
   }
 }

--- a/web/app/routes/authenticated.ts
+++ b/web/app/routes/authenticated.ts
@@ -2,7 +2,9 @@ import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
 import AuthenticatedUserService from "hermes/services/authenticated-user";
 import window from "ember-window-mock";
-import SessionService, { REDIRECT_LOCAL_STORAGE_KEY } from "hermes/services/session";
+import SessionService, {
+  REDIRECT_LOCAL_STORAGE_KEY,
+} from "hermes/services/session";
 
 export default class AuthenticatedRoute extends Route {
   @service declare session: SessionService;
@@ -28,7 +30,13 @@ export default class AuthenticatedRoute extends Route {
     ) {
       // ember-simple-auth uses this value to set cookies when fastboot is enabled: https://github.com/mainmatter/ember-simple-auth/blob/a7e583cf4d04d6ebc96b198a8fa6dde7445abf0e/packages/ember-simple-auth/addon/-internals/routing.js#L12
 
-      window.localStorage.setItem(REDIRECT_LOCAL_STORAGE_KEY, transition.intent.url);
+      window.localStorage.setItem(
+        REDIRECT_LOCAL_STORAGE_KEY,
+        JSON.stringify({
+          url: transition.intent.url,
+          expiresOn: Date.now() + 60 * 2000, // 2 minutes
+        })
+      );
     }
   }
 }

--- a/web/app/services/session.ts
+++ b/web/app/services/session.ts
@@ -13,8 +13,19 @@ export default class SessionService extends EmberSimpleAuthSessionService {
   // Because we redirect as part of the authentication flow, the parameter storing the transition gets reset. Instead, we keep track of the redirectTarget in browser sessionStorage and override the handleAuthentication method as recommended by ember-simple-auth.
 
   handleAuthentication(routeAfterAuthentication: string) {
-    let redirectTarget = window.localStorage.getItem(REDIRECT_LOCAL_STORAGE_KEY);
+    let redirectObject = window.localStorage.getItem(
+      REDIRECT_LOCAL_STORAGE_KEY
+    );
+
+    let redirectTarget: string | null = null;
     let transition;
+
+    if (redirectObject) {
+      // Check if the object is less than 2 minutes old
+      if (Date.now() < JSON.parse(redirectObject).expiresOn) {
+        redirectTarget = JSON.parse(redirectObject).url;
+      }
+    }
 
     if (redirectTarget) {
       transition = this.router.transitionTo(redirectTarget);

--- a/web/app/services/session.ts
+++ b/web/app/services/session.ts
@@ -3,7 +3,7 @@ import RouterService from "@ember/routing/router-service";
 import EmberSimpleAuthSessionService from "ember-simple-auth/services/session";
 import window from "ember-window-mock";
 
-export const SESSION_STORAGE_KEY = "hermes.redirectTarget";
+export const REDIRECT_LOCAL_STORAGE_KEY = "hermes.redirectTarget";
 
 export default class SessionService extends EmberSimpleAuthSessionService {
   @service declare router: RouterService;
@@ -13,7 +13,7 @@ export default class SessionService extends EmberSimpleAuthSessionService {
   // Because we redirect as part of the authentication flow, the parameter storing the transition gets reset. Instead, we keep track of the redirectTarget in browser sessionStorage and override the handleAuthentication method as recommended by ember-simple-auth.
 
   handleAuthentication(routeAfterAuthentication: string) {
-    let redirectTarget = window.sessionStorage.getItem(SESSION_STORAGE_KEY);
+    let redirectTarget = window.localStorage.getItem(REDIRECT_LOCAL_STORAGE_KEY);
     let transition;
 
     if (redirectTarget) {
@@ -24,7 +24,7 @@ export default class SessionService extends EmberSimpleAuthSessionService {
       );
     }
     transition.followRedirects().then(() => {
-      window.sessionStorage.removeItem(SESSION_STORAGE_KEY);
+      window.localStorage.removeItem(REDIRECT_LOCAL_STORAGE_KEY);
     });
   }
 }

--- a/web/tests/unit/services/session-test.ts
+++ b/web/tests/unit/services/session-test.ts
@@ -1,0 +1,64 @@
+import { module, test } from "qunit";
+import { setupTest } from "ember-qunit";
+import SessionService, {
+  REDIRECT_LOCAL_STORAGE_KEY,
+} from "hermes/services/session";
+import window from "ember-window-mock";
+import { settled, waitFor } from "@ember/test-helpers";
+
+module("Unit | Service | session", function (hooks) {
+  setupTest(hooks);
+
+  test("it handles authentication", async function (assert) {
+    const sessionSvc = this.owner.lookup("service:session") as SessionService;
+
+    // mock the service method
+    sessionSvc.handleAuthentication = (_routeAfterAuthentication: string) => {
+      let redirectObject = window.localStorage.getItem(
+        REDIRECT_LOCAL_STORAGE_KEY
+      );
+
+      let returnValue: string | null = null;
+
+      if (redirectObject) {
+        // Check if the object is less than 2 minutes old
+        if (Date.now() < JSON.parse(redirectObject).expiresOn) {
+          returnValue = `redirect valid: ${JSON.parse(redirectObject).url}`;
+        } else {
+          returnValue = "redirect expired";
+        }
+      } else {
+        returnValue = "redirect not found";
+      }
+
+      return returnValue;
+    };
+
+    assert.equal(sessionSvc.handleAuthentication("none"), "redirect not found");
+
+    window.localStorage.setItem(
+      REDIRECT_LOCAL_STORAGE_KEY,
+      JSON.stringify({
+        url: "testURL",
+        expiresOn: Date.now() + 60 * 2000, // 2 minutes
+      })
+    );
+
+    assert.equal(
+      sessionSvc.handleAuthentication("none"),
+      "redirect valid: testURL"
+    );
+
+    window.localStorage.setItem(
+      REDIRECT_LOCAL_STORAGE_KEY,
+      JSON.stringify({
+        url: "testURL",
+        expiresOn: Date.now() - 60 * 2000, // -2 minutes
+      })
+    );
+
+    assert.equal(sessionSvc.handleAuthentication("none"), "redirect expired");
+
+    window.localStorage.removeItem(REDIRECT_LOCAL_STORAGE_KEY);
+  });
+});


### PR DESCRIPTION
Moves the user's redirectIntent from SessionStorage to LocalStorage, where it can survive a cross-origin transition. Sets a 2-minute expiration on the cookie to prevent old redirectIntents from sticking around.