### PR TITLE
Fixes visual bug on search popover

### DIFF
--- a/web/app/components/header/search.hbs
+++ b/web/app/components/header/search.hbs
@@ -31,7 +31,7 @@
               <LinkTo
                 @route="authenticated.results"
                 @query={{hash q=this.query page=1}}
-                class="hds-dropdown-list-item--interactive"
+                class="hds-dropdown-list-item--variant-interactive"
               >
                 <FlightIcon @name="search" class="mr-1.5" />
                 <span>View all results for "{{this.query}}"</span>
@@ -44,7 +44,7 @@
                 <LinkTo
                   @route="authenticated.all"
                   @query={{hash product=(array product)}}
-                  class="hds-dropdown-list-item--interactive"
+                  class="hds-dropdown-list-item--variant-interactive"
                 >
                   <FlightIcon @name="folder" class="mr-1.5" />
                   <span class="flex items-center">View all


### PR DESCRIPTION
Updates a couple search links to their [newly updated](https://github.com/hashicorp/design-system/releases) classnames. A patch of #123 

Current:
<img width="98" alt="CleanShot 2023-04-12 at 13 50 30@2x" src="https://user-images.githubusercontent.com/754957/231541960-4bab6c6e-f347-4c88-a68f-28d9c33e6a61.png">

Revised:
<img width="115" alt="CleanShot 2023-04-12 at 13 50 02@2x" src="https://user-images.githubusercontent.com/754957/231541868-12eea008-a11a-4081-8d4f-4f27802373f4.png">
