### PR TITLE
Auth: Ignore saving certain transitions

### DIFF
--- a/web/app/routes/application.js
+++ b/web/app/routes/application.js
@@ -34,16 +34,23 @@ export default class ApplicationRoute extends Route {
     let transitionTo = transition.intent.url ?? transition.to.name;
 
     /**
-     * Capture the transition intent and save it to session/localStorage.
+     * If a transition intent exists and it isn't to the `/` or `authenticate` routes,
+     * capture and save it to session/localStorage for a later redirect.
      */
-    window.sessionStorage.setItem(REDIRECT_STORAGE_KEY, transitionTo);
-    window.localStorage.setItem(
-      REDIRECT_STORAGE_KEY,
-      JSON.stringify({
-        url: transitionTo,
-        expiresOn: Date.now() + 60 * 5000, // 5 minutes
-      })
-    );
+    if (
+      transitionTo &&
+      transitionTo !== "/" &&
+      transitionTo !== "authenticate"
+    ) {
+      window.sessionStorage.setItem(REDIRECT_STORAGE_KEY, transitionTo);
+      window.localStorage.setItem(
+        REDIRECT_STORAGE_KEY,
+        JSON.stringify({
+          url: transitionTo,
+          expiresOn: Date.now() + 60 * 5000, // 5 minutes
+        })
+      );
+    }
 
     await this.session.setup();
 

--- a/web/app/services/session.ts
+++ b/web/app/services/session.ts
@@ -112,7 +112,7 @@ export default class SessionService extends EmberSimpleAuthSessionService {
       }
     }
 
-    if (redirectTarget && redirectTarget !== "/authenticate") {
+    if (redirectTarget) {
       transition = this.router.transitionTo(redirectTarget);
     } else {
       transition = this.router.transitionTo(


### PR DESCRIPTION
Ignores post-auth redirectTargets to the root and Authenticate routes. Fixes a bug causing valid redirects to be overwritten.

When you try to access an authenticated route, Ember Simple Auth restores your previous token, which, if expired, will cause the session to invalidate. By default, this [reloads the Ember app](https://ember-simple-auth.com/api/classes/SessionService.html#method_handleInvalidation) in an effort to clear data. On refresh, the application beforeModel receives a new transition, this time to the application root. Currently we let this transition target through, overwriting the valid target. Now we ignore it :----)