### PR TITLE
Upgrade Design System Components

### DIFF
--- a/web/app/components/header/facet-dropdown-list.hbs
+++ b/web/app/components/header/facet-dropdown-list.hbs
@@ -4,7 +4,7 @@
   {{did-insert @registerPopover}}
   role={{if @inputIsShown "combobox"}}
   id="facet-dropdown-popover"
-  class="facet-dropdown-popover hds-dropdown-list
+  class="facet-dropdown-popover hds-dropdown__content
     {{if @anchorToRight 'anchor-right'}}
     {{if @inputIsShown 'large'}}
     {{if (and (not @inputIsShown) (eq this.facetName 'status')) 'medium'}}"

--- a/web/app/components/header/search.hbs
+++ b/web/app/components/header/search.hbs
@@ -23,7 +23,7 @@
         </span>
       {{/unless}}
       {{#if this.query}}
-        <dd.Content class="hds-dropdown-list search-dropdown">
+        <dd.Content class="hds-dropdown__content search-dropdown">
           {{#if this.bestMatches}}
             <div
               class="flex flex-col border-0 border-b hds-border-primary pb-1"

--- a/web/app/styles/components/header/facet-dropdown.scss
+++ b/web/app/styles/components/header/facet-dropdown.scss
@@ -1,7 +1,7 @@
 .facet-dropdown-popover {
   @apply absolute -bottom-1 left-0 bg-color-page-primary translate-y-full flex flex-col rounded-md w-full max-h-[400px] pt-0 z-50;
 
-  &.hds-dropdown-list {
+  &.hds-dropdown__content {
     @apply min-w-[175px];
   }
 

--- a/web/app/styles/ember-power-select-theme.scss
+++ b/web/app/styles/ember-power-select-theme.scss
@@ -32,7 +32,7 @@ $ember-power-select-multiple-option-padding: 0 7px;
 $ember-power-select-multiple-option-line-height: 1.3;
 
 .ember-basic-dropdown-content {
-  .hds-dropdown-list-item--interactive {
+  .hds-dropdown-list-item--variant-interactive {
     @apply flex items-center px-3;
 
     &:hover {

--- a/web/app/styles/hds-overrides.scss
+++ b/web/app/styles/hds-overrides.scss
@@ -7,8 +7,8 @@
 }
 
 .hds-dropdown-toggle-button .hds-button__icon,
-.hds-dropdown-toggle-icon__chevron {
-  transition: none;
+.hds-dropdown-toggle-chevron > svg {
+  transition: none !important;
 }
 
 .hds-link-standalone.small-external-link {

--- a/web/package.json
+++ b/web/package.json
@@ -119,7 +119,7 @@
   "dependencies": {
     "@csstools/postcss-sass": "^5.0.1",
     "@floating-ui/dom": "^1.2.4",
-    "@hashicorp/design-system-components": "^1.4.0",
+    "@hashicorp/design-system-components": "^2.0.0",
     "@hashicorp/ember-flight-icons": "^3.0.2",
     "@types/sinon": "^10.0.13",
     "algoliasearch": "^4.13.0",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1781,6 +1781,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ember/render-modifiers@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@ember/render-modifiers@npm:2.0.5"
+  dependencies:
+    "@embroider/macros": ^1.0.0
+    ember-cli-babel: ^7.26.11
+    ember-modifier-manager-polyfill: ^1.2.0
+  peerDependencies:
+    ember-source: ^3.8 || ^4.0.0
+  checksum: ebeb4d573968f46490f8f5618b9d85f2c7ca39cee5b854bb497a3aee7dee3d710ab02b9677df30f1e2a484e712dd89171045118da563d9d9a6c316ccdccc2671
+  languageName: node
+  linkType: hard
+
 "@ember/string@npm:^3.0.0":
   version: 3.0.0
   resolution: "@ember/string@npm:3.0.0"
@@ -2101,33 +2114,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hashicorp/design-system-components@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "@hashicorp/design-system-components@npm:1.4.0"
+"@hashicorp/design-system-components@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@hashicorp/design-system-components@npm:2.0.0"
   dependencies:
-    "@hashicorp/design-system-tokens": ^1.2.0
+    "@ember/render-modifiers": ^2.0.5
+    "@hashicorp/design-system-tokens": ^1.4.1
     "@hashicorp/ember-flight-icons": ^3.0.2
     dialog-polyfill: ^0.5.6
-    ember-auto-import: ^2.4.2
+    ember-auto-import: ^2.6.0
     ember-cached-decorator-polyfill: ^0.1.4
     ember-cli-babel: ^7.26.11
-    ember-cli-htmlbars: ^6.1.0
+    ember-cli-htmlbars: ^6.2.0
     ember-cli-sass: ^10.0.1
-    ember-composable-helpers: ^4.4.1
+    ember-composable-helpers: ^4.5.0
     ember-focus-trap: ^1.0.1
     ember-keyboard: ^8.1.0
     ember-named-blocks-polyfill: ^0.2.5
     ember-style-modifier: ^0.8.0
     ember-truth-helpers: ^3.0.0
-    sass: ^1.43.4
-  checksum: b1b821efc16597ad862bd30a634adb379cad1816b568fbc519e884ba4c5069c75efe7db0f4a0317b922a9360972687b329456b5dc18e0de5c9c94d9829040523
+    sass: ^1.58.3
+  checksum: cc72319c2d6294719c5a9c6e98ef13c27a8f1ec7bcc31425b1fd11d4a8ad1ebd044f6b5c29710f343301583edfa6198d3617c9c2794f021b53eb15feb4847a3a
   languageName: node
   linkType: hard
 
-"@hashicorp/design-system-tokens@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@hashicorp/design-system-tokens@npm:1.2.0"
-  checksum: 29a23eff8ef5cfbbdf7aa9ad1184a313d8bfb58cc4bf16d49d73782d54d0de64fa4a6024e13200a1ad6661ad7d5d4a5b83954d4d0a1622c9e838b2b66e46a65e
+"@hashicorp/design-system-tokens@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "@hashicorp/design-system-tokens@npm:1.4.1"
+  checksum: 3f9602be037643d6c1fe695ab07ff7a19bd71b27ec693fcb94373ba9eb6246b248bc4a0739f6248a6359de67e2236780d66b3206f0ae669bb31a4e3a519d877a
   languageName: node
   linkType: hard
 
@@ -4350,7 +4364,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-import-util@npm:^1.1.0, babel-import-util@npm:^1.2.0":
+"babel-import-util@npm:^1.1.0, babel-import-util@npm:^1.2.0, babel-import-util@npm:^1.3.0":
   version: 1.3.0
   resolution: "babel-import-util@npm:1.3.0"
   checksum: 41c6b4276ceefd2263f59be97a99bf8d948899c76587b273d115e91fa9067b0d9cc80ba727a795732052e078c30a3665649c725aed966826bf7c0a258a5fcf03
@@ -4448,6 +4462,15 @@ __metadata:
     magic-string: ^0.26.0
     string.prototype.matchall: ^4.0.5
   checksum: aa67214290e498c86a775737529ea353d88988875fc95781cc6eec509064c4430f9433891d9c43ec30f14490c3413277043eed167a0d9d1be442a951e2adffc4
+  languageName: node
+  linkType: hard
+
+"babel-plugin-ember-template-compilation@npm:^2.0.0, babel-plugin-ember-template-compilation@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "babel-plugin-ember-template-compilation@npm:2.0.2"
+  dependencies:
+    babel-import-util: ^1.3.0
+  checksum: 2594153919061e1e266d73a29c3166a0e9cdafdda88ed1fe0b274ee5f7c3ad4ea00a12690998864b2ce58f74c90a4cfb61ac9644764bc0df06ee91ff24459d57
   languageName: node
   linkType: hard
 
@@ -7494,6 +7517,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ember-auto-import@npm:^2.6.0":
+  version: 2.6.3
+  resolution: "ember-auto-import@npm:2.6.3"
+  dependencies:
+    "@babel/core": ^7.16.7
+    "@babel/plugin-proposal-class-properties": ^7.16.7
+    "@babel/plugin-proposal-decorators": ^7.16.7
+    "@babel/preset-env": ^7.16.7
+    "@embroider/macros": ^1.0.0
+    "@embroider/shared-internals": ^2.0.0
+    babel-loader: ^8.0.6
+    babel-plugin-ember-modules-api-polyfill: ^3.5.0
+    babel-plugin-ember-template-compilation: ^2.0.1
+    babel-plugin-htmlbars-inline-precompile: ^5.2.1
+    babel-plugin-syntax-dynamic-import: ^6.18.0
+    broccoli-debug: ^0.6.4
+    broccoli-funnel: ^3.0.8
+    broccoli-merge-trees: ^4.2.0
+    broccoli-plugin: ^4.0.0
+    broccoli-source: ^3.0.0
+    css-loader: ^5.2.0
+    debug: ^4.3.1
+    fs-extra: ^10.0.0
+    fs-tree-diff: ^2.0.0
+    handlebars: ^4.3.1
+    js-string-escape: ^1.0.1
+    lodash: ^4.17.19
+    mini-css-extract-plugin: ^2.5.2
+    parse5: ^6.0.1
+    resolve: ^1.20.0
+    resolve-package-path: ^4.0.3
+    semver: ^7.3.4
+    style-loader: ^2.0.0
+    typescript-memoize: ^1.0.0-alpha.3
+    walk-sync: ^3.0.0
+  checksum: e42c0f9dee74c94a16c8b4d701707f457e8955ad340e68be32375ff32fba030fcaa53aa4e4fd2d482fabe0a320ceabc034520c73601c8d69caa6268093dd0f65
+  languageName: node
+  linkType: hard
+
 "ember-basic-dropdown@npm:^4.0.5":
   version: 4.0.5
   resolution: "ember-basic-dropdown@npm:4.0.5"
@@ -7750,6 +7812,28 @@ __metadata:
     silent-error: ^1.1.1
     walk-sync: ^2.2.0
   checksum: d75fbe973196bdc1df6a04a11310064125108eb105e903a842698f0dd6c133d2e1699860ea1c8237d0c62f92b01da4ebc7b672e862b2e572922f0f86f243a9a1
+  languageName: node
+  linkType: hard
+
+"ember-cli-htmlbars@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "ember-cli-htmlbars@npm:6.2.0"
+  dependencies:
+    "@ember/edition-utils": ^1.2.0
+    babel-plugin-ember-template-compilation: ^2.0.0
+    babel-plugin-htmlbars-inline-precompile: ^5.3.0
+    broccoli-debug: ^0.6.5
+    broccoli-persistent-filter: ^3.1.2
+    broccoli-plugin: ^4.0.3
+    ember-cli-version-checker: ^5.1.2
+    fs-tree-diff: ^2.0.1
+    hash-for-dep: ^1.5.1
+    heimdalljs-logger: ^0.1.10
+    js-string-escape: ^1.0.1
+    semver: ^7.3.4
+    silent-error: ^1.1.1
+    walk-sync: ^2.2.0
+  checksum: 1a0f94152ae381aed4c0300f4d8e756d60bfc4dfd1357fd49a0d36d420d65d6dc3f5761e604976f63edd11bc264959dddbd1b4c8401e9922711eafc748f4df92
   languageName: node
   linkType: hard
 
@@ -8178,7 +8262,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-composable-helpers@npm:^4.4.1":
+"ember-composable-helpers@npm:^4.5.0":
   version: 4.5.0
   resolution: "ember-composable-helpers@npm:4.5.0"
   dependencies:
@@ -10832,7 +10916,7 @@ __metadata:
     "@floating-ui/dom": ^1.2.4
     "@glimmer/component": ^1.0.4
     "@glimmer/tracking": ^1.0.4
-    "@hashicorp/design-system-components": ^1.4.0
+    "@hashicorp/design-system-components": ^2.0.0
     "@hashicorp/ember-flight-icons": ^3.0.2
     "@tsconfig/ember": latest
     "@types/ember": latest
@@ -15550,7 +15634,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass@npm:^1.43.4, sass@npm:^1.49.7":
+"sass@npm:^1.49.7":
   version: 1.56.2
   resolution: "sass@npm:1.56.2"
   dependencies:
@@ -15560,6 +15644,19 @@ __metadata:
   bin:
     sass: sass.js
   checksum: 7b1f524d04bc42df3bac6dc5201ff7475635b7df9a1390430ed5bd58b6a73ea1ae58b83ccea8da293cb77b85b4c848faf5f2779ca4b91b9303948c251d0ddca4
+  languageName: node
+  linkType: hard
+
+"sass@npm:^1.58.3":
+  version: 1.60.0
+  resolution: "sass@npm:1.60.0"
+  dependencies:
+    chokidar: ">=3.0.0 <4.0.0"
+    immutable: ^4.0.0
+    source-map-js: ">=0.6.2 <2.0.0"
+  bin:
+    sass: sass.js
+  checksum: 06e163c37af466ec194cf2ed8dab616372afeb19322d356947d48ea664fc38398ae77c4d91bea9cb0ace954ce289d5518d0f8555ecc49f6bf2539a8ef52fc580
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrades the HDS components package to 2.0.0; updates some styles and classnames based on the changes.

Heads up, there's a persistent border on the user dropdown now:

<img width="242" alt="CleanShot 2023-04-05 at 21 12 22@2x" src="https://user-images.githubusercontent.com/754957/230247935-6ea5fb69-48de-486f-9c9b-102ab8bd2521.png">
