### PR TITLE
Remove leftover tooltips during modifier cleanup

### DIFF
--- a/web/app/modifiers/tooltip.ts
+++ b/web/app/modifiers/tooltip.ts
@@ -63,6 +63,10 @@ function cleanup(instance: TooltipModifier) {
   if (instance.floatingUICleanup) {
     instance.floatingUICleanup();
   }
+
+  if (instance.tooltip) {
+    instance.tooltip.remove();
+  }
 }
 
 export default class TooltipModifier extends Modifier<TooltipModifierSignature> {


### PR DESCRIPTION
Adds a conditional `remove()` call to the tooltip modifier's `cleanup` function to fix a bug causing tooltips to stay open if their trigger were removed before `hideTooltip` ran.

To recreate current bug:
1. Hover a tooltipped button — "collapse sidebar," for example
2. With the tooltip open, key the browser's back button (cmd+leftArrow)
3. You'll see the tooltip stays open and can't be dismissed

In this case, the tooltip persisted because neither the `focusout` nor `mouseleave` events ran, and because, until now, our cleanup didn't plan for that.