### PR TITLE
Set default anchor style

### DIFF
--- a/web/app/components/doc/inline.hbs
+++ b/web/app/components/doc/inline.hbs
@@ -15,7 +15,7 @@
 <LinkTo
   @route="authenticated.document"
   @model="{{@docID}}"
-  class="flex items-center space-x-3 no-underline py-2 px-3 hover:bg-[color:var(--token-color-palette-neutral-100)]"
+  class="flex items-center space-x-3 py-2 px-3 hover:bg-[color:var(--token-color-palette-neutral-100)]"
 >
   <div
     class="relative flex flex-shrink-0 items-center w-[40px] h-[56px] hds-surface-mid

--- a/web/app/components/doc/row.hbs
+++ b/web/app/components/doc/row.hbs
@@ -20,7 +20,7 @@
       @route="authenticated.document"
       @model="{{@docID}}"
       @query={{hash draft=@isDraft}}
-      class="flex  space-x-4 no-underline"
+      class="flex  space-x-4"
     >
       <div
         class="relative flex flex-shrink-0 items-center w-[40px] h-[56px] hds-surface-mid

--- a/web/app/components/doc/tile.hbs
+++ b/web/app/components/doc/tile.hbs
@@ -19,7 +19,7 @@
 <LinkTo
   @route="authenticated.document"
   @model="{{@docID}}"
-  class="flex flex-col items-start space-y-2 no-underline p-4 -m-4 rounded-md hover:bg-[color:var(--token-color-palette-neutral-50)] active:bg-[color:var(--token-color-palette-neutral-100)] overflow-hidden"
+  class="flex flex-col items-start space-y-2 p-4 -m-4 rounded-md hover:bg-[color:var(--token-color-palette-neutral-50)] active:bg-[color:var(--token-color-palette-neutral-100)] overflow-hidden"
 >
   <div class="flex flex-col items-start w-[108px] space-y-3">
     <div

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -654,7 +654,7 @@
                         @iconPosition="trailing"
                         @hrefIsExternal={{true}}
                         @href={{link.url}}
-                        class="no-underline text-body-100"
+                        class="text-body-100"
                       >
                         {{link.text}}
                       </Hds::Link::Inline>

--- a/web/app/components/pagination/link.hbs
+++ b/web/app/components/pagination/link.hbs
@@ -1,6 +1,6 @@
 {{#if @disabled}}
   <span
-    class="w-9 h-12 grid place-items-center no-underline text-color-foreground-primary relative
+    class="w-9 h-12 grid place-items-center relative
       {{if @icon 'opacity-50' 'text-color-foreground-action'}}"
   >
     {{#if @icon}}
@@ -16,7 +16,7 @@
   <LinkTo
     @route={{this.currentRouteName}}
     @query={{hash page=@page}}
-    class="w-9 h-12 hover:text-color-foreground-strong grid place-items-center no-underline text-color-foreground-primary"
+    class="w-9 h-12 hover:text-color-foreground-strong grid place-items-center"
   >
     {{#if @icon}}
       <FlightIcon @name={{@icon}} />

--- a/web/app/styles/app.scss
+++ b/web/app/styles/app.scss
@@ -57,6 +57,11 @@ body {
   color: var(--token-color-foreground-primary);
 }
 
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
 .x-container {
   @apply w-full max-w-screen-lg mx-auto px-8;
 }

--- a/web/app/styles/ember-power-select-theme.scss
+++ b/web/app/styles/ember-power-select-theme.scss
@@ -33,7 +33,7 @@ $ember-power-select-multiple-option-line-height: 1.3;
 
 .ember-basic-dropdown-content {
   .hds-dropdown-list-item--interactive {
-    @apply no-underline text-color-foreground-primary flex items-center px-3;
+    @apply flex items-center px-3;
 
     &:hover {
       @apply bg-color-surface-interactive-hover;


### PR DESCRIPTION
Sets a default anchor style — `text-decoration: none; color: inherit` – to reduce redundant styling.

