### PR TITLE
Add API endpoint for recently viewed docs

### DIFF
--- a/internal/api/me_recently_viewed_docs.go
+++ b/internal/api/me_recently_viewed_docs.go
@@ -1,0 +1,129 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp-forge/hermes/internal/config"
+	"github.com/hashicorp-forge/hermes/pkg/models"
+	"github.com/hashicorp/go-hclog"
+	"gorm.io/gorm"
+)
+
+type recentlyViewedDoc struct {
+	ID      string `json:"id"`
+	IsDraft bool   `json:"isDraft"`
+}
+
+func MeRecentlyViewedDocsHandler(
+	cfg *config.Config,
+	l hclog.Logger,
+	db *gorm.DB,
+) http.Handler {
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		errResp := func(httpCode int, userErrMsg, logErrMsg string, err error) {
+			l.Error(logErrMsg,
+				"method", r.Method,
+				"path", r.URL.Path,
+				"error", err,
+			)
+			errJSON := fmt.Sprintf(`{"error": "%s"}`, userErrMsg)
+			http.Error(w, errJSON, httpCode)
+		}
+
+		// Authorize request.
+		userEmail := r.Context().Value("userEmail").(string)
+		if userEmail == "" {
+			errResp(
+				http.StatusUnauthorized,
+				"No authorization information for request",
+				"no user email found in request context",
+				nil,
+			)
+			return
+		}
+
+		switch r.Method {
+		case "GET":
+			// Find or create user.
+			u := models.User{
+				EmailAddress: userEmail,
+			}
+			if err := u.FirstOrCreate(db); err != nil {
+				errResp(
+					http.StatusInternalServerError,
+					"Error authorizing the request",
+					"error finding or creating user",
+					err,
+				)
+				return
+			}
+
+			// Get recently viewed documents for the user.
+			var rvds []models.RecentlyViewedDoc
+			if err := db.Where(&models.RecentlyViewedDoc{UserID: int(u.ID)}).
+				Order("viewed_at desc").
+				Find(&rvds).Error; err != nil {
+
+				errResp(
+					http.StatusInternalServerError,
+					"Error finding recently viewed documents",
+					"error finding recently viewed documents in database",
+					err,
+				)
+				return
+			}
+
+			// Build response.
+			var res []recentlyViewedDoc
+			for _, d := range rvds {
+				// Get document in database.
+				doc := models.Document{
+					Model: gorm.Model{
+						ID: uint(d.DocumentID),
+					},
+				}
+				if err := doc.Get(db); err != nil {
+					errResp(
+						http.StatusInternalServerError,
+						"Error getting document",
+						"error getting document in database",
+						err,
+					)
+					return
+				}
+
+				isDraft := false
+				// The document is a draft if it's in WIP status and wasn't imported.
+				if doc.Status == models.WIPDocumentStatus && !doc.Imported {
+					isDraft = true
+				}
+
+				res = append(res, recentlyViewedDoc{
+					ID:      doc.GoogleFileID,
+					IsDraft: isDraft,
+				})
+			}
+
+			// Write response.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			enc := json.NewEncoder(w)
+			if err := enc.Encode(res); err != nil {
+				errResp(
+					http.StatusInternalServerError,
+					"Error finding recently viewed documents",
+					"error encoding response to JSON",
+					err,
+				)
+				return
+			}
+
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+	})
+}

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -267,6 +267,8 @@ func (c *Command) Run(args []string) int {
 		{"/api/v1/drafts/",
 			api.DraftsDocumentHandler(cfg, c.Log, algoSearch, algoWrite, goog, db)},
 		{"/api/v1/me", api.MeHandler(c.Log)},
+		{"/api/v1/me/recently-viewed-docs",
+			api.MeRecentlyViewedDocsHandler(cfg, c.Log, db)},
 		{"/api/v1/me/subscriptions",
 			api.MeSubscriptionsHandler(cfg, c.Log, goog, db)},
 		{"/api/v1/people", api.PeopleDataHandler(cfg, c.Log, goog)},

--- a/web/app/services/recently-viewed-docs.ts
+++ b/web/app/services/recently-viewed-docs.ts
@@ -74,18 +74,7 @@ export default class RecentlyViewedDocsService extends Service {
        * Fetch the file IDs from the Google Index file.
        */
       let fetchResponse = await this.fetchSvc.fetch(
-        `https://www.googleapis.com/drive/v3/files/${this.indexID}?` +
-          new URLSearchParams({
-            alt: "media",
-            fields: "files(id, name)",
-          }),
-        {
-          headers: {
-            Authorization:
-              "Bearer " + this.session.data.authenticated.access_token,
-            "Content-Type": "application/json",
-          },
-        }
+        "/api/v1/me/recently-viewed-docs"
       );
 
       this.index = await fetchResponse?.json();

--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -179,6 +179,17 @@ export default function (mirageConfig) {
           schema.document.findBy({ objectID: request.params.document_id }).attrs
         );
       });
+
+      /**
+       * Used by the Dashboard route to get a user's recently viewed documents.
+       */
+      this.get("/me/recently-viewed-docs", (schema) => {
+        let index = schema.recentlyViewedDocs.all().models.map((doc) => {
+          return doc.attrs;
+        });
+        return new Response(200, {}, index);
+      });
+
       /**
        * Used by the AuthenticatedUserService to get the user's subscriptions.
        */


### PR DESCRIPTION
This PR adds an API endpoint `/api/v1/me/recently-viewed-docs` to retrieve recently viewed docs for a logged-in user. Now the source of truth for recently viewed docs is the database, whereas Hermes previously got this information from a JSON file stored in Google Drive's application data - this PR doesn't remove updating the data there yet (this will be done shortly in another PR).

Additionally a bug in the logic for updating the recently viewed docs in the database was fixed: the recently viewed documents were being updated correctly, but there was the potential for the wrong document's "viewed at" time to be modified. This resulted the dashboard's recently viewed documents section to sometimes be displayed out of order.