### PR TITLE
Enable changing product of a draft document via the API

### DIFF
--- a/internal/api/drafts.go
+++ b/internal/api/drafts.go
@@ -39,6 +39,7 @@ type DraftsRequest struct {
 type DraftsPatchRequest struct {
 	Approvers    []string `json:"approvers,omitempty"`
 	Contributors []string `json:"contributors,omitempty"`
+	Product      string   `json:"product,omitempty"`
 	Summary      string   `json:"summary,omitempty"`
 	// Tags                []string `json:"tags,omitempty"`
 	Title string `json:"title,omitempty"`
@@ -432,7 +433,8 @@ func DraftsDocumentHandler(
 	l hclog.Logger,
 	ar *algolia.Client,
 	aw *algolia.Client,
-	s *gw.Service) http.Handler {
+	s *gw.Service,
+	db *gorm.DB) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Get document ID from URL path
@@ -633,6 +635,22 @@ func DraftsDocumentHandler(
 				return
 			}
 
+			// Validate product if it is in the patch request.
+			if req.Product != "" {
+				p := models.Product{Name: req.Product}
+				if err := p.Get(db); err != nil {
+					l.Error("error getting product",
+						"error", err,
+						"method", r.Method,
+						"path", r.URL.Path,
+						"product", req.Product,
+						"doc_id", docId)
+					http.Error(w, "Bad request: invalid product",
+						http.StatusBadRequest)
+					return
+				}
+			}
+
 			// Compare contributors in request and stored object in Algolia
 			// before we save the patched objected
 			// Find out contributors to share the document with
@@ -715,6 +733,25 @@ func DraftsDocumentHandler(
 			if len(contributorsToRemoveSharing) > 0 {
 				l.Info("removed contributors from document",
 					"contributors_count", len(contributorsToRemoveSharing))
+			}
+
+			// Update product in the database (if it is in the patch request).
+			if req.Product != "" {
+				d := models.Document{
+					GoogleFileID: docId,
+					Product:      models.Product{Name: req.Product},
+				}
+				if err := d.Upsert(db); err != nil {
+					l.Error("error upserting document to update product",
+						"error", err,
+						"method", r.Method,
+						"path", r.URL.Path,
+						"product", req.Product,
+						"doc_id", docId)
+					http.Error(w, "Error patching document draft",
+						http.StatusInternalServerError)
+					return
+				}
 			}
 
 			// Save new modified draft doc object in Algolia.

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -265,7 +265,7 @@ func (c *Command) Run(args []string) int {
 		{"/api/v1/drafts",
 			api.DraftsHandler(cfg, c.Log, algoSearch, algoWrite, goog, db)},
 		{"/api/v1/drafts/",
-			api.DraftsDocumentHandler(cfg, c.Log, algoSearch, algoWrite, goog)},
+			api.DraftsDocumentHandler(cfg, c.Log, algoSearch, algoWrite, goog, db)},
 		{"/api/v1/me/subscriptions",
 			api.MeSubscriptionsHandler(cfg, c.Log, goog, db)},
 		{"/api/v1/people", api.PeopleDataHandler(cfg, c.Log, goog)},

--- a/pkg/models/document.go
+++ b/pkg/models/document.go
@@ -33,8 +33,9 @@ type Document struct {
 	// DocumentModifiedAt is the time the document was last modified.
 	DocumentModifiedAt time.Time
 
-	// DocumentNumber is a document identifier containing a product/area
-	// abbreviation and a number (e.g., "TF-123").
+	// DocumentNumber is a document number unique to each product/area. It
+	// with the product abbreviation to form a document identifier
+	// (e.g., "TF-123").
 	DocumentNumber int `gorm:"index:latest_product_number"`
 
 	// DocumentType is the document type.

--- a/pkg/models/document.go
+++ b/pkg/models/document.go
@@ -306,6 +306,14 @@ func (d *Document) createAssocations(db *gorm.DB) error {
 		d.OwnerID = &d.Owner.ID
 	}
 
+	// Get product if ProductID is not set.
+	if d.ProductID == 0 && d.Product.Name != "" {
+		if err := d.Product.Get(db); err != nil {
+			return fmt.Errorf("error getting product: %w", err)
+		}
+		d.ProductID = d.Product.ID
+	}
+
 	return nil
 }
 

--- a/pkg/models/document.go
+++ b/pkg/models/document.go
@@ -34,7 +34,7 @@ type Document struct {
 	DocumentModifiedAt time.Time
 
 	// DocumentNumber is a document number unique to each product/area. It
-	// with the product abbreviation to form a document identifier
+	// pairs with the product abbreviation to form a document identifier
 	// (e.g., "TF-123").
 	DocumentNumber int `gorm:"index:latest_product_number"`
 


### PR DESCRIPTION
This PR enables changing the product of a draft document via a PATCH request to `api/v1/drafts/{DOC_ID}`.