### PR TITLE
Simplify session/localStorage logic; Add isLoggedIn check

### DIFF
--- a/web/app/routes/application.js
+++ b/web/app/routes/application.js
@@ -1,6 +1,4 @@
 import Route from "@ember/routing/route";
-import { UnauthorizedError } from "@ember-data/adapter/error";
-import { action } from "@ember/object";
 import config from "hermes/config/environment";
 import { inject as service } from "@ember/service";
 
@@ -9,14 +7,6 @@ export default class ApplicationRoute extends Route {
   @service("fetch") fetchSvc;
   @service flags;
   @service session;
-
-  @action
-  error(error) {
-    if (error instanceof UnauthorizedError) {
-      this.session.invalidate();
-      return;
-    }
-  }
 
   async beforeModel() {
     await this.session.setup();

--- a/web/app/routes/application.js
+++ b/web/app/routes/application.js
@@ -1,4 +1,6 @@
 import Route from "@ember/routing/route";
+import { UnauthorizedError } from "@ember-data/adapter/error";
+import { action } from "@ember/object";
 import config from "hermes/config/environment";
 import { inject as service } from "@ember/service";
 
@@ -7,6 +9,14 @@ export default class ApplicationRoute extends Route {
   @service("fetch") fetchSvc;
   @service flags;
   @service session;
+
+  @action
+  error(error) {
+    if (error instanceof UnauthorizedError) {
+      this.session.invalidate();
+      return;
+    }
+  }
 
   async beforeModel() {
     await this.session.setup();

--- a/web/app/routes/authenticated.ts
+++ b/web/app/routes/authenticated.ts
@@ -1,8 +1,8 @@
 import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
 import AuthenticatedUserService from "hermes/services/authenticated-user";
-import SessionService, { REDIRECT_STORAGE_KEY } from "hermes/services/session";
 import window from "ember-window-mock";
+import SessionService, { REDIRECT_STORAGE_KEY } from "hermes/services/session";
 
 export default class AuthenticatedRoute extends Route {
   @service declare session: SessionService;

--- a/web/app/routes/authenticated.ts
+++ b/web/app/routes/authenticated.ts
@@ -1,65 +1,46 @@
 import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
 import AuthenticatedUserService from "hermes/services/authenticated-user";
-import window from "ember-window-mock";
 import SessionService, { REDIRECT_STORAGE_KEY } from "hermes/services/session";
+import window from "ember-window-mock";
 
 export default class AuthenticatedRoute extends Route {
   @service declare session: SessionService;
   @service declare authenticatedUser: AuthenticatedUserService;
 
-  async afterModel(): Promise<void> {
-    await this.authenticatedUser.loadInfo.perform();
-    void this.session.pollForExpiredAuth.perform();
-  }
-
-  async beforeModel(transition: any): Promise<void> {
-    // If the user isn't authenticated, transition to the auth screen
-    let requireAuthentication = this.session.requireAuthentication(
+  async afterModel(transition: any): Promise<void> {
+    let isLoggedIn = this.session.requireAuthentication(
       transition,
       "authenticate"
     );
-
-    // See if we have a redirect target stored in sessionStorage
-    let storageItem = window.sessionStorage.getItem(REDIRECT_STORAGE_KEY);
-
-    if (!storageItem) {
-      // If we don't have a redirect target in sessionStorage, check localStorage
-      storageItem = window.localStorage.getItem(REDIRECT_STORAGE_KEY);
-
-      // If the redirect target in localStorage is expired, remove it
-      if (storageItem && Date.now() > JSON.parse(storageItem).expiresOn) {
-        window.localStorage.removeItem(REDIRECT_STORAGE_KEY);
-        storageItem = null;
-      }
+    if (isLoggedIn) {
+      await this.authenticatedUser.loadInfo.perform();
+      void this.session.pollForExpiredAuth.perform();
     }
+  }
 
-    if (
-      !storageItem &&
-      !requireAuthentication &&
-      transition.to.name != "authenticated.index"
-    ) {
-      // ember-simple-auth uses this value to set cookies when fastboot is enabled: https://github.com/mainmatter/ember-simple-auth/blob/a7e583cf4d04d6ebc96b198a8fa6dde7445abf0e/packages/ember-simple-auth/addon/-internals/routing.js#L12
+  beforeModel(transition: any): void {
+    /**
+     * We expect a `transition.intent.url`, but in rare cases, it's undefined,
+     * e.g., when clicking the "view dashboard" button from the 404 route.
+     * When this happens, we fall back to `transition.to.name`.
+     *
+     * For reference:
+     * `transition.intent.url` e.g., 'documents/1'
+     * `transition.to.name` e.g., 'authenticated.documents'
+     */
+    let transitionTo = transition.intent.url ?? transition.to.name;
 
-      /**
-       * We expect a `transition.intent.url`, but in rare cases, it's undefined,
-       * e.g., when clicking the "view dashboard" button from the 404 route.
-       * When this happens, we fall back to `transition.to.name`.
-       *
-       * For reference:
-       * `transition.intent.url` e.g., 'documents/1'
-       * `transition.to.name` e.g., 'authenticated.documents'
-       */
-      let transitionTo = transition.intent.url ?? transition.to.name;
-
-      window.sessionStorage.setItem(REDIRECT_STORAGE_KEY, transitionTo);
-      window.localStorage.setItem(
-        REDIRECT_STORAGE_KEY,
-        JSON.stringify({
-          url: transitionTo,
-          expiresOn: Date.now() + 60 * 5000, // 5 minutes
-        })
-      );
-    }
+    /**
+     * Capture the transition intent and save it to session/localStorage.
+     */
+    window.sessionStorage.setItem(REDIRECT_STORAGE_KEY, transitionTo);
+    window.localStorage.setItem(
+      REDIRECT_STORAGE_KEY,
+      JSON.stringify({
+        url: transitionTo,
+        expiresOn: Date.now() + 60 * 5000, // 5 minutes
+      })
+    );
   }
 }

--- a/web/app/routes/authenticated.ts
+++ b/web/app/routes/authenticated.ts
@@ -9,6 +9,7 @@ export default class AuthenticatedRoute extends Route {
   @service declare authenticatedUser: AuthenticatedUserService;
 
   async afterModel(transition: any): Promise<void> {
+    // If the user isn't authenticated, transition to the auth screen
     let isLoggedIn = this.session.requireAuthentication(
       transition,
       "authenticate"


### PR DESCRIPTION
Simplifies the logic for saving session/localStorage redirect values.

Adds an `isLoggedIn` check to prevent a 401 that was bubbling up to the [application error](https://github.com/hashicorp-forge/hermes/blob/main/web/app/routes/application.js#L13-L19) and triggering an unnecesary invalidate call. You can see in the screenshot that it's the [previously unconditional `loadUserInfo` call](https://github.com/hashicorp-forge/hermes/blob/main/web/app/routes/authenticated.ts#L11-L14) that's triggering the error and causing the session to invalidate:

<img width="551" alt="CleanShot 2023-04-06 at 17 09 18@2x" src="https://user-images.githubusercontent.com/754957/230494654-cd6e2244-4473-4c7e-89d1-27842171731a.png">

