### PR TITLE
Fix DocThumbnail z-index bug

### DIFF
--- a/web/app/components/doc/thumbnail.hbs
+++ b/web/app/components/doc/thumbnail.hbs
@@ -14,7 +14,7 @@
     {{/if}}
 
     {{#if (or this.isApproved this.isObsolete)}}
-      <div class="absolute w-full z-20">
+      <div class="absolute w-full">
         <FlightIcon
           data-test-doc-status-icon
           @name={{if this.isApproved "check-circle" "archive"}}


### PR DESCRIPTION
Fixes a bug causing docThumbnail icons to appear above flashMessages.

Current: 
![CleanShot 2023-04-13 at 13 42 26](https://user-images.githubusercontent.com/754957/231841574-11297f64-0cb9-480d-a74b-88118afe998f.png)

Fixed:
![CleanShot 2023-04-13 at 13 42 09](https://user-images.githubusercontent.com/754957/231841634-7884fc00-30bc-42c4-ae88-2c47297855f5.png)
