### PR TITLE
Add leading slash to share link

### DIFF
--- a/web/app/components/document/sidebar/header.ts
+++ b/web/app/components/document/sidebar/header.ts
@@ -23,7 +23,7 @@ export default class DocumentSidebarHeaderComponent extends Component<DocumentSi
   protected get url() {
     const shortLinkBaseURL = this.configSvc.config.short_link_base_url;
     return shortLinkBaseURL
-      ? `${shortLinkBaseURL + this.args.document.docType.toLowerCase()}/${
+      ? `/${shortLinkBaseURL + this.args.document.docType.toLowerCase()}/${
           this.args.document.docNumber
         }`
       : window.location.href;


### PR DESCRIPTION
Adds a missing slash to our sharkLink urls.