### PR TITLE
Add HTMLElement Helper

### DIFF
--- a/web/app/helpers/html-element.ts
+++ b/web/app/helpers/html-element.ts
@@ -1,0 +1,6 @@
+import { helper } from "@ember/component/helper";
+import htmlElement from "hermes/utils/html-element";
+
+export default helper(([selector]: [string]) => {
+  return htmlElement(selector);
+});

--- a/web/tests/integration/helpers/html-element-test.ts
+++ b/web/tests/integration/helpers/html-element-test.ts
@@ -1,0 +1,21 @@
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+import { render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+
+module("Integration | Helper | html-element", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("", async function (assert) {
+    await render(hbs`
+      {{#in-element (html-element ".container")}}
+        <div class="content">
+          Like magic
+        </div>
+      {{/in-element}}
+      <div class="container"></div>
+    `);
+
+    assert.dom(".container .content").hasText("Like magic");
+  });
+});

--- a/web/tests/integration/helpers/html-element-test.ts
+++ b/web/tests/integration/helpers/html-element-test.ts
@@ -8,12 +8,13 @@ module("Integration | Helper | html-element", function (hooks) {
 
   test("", async function (assert) {
     await render(hbs`
+      <div class="container"></div>
+
       {{#in-element (html-element ".container")}}
         <div class="content">
           Like magic
         </div>
       {{/in-element}}
-      <div class="container"></div>
     `);
 
     assert.dom(".container .content").hasText("Like magic");


### PR DESCRIPTION
Adds a template helper for the `htmlElement` utility. Will be used mostly with `in-element` to quickly target known elements like `.ember-application`.