### PR TITLE
Set default list styles

### DIFF
--- a/web/app/components/custom-editable-field.hbs
+++ b/web/app/components/custom-editable-field.hbs
@@ -42,7 +42,7 @@
   >
     <:default>
       {{#if this.people.length}}
-        <ol class="list-none">
+        <ol>
           {{#each this.people as |person|}}
             <li class="whitespace-nowrap">
               {{#if person.imgURL}}

--- a/web/app/components/doc/state.hbs
+++ b/web/app/components/doc/state.hbs
@@ -1,7 +1,7 @@
 {{#unless @hideProgress}}
   <ol
     class="state--{{this.dasherizedName}}
-      grid grid-cols-3 w-full items-center list-none gap-0.5"
+      grid grid-cols-3 w-full items-center gap-0.5"
   >
     <Doc::StateProgressBar class={{this.state.barOneClass}} />
     <Doc::StateProgressBar class={{this.state.barTwoClass}} />

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -648,7 +648,7 @@
                 </Hds::Form::Checkbox::Field>
               </div>
               {{#if check.links.length}}
-                <ul class="list-none pl-6 mt-1.5">
+                <ul class="pl-6 mt-1.5">
                   {{#each check.links as |link|}}
                     <li>
                       <Hds::Link::Inline

--- a/web/app/components/header/facet-dropdown-list.hbs
+++ b/web/app/components/header/facet-dropdown-list.hbs
@@ -44,7 +44,7 @@
         data-test-facet-dropdown-menu
         id="facet-dropdown-menu"
         role={{if @inputIsShown "listbox" "menu"}}
-        class="py-3 list-none"
+        class="py-3"
         aria-activedescendant={{unless
           (eq @focusedItemIndex -1)
           (concat "facet-dropdown-menu-item-" @focusedItemIndex)

--- a/web/app/components/settings/subscription-list.hbs
+++ b/web/app/components/settings/subscription-list.hbs
@@ -8,7 +8,7 @@
 />
 <ol
   data-test-subscription-list
-  class="list-none mt-5 w-full divide-y divide-color-border-primary"
+  class="mt-5 w-full divide-y divide-color-border-primary"
 >
   {{#each this.shownItems as |listItem|}}
     <Settings::SubscriptionListItem @productArea={{listItem}} />

--- a/web/app/styles/app.scss
+++ b/web/app/styles/app.scss
@@ -58,6 +58,10 @@ body {
   color: var(--token-color-foreground-primary);
 }
 
+ul, ol {
+  list-style: none;
+}
+
 .x-container {
   @apply w-full max-w-screen-lg mx-auto px-8;
 }

--- a/web/app/styles/components/header/facet-dropdown.scss
+++ b/web/app/styles/components/header/facet-dropdown.scss
@@ -1,5 +1,5 @@
 .facet-dropdown-popover {
-  @apply absolute -bottom-1 left-0 bg-color-page-primary translate-y-full flex flex-col rounded-md list-none  w-full max-h-[400px] pt-0 z-10;
+  @apply absolute -bottom-1 left-0 bg-color-page-primary translate-y-full flex flex-col rounded-md w-full max-h-[400px] pt-0 z-10;
 
   &.hds-dropdown-list {
     @apply min-w-[175px];

--- a/web/app/styles/components/sidebar.scss
+++ b/web/app/styles/components/sidebar.scss
@@ -17,7 +17,7 @@
   }
 
   .person-list {
-    @apply w-full list-none space-y-2;
+    @apply w-full space-y-2;
   }
 
   .sidebar-footer {

--- a/web/app/templates/authenticated/new/index.hbs
+++ b/web/app/templates/authenticated/new/index.hbs
@@ -2,7 +2,7 @@
 
 <h1>Choose a template</h1>
 <p>Start by choosing the document type you choose to create.</p>
-<ol class="mt-9 grid grid-cols-3 gap-4 list-none">
+<ol class="mt-9 grid grid-cols-3 gap-4">
   {{#each @model as |docType|}}
     <li class="relative">
       <LinkTo


### PR DESCRIPTION
Sets a default list style — `none` — to reduce redundant code. Removes `no-list` classes site-wide.