### PR TITLE
Add /me endpoint to determine if the user is currently authenticated

### DIFF
--- a/internal/api/me.go
+++ b/internal/api/me.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+func MeHandler(
+	l hclog.Logger,
+) http.Handler {
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		errResp := func(httpCode int, userErrMsg, logErrMsg string, err error) {
+			l.Error(logErrMsg,
+				"method", r.Method,
+				"path", r.URL.Path,
+				"error", err,
+			)
+			errJSON := fmt.Sprintf(`{"error": "%s"}`, userErrMsg)
+			http.Error(w, errJSON, httpCode)
+		}
+
+		// Authorize request.
+		userEmail := r.Context().Value("userEmail").(string)
+		if userEmail == "" {
+			errResp(
+				http.StatusUnauthorized,
+				"No authorization information for request",
+				"no user email found in request context",
+				nil,
+			)
+			return
+		}
+
+		switch r.Method {
+		// The HEAD method is used to determine if the user is currently
+		// authenticated.
+		case "HEAD":
+			w.WriteHeader(http.StatusOK)
+			return
+
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+	})
+}

--- a/internal/api/me_subscriptions.go
+++ b/internal/api/me_subscriptions.go
@@ -81,22 +81,6 @@ func MeSubscriptionsHandler(
 				)
 				return
 			}
-		case "HEAD":
-			// Find or create user.
-			u := models.User{
-				EmailAddress: userEmail,
-			}
-			// Write response.
-			w.WriteHeader(http.StatusOK)
-			if err := u.FirstOrCreate(db); err != nil {
-				errResp(
-					http.StatusInternalServerError,
-					"Error authorizing the request",
-					"error finding or creating user",
-					err,
-				)
-				return
-			}
 
 		case "POST":
 			// Decode request.

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -266,6 +266,7 @@ func (c *Command) Run(args []string) int {
 			api.DraftsHandler(cfg, c.Log, algoSearch, algoWrite, goog, db)},
 		{"/api/v1/drafts/",
 			api.DraftsDocumentHandler(cfg, c.Log, algoSearch, algoWrite, goog)},
+		{"/api/v1/me", api.MeHandler(c.Log)},
 		{"/api/v1/me/subscriptions",
 			api.MeSubscriptionsHandler(cfg, c.Log, goog, db)},
 		{"/api/v1/people", api.PeopleDataHandler(cfg, c.Log, goog)},


### PR DESCRIPTION
This adds a `/me` endpoint to determine if the user is currently authenticated (at least that's it for right now - we might add more functionality to this endpoint in the future). This is to support #82.