### PR TITLE
Move shareLink slash

### DIFF
--- a/web/app/components/document/sidebar/header.ts
+++ b/web/app/components/document/sidebar/header.ts
@@ -23,9 +23,7 @@ export default class DocumentSidebarHeaderComponent extends Component<DocumentSi
   protected get url() {
     const shortLinkBaseURL = this.configSvc.config.short_link_base_url;
     return shortLinkBaseURL
-      ? `/${shortLinkBaseURL + this.args.document.docType.toLowerCase()}/${
-          this.args.document.docNumber.toLowerCase()
-        }`
+      ? `${shortLinkBaseURL}/${this.args.document.docType.toLowerCase()}/${this.args.document.docNumber.toLowerCase()}`
       : window.location.href;
   }
 }

--- a/web/app/components/document/sidebar/header.ts
+++ b/web/app/components/document/sidebar/header.ts
@@ -24,7 +24,7 @@ export default class DocumentSidebarHeaderComponent extends Component<DocumentSi
     const shortLinkBaseURL = this.configSvc.config.short_link_base_url;
     return shortLinkBaseURL
       ? `/${shortLinkBaseURL + this.args.document.docType.toLowerCase()}/${
-          this.args.document.docNumber
+          this.args.document.docNumber.toLowerCase()
         }`
       : window.location.href;
   }


### PR DESCRIPTION
I accidentally had the slash to start the URL rather than appear after the shortlinkURL