### PR TITLE
Add names to People API response by using data from the Admin Directory API

### DIFF
--- a/pkg/googleworkspace/admin_helpers.go
+++ b/pkg/googleworkspace/admin_helpers.go
@@ -1,13 +1,12 @@
 package googleworkspace
 
-/*
 import (
 	"fmt"
-	"strings"
 
 	admin "google.golang.org/api/admin/directory/v1"
 )
 
+/*
 // CreateGroup creates a Google Group.
 func (s *Service) CreateGroup(
 	id, name, description, email string) (*admin.Group, error) {
@@ -54,3 +53,14 @@ func (s *Service) GetGroup(groupKey string) (*admin.Group, error) {
 	return resp, nil
 }
 */
+
+// GetUser gets a user.
+func (s *Service) GetUser(userKey string) (*admin.User, error) {
+	resp, err := s.Admin.Users.Get(userKey).
+		ViewType("domain_public").
+		Do()
+	if err != nil {
+		return nil, fmt.Errorf("error getting user: %w", err)
+	}
+	return resp, nil
+}

--- a/pkg/googleworkspace/service.go
+++ b/pkg/googleworkspace/service.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/oauth2/jwt"
 
 	"github.com/pkg/browser"
-	// admin "google.golang.org/api/admin/directory/v1"
+	admin "google.golang.org/api/admin/directory/v1"
 	"google.golang.org/api/docs/v1"
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/gmail/v1"
@@ -25,7 +25,7 @@ import (
 
 // Service provides access to the Google Workspace API.
 type Service struct {
-	// Admin  *admin.Service
+	Admin  *admin.Service
 	Docs   *docs.Service
 	Drive  *drive.Service
 	Gmail  *gmail.Service
@@ -50,6 +50,7 @@ func NewFromConfig(cfg *Config) *Service {
 		PrivateKey: []byte(cfg.PrivateKey),
 		Scopes: []string{
 			// "https://www.googleapis.com/auth/admin.directory.group",
+			"https://www.googleapis.com/auth/admin.directory.user.readonly",
 			"https://www.googleapis.com/auth/directory.readonly",
 			"https://www.googleapis.com/auth/documents",
 			"https://www.googleapis.com/auth/drive",
@@ -60,10 +61,10 @@ func NewFromConfig(cfg *Config) *Service {
 	}
 	client := conf.Client(context.TODO())
 
-	// adminSrv, err := admin.NewService(context.TODO(), option.WithHTTPClient(client))
-	// if err != nil {
-	// 	log.Fatalf("Unable to retrieve Admin client: %v", err)
-	// }
+	adminSrv, err := admin.NewService(context.TODO(), option.WithHTTPClient(client))
+	if err != nil {
+		log.Fatalf("Unable to retrieve Admin client: %v", err)
+	}
 	docSrv, err := docs.NewService(context.TODO(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Unable to retrieve Docs client: %v", err)
@@ -87,7 +88,7 @@ func NewFromConfig(cfg *Config) *Service {
 	peoplePeopleSrv := people.NewPeopleService(peopleSrv)
 
 	return &Service{
-		// Admin:  adminSrv,
+		Admin:  adminSrv,
 		Docs:   docSrv,
 		Drive:  driveSrv,
 		Gmail:  gmailSrv,
@@ -111,6 +112,7 @@ func New() *Service {
 	// If modifying these scopes, delete your previously saved token.json.
 	gc, err := google.ConfigFromJSON(b,
 		// "https://www.googleapis.com/auth/admin.directory.group",
+		"https://www.googleapis.com/auth/admin.directory.user.readonly",
 		"https://www.googleapis.com/auth/directory.readonly",
 		"https://www.googleapis.com/auth/documents",
 		"https://www.googleapis.com/auth/drive",
@@ -120,10 +122,10 @@ func New() *Service {
 	}
 	client := getClient(gc)
 
-	// adminSrv, err := admin.NewService(context.TODO(), option.WithHTTPClient(client))
-	// if err != nil {
-	// 	log.Fatalf("Unable to retrieve Admin client: %v", err)
-	// }
+	adminSrv, err := admin.NewService(context.TODO(), option.WithHTTPClient(client))
+	if err != nil {
+		log.Fatalf("Unable to retrieve Admin client: %v", err)
+	}
 	docSrv, err := docs.NewService(context.TODO(), option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Unable to retrieve Google Docs client: %v", err)
@@ -147,7 +149,7 @@ func New() *Service {
 	peoplePeopleSrv := people.NewPeopleService(peopleSrv)
 
 	return &Service{
-		// Admin:  adminSrv,
+		Admin:  adminSrv,
 		Docs:   docSrv,
 		Drive:  driveSrv,
 		Gmail:  gmailSrv,


### PR DESCRIPTION
There is an unfortunate [bug](https://issuetracker.google.com/issues/196235775) with the Google People API where searching the directory doesn't return names of users. This PR gets around the bug by instead using the Admin Directory API to get this information and replacing it in the People API response. This is obviously kind of a hack, but I couldn't find another way to get names of users through Google's APIs.

Some considerations (why this is currently a draft PR):
- This significantly increases the latency when searching for people. In my testing, searches that return a full 5 people back (added this maximum in this PR with `PageSize(5)`) can take around 3 seconds, which might be unacceptable.
- This also requires enabling the Admin API. I had forgotten that we actually had done this a while ago to interact with Google Groups (the approach was since abandoned and we had some commented code for this, _for reasons_?). Enabling this API might not be a blocker either way, but wanted to also call this out because it will at least require release notes documentation as a breaking change.