### PR TITLE
Add shortLinkBaseURL checks (trailingSlack, isValidURL) and test them

### DIFF
--- a/web/app/components/document/sidebar/header.hbs
+++ b/web/app/components/document/sidebar/header.hbs
@@ -17,6 +17,7 @@
     {{#if this.shareButtonIsShown}}
       <CopyURLButton
         data-test-sidebar-copy-url-button
+        data-test-copy-url-value={{this.url}}
         @url={{this.url}}
         @tooltipPlacement={{if @isCollapsed "right" "bottom"}}
         class="sidebar-header-button"

--- a/web/app/components/document/sidebar/header.ts
+++ b/web/app/components/document/sidebar/header.ts
@@ -12,6 +12,15 @@ interface DocumentSidebarHeaderComponentSignature {
   };
 }
 
+export function isValidURL(input: string) {
+  try {
+    new URL(input);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export default class DocumentSidebarHeaderComponent extends Component<DocumentSidebarHeaderComponentSignature> {
   @service("config") declare configSvc: ConfigService;
 
@@ -21,9 +30,22 @@ export default class DocumentSidebarHeaderComponent extends Component<DocumentSi
   }
 
   protected get url() {
-    const shortLinkBaseURL = this.configSvc.config.short_link_base_url;
+    let shortLinkBaseURL: string | undefined =
+      this.configSvc.config.short_link_base_url;
+
+    if (shortLinkBaseURL) {
+      // Add a trailing slash if the URL needs one
+      if (!shortLinkBaseURL.endsWith("/")) {
+        shortLinkBaseURL += "/";
+      }
+      // Reject invalid URLs
+      if (!isValidURL(shortLinkBaseURL)) {
+        shortLinkBaseURL = undefined;
+      }
+    }
+
     return shortLinkBaseURL
-      ? `/${
+      ? `${
           shortLinkBaseURL + this.args.document.docType.toLowerCase()
         }/${this.args.document.docNumber.toLowerCase()}`
       : window.location.href;

--- a/web/app/components/document/sidebar/header.ts
+++ b/web/app/components/document/sidebar/header.ts
@@ -23,7 +23,7 @@ export default class DocumentSidebarHeaderComponent extends Component<DocumentSi
   protected get url() {
     const shortLinkBaseURL = this.configSvc.config.short_link_base_url;
     return shortLinkBaseURL
-      ? `${shortLinkBaseURL + this.args.document.docType.toLowerCase()}/${
+      ? `/${shortLinkBaseURL + this.args.document.docType.toLowerCase()}/${
           this.args.document.docNumber
         }`
       : window.location.href;


### PR DESCRIPTION
Adds some safeguarding to the ShortLinkBaseURL functions: We now have trailing-slash logic and we confirm the URL is valid before using it. 