### PR TITLE
Tweak CSS `z-index` of FacetDropdowns and DocThumbnail outline

### DIFF
--- a/web/app/styles/components/doc/thumbnail.scss
+++ b/web/app/styles/components/doc/thumbnail.scss
@@ -4,7 +4,7 @@
   // Outer border / shadow
   &::after {
     content: "";
-    @apply absolute z-50 pointer-events-none;
+    @apply absolute z-10 pointer-events-none;
     // Make the element 1px smaller than its container
     // so its shadow picks up colors from the elements below it.
     @apply top-px right-px bottom-px left-px;

--- a/web/app/styles/components/header/facet-dropdown.scss
+++ b/web/app/styles/components/header/facet-dropdown.scss
@@ -1,5 +1,5 @@
 .facet-dropdown-popover {
-  @apply absolute -bottom-1 left-0 bg-color-page-primary translate-y-full flex flex-col rounded-md w-full max-h-[400px] pt-0 z-10;
+  @apply absolute -bottom-1 left-0 bg-color-page-primary translate-y-full flex flex-col rounded-md w-full max-h-[400px] pt-0 z-50;
 
   &.hds-dropdown-list {
     @apply min-w-[175px];


### PR DESCRIPTION
Fixes a graphical bug on the search template where the doc-thumbnail outline was appearing above the facet dropdowns:

![CleanShot 2023-04-05 at 10 05 54@2x](https://user-images.githubusercontent.com/754957/230105848-56f64d81-3258-4c8c-9071-b3ee43010f5b.png)
