### PR TITLE
Add exponential backoff to Google Drive list files call

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -266,7 +266,7 @@ func (idx *Indexer) Run() error {
 		// Update published document headers, if configured.
 		if idx.UpdateDocumentHeaders {
 			log.Info("refreshing published document headers",
-				"folder_id", idx.DraftsFolderID,
+				"folder_id", idx.DocumentsFolderID,
 			)
 			currentTime := time.Now().UTC()
 

--- a/pkg/googleworkspace/backoff.go
+++ b/pkg/googleworkspace/backoff.go
@@ -1,0 +1,28 @@
+package googleworkspace
+
+import (
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/hashicorp/go-hclog"
+)
+
+// defaultBackoff returns a default exponential backoff configuration for Google
+// Workspace APIs.
+func defaultBackoff() *backoff.ExponentialBackOff {
+	bo := backoff.NewExponentialBackOff()
+	bo.MaxElapsedTime = 2 * time.Minute
+
+	return bo
+}
+
+// backoffNotify is an exponential backoff notify function that logs the error
+// and wait duration as a warning.
+func backoffNotify(err error, d time.Duration) {
+	// TODO: enable passing in a logger.
+	l := hclog.Default()
+	l.Warn("backoff error (retrying)",
+		"error", err,
+		"delay", d,
+	)
+}

--- a/pkg/googleworkspace/docs_helpers.go
+++ b/pkg/googleworkspace/docs_helpers.go
@@ -17,13 +17,13 @@ func (s *Service) GetDoc(id string) (*docs.Document, error) {
 	op := func() error {
 		d, err = s.Docs.Documents.Get(id).Do()
 		if err != nil {
-			return err
+			return fmt.Errorf("error getting document: %w", err)
 		}
 
 		return nil
 	}
 
-	boErr := backoff.Retry(op, backoff.NewExponentialBackOff())
+	boErr := backoff.RetryNotify(op, defaultBackoff(), backoffNotify)
 	if boErr != nil {
 		return nil, boErr
 	}

--- a/pkg/googleworkspace/people_helpers.go
+++ b/pkg/googleworkspace/people_helpers.go
@@ -1,6 +1,8 @@
 package googleworkspace
 
 import (
+	"fmt"
+
 	"github.com/cenkalti/backoff/v4"
 	"google.golang.org/api/people/v1"
 )
@@ -19,7 +21,7 @@ func (s *Service) SearchPeople(query string) ([]*people.Person, error) {
 	op := func() error {
 		resp, err = call.Do()
 		if err != nil {
-			return err
+			return fmt.Errorf("error searching people directory: %w", err)
 		}
 
 		return nil
@@ -34,7 +36,7 @@ func (s *Service) SearchPeople(query string) ([]*people.Person, error) {
 			call = call.PageToken(nextPageToken)
 		}
 
-		boErr := backoff.Retry(op, backoff.NewExponentialBackOff())
+		boErr := backoff.RetryNotify(op, defaultBackoff(), backoffNotify)
 		if boErr != nil {
 			return nil, boErr
 		}


### PR DESCRIPTION
This PR adds exponential backoff to the Google Drive list files call, which seems to return an internal error relatively frequently. It also creates a default backoff configuration with a shorter max elapsed time of 2 minutes (the default is 15 minutes) and logs warnings when backoff errors are returned but we're still retrying.

And unrelatedly, it fixes a log line with the wrong folder ID.