### PR TITLE
WIP: Increase facet limit; Add loader for long lists

### DIFF
--- a/web/app/components/header/facet-dropdown-list-item.hbs
+++ b/web/app/components/header/facet-dropdown-list-item.hbs
@@ -29,7 +29,7 @@
       />
     {{/if}}
     <div class="w-full flex justify-between overflow-hidden">
-      <span data-test-facet-dropdown-list-item-value>
+      <span class="truncate" data-test-facet-dropdown-list-item-value>
         {{@value}}
       </span>
       {{#unless this.sortByQueryParams}}

--- a/web/app/components/header/facet-dropdown.hbs
+++ b/web/app/components/header/facet-dropdown.hbs
@@ -30,24 +30,34 @@
     }}
   />
   {{#if this.dropdownIsShown}}
-    <Header::FacetDropdownList
-      {{dismissible dismiss=this.hideDropdown related=this.triggerElement}}
-      @shownFacets={{this.shownFacets}}
-      @label={{@label}}
-      @inputIsShown={{this.inputIsShown}}
-      @onInput={{perform this.onInput}}
-      @resetFocusedItemIndex={{this.resetFocusedItemIndex}}
-      @registerScrollContainer={{this.registerScrollContainer}}
-      @query={{this.query}}
-      @focusedItemIndex={{this.focusedItemIndex}}
-      @setFocusedItemIndex={{this.setFocusedItemIndex}}
-      @listItemRole={{this.listItemRole}}
-      @registerPopover={{this.registerPopover}}
-      @popoverElement={{this.popoverElement}}
-      @triggerElement={{this.triggerElement}}
-      @hideDropdown={{this.hideDropdown}}
-      @anchorToRight={{@anchorToRight}}
-      @currentSortByValue={{@currentSortByValue}}
-    />
+    {{#if this.loaderIsShown}}
+      <div
+        class="facet-dropdown-popover px-4 pt-3 pb-3.5 large hds-dropdown-list text-color-foreground-faint text-body-200"
+        data-test-facet-dropdown-loader
+        {{did-insert (perform this.removeLoader)}}
+      >
+        Loading...
+      </div>
+    {{else}}
+      <Header::FacetDropdownList
+        {{dismissible dismiss=this.hideDropdown related=this.triggerElement}}
+        @shownFacets={{this.shownFacets}}
+        @label={{@label}}
+        @inputIsShown={{this.inputIsShown}}
+        @onInput={{perform this.onInput}}
+        @resetFocusedItemIndex={{this.resetFocusedItemIndex}}
+        @registerScrollContainer={{this.registerScrollContainer}}
+        @query={{this.query}}
+        @focusedItemIndex={{this.focusedItemIndex}}
+        @setFocusedItemIndex={{this.setFocusedItemIndex}}
+        @listItemRole={{this.listItemRole}}
+        @registerPopover={{this.registerPopover}}
+        @popoverElement={{this.popoverElement}}
+        @triggerElement={{this.triggerElement}}
+        @hideDropdown={{this.hideDropdown}}
+        @anchorToRight={{@anchorToRight}}
+        @currentSortByValue={{@currentSortByValue}}
+      />
+    {{/if}}
   {{/if}}
 </div>

--- a/web/app/services/algolia.ts
+++ b/web/app/services/algolia.ts
@@ -17,7 +17,7 @@ import {
 import SessionService from "./session";
 
 export const HITS_PER_PAGE = 12;
-export const MAX_VALUES_PER_FACET = 100;
+export const MAX_VALUES_PER_FACET = 1000; // Algolia max
 export const FACET_NAMES = ["docType", "owners", "product", "status"];
 
 export type AlgoliaSearchParams = RequestOptions & SearchOptions;


### PR DESCRIPTION
Increases the Algolia maxFacets value to 1000 — [the highest number](https://www.youtube.com/watch?v=9P2ROAbQZYw&themeRefresh=1) — so that more document owners are searchable via the filter dropdowns.

And because long lists can take a second to load, I've added and tested a loading function for lists longer than 250. This is a short-term fix while we explore more robust solutions that can handle more than 1000 authors and display them quicker.

Also fixes a truncation bug on longer owner names.