### PR TITLE
Add checks to approvers

### DIFF
--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -245,6 +245,10 @@
                 {{#each this.approvers as |approver|}}
                   <li>
                     <Person
+                      @badge={{if
+                        (has-approved-doc @document approver.email)
+                        "approved"
+                      }}
                       @imgURL={{approver.imgURL}}
                       @email={{approver.email}}
                     />

--- a/web/app/components/person.hbs
+++ b/web/app/components/person.hbs
@@ -1,24 +1,39 @@
 {{#unless this.isHidden}}
   <div class="flex space-x-2 w-full" ...attributes>
-    <div
-      class="w-5 h-5 shrink-0 overflow-hidden rounded-full flex justify-center items-center bg-[color:var(--token-color-palette-alpha-300)]"
-    >
-      {{#if @imgURL}}
-        <img src={{@imgURL}} referrerpolicy="no-referrer" class="w-full" />
-      {{else}}
-        <div class="hds-foreground-high-contrast hds-typography-body-100 flex">
-          {{#if @email}}
-            <span class="capitalize">
-              {{get-first-letter @email}}
-            </span>
-          {{else}}
-            <FlightIcon @name="user" class="scale-90" />
-          {{/if}}
+    <div class="relative">
+      {{#if (eq @badge "approved")}}
+        <div
+          data-test-person-approved-badge
+          class="bg-color-page-faint flex rounded-full absolute -bottom-1.5 -right-1.5 p-0.5 scale-[70%] origin-bottom-right"
+        >
+          <FlightIcon
+            @name="check-circle-fill"
+            class="text-color-palette-green-200"
+          />
         </div>
       {{/if}}
+      <div
+        class="w-5 h-5 shrink-0 overflow-hidden rounded-full flex justify-center items-center bg-[color:var(--token-color-palette-alpha-300)]"
+      >
+        {{#if @imgURL}}
+          <img src={{@imgURL}} referrerpolicy="no-referrer" class="w-full" />
+        {{else}}
+          <div
+            class="hds-foreground-high-contrast hds-typography-body-100 flex"
+          >
+            {{#if @email}}
+              <span class="capitalize">
+                {{get-first-letter @email}}
+              </span>
+            {{else}}
+              <FlightIcon @name="user" class="scale-90" />
+            {{/if}}
+          </div>
+        {{/if}}
+      </div>
     </div>
     <div
-      class="person-email hds-typography-body-200 truncate hds-foreground-primary"
+      class="person-email hds-typography-body-200 truncate hds-foreground-primary relative"
       title={{@email}}
     >
       {{or @email "Unknown"}}

--- a/web/app/helpers/has-approved-doc.ts
+++ b/web/app/helpers/has-approved-doc.ts
@@ -1,0 +1,10 @@
+import { helper } from "@ember/component/helper";
+import { HermesDocument } from "hermes/types/document";
+
+export default helper(([document, approverEmail]: [HermesDocument, string]) => {
+  if (document.approvedBy) {
+    return document.approvedBy.some((email) => email === approverEmail);
+  } else {
+    return false;
+  }
+});

--- a/web/app/types/document.d.ts
+++ b/web/app/types/document.d.ts
@@ -13,6 +13,7 @@ export interface HermesDocument {
   docType: string;
   title: string;
   isDraft?: boolean;
+  approvedBy?: string[];
 
   thumbnail?: string;
   _snippetResult?: {

--- a/web/tests/integration/components/person-test.js
+++ b/web/tests/integration/components/person-test.js
@@ -38,15 +38,35 @@ module("Integration | Component | person", function (hooks) {
 
     this.set("email", null);
 
-
     assert.dom(".person img").doesNotExist();
     assert.dom(".person .person-email").hasText("Unknown");
     assert.dom(".person span").doesNotExist();
     assert.dom(".person svg").exists();
 
-
     this.set("ignoreUnknown", true);
 
     assert.dom(".person").doesNotExist();
+  });
+
+  test("it renders a contextual checkmark", async function (assert) {
+    this.set("badge", null);
+
+    await render(hbs`
+      <Person
+        @badge={{this.badge}}
+      />
+    `);
+
+    assert.dom("[data-test-person-approved-badge]").doesNotExist();
+
+    this.set("badge", "approved");
+
+    assert.dom("[data-test-person-approved-badge]").exists();
+
+    this.set("badge", "pending");
+
+    assert
+      .dom("[data-test-person-approved-badge]")
+      .doesNotExist("only shows a badge if the correct value is passed in");
   });
 });

--- a/web/tests/integration/helpers/has-approved-doc-test.ts
+++ b/web/tests/integration/helpers/has-approved-doc-test.ts
@@ -1,0 +1,35 @@
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+import { render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+
+module("Integration | Helper | has-approved-doc", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("", async function (assert) {
+    this.set("document", {
+      approvedBy: [],
+    });
+
+    const email = "person@example.com";
+    this.set("email", email);
+
+    await render(hbs`
+      <div>
+        {{#if (has-approved-doc this.document this.email)}}
+          Has approved
+        {{else}}
+          Has not approved
+        {{/if}}
+      </div>
+    `);
+
+    assert.dom("div").hasText("Has not approved");
+
+    this.set("document", {
+      approvedBy: [email],
+    });
+
+    assert.dom("div").hasText("Has approved");
+  });
+});


### PR DESCRIPTION
Adds a checkmark icon to approvers who have approved via Hermes.

<img width="115" alt="CleanShot 2023-04-07 at 13 50 36@2x" src="https://user-images.githubusercontent.com/754957/230654447-9e2c4ecd-3fd3-41be-9e91-ce08d93f4f8a.png">

Introduces a `has-approved-doc` template helper to cross-reference the `approvers` and `approvedBy` arrays.