### PR TITLE
Tweak `me` handling in Mirage

### DIFF
--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -147,7 +147,9 @@ export default function (mirageConfig) {
           return schema.mes.first().attrs;
         } else {
           // Otherwise, create and return a new user.
-          return schema.mes.create().attrs;
+          return schema.mes.create({
+            isLoggedIn: true,
+          }).attrs;
         }
       });
 

--- a/web/tests/acceptance/application-test.ts
+++ b/web/tests/acceptance/application-test.ts
@@ -65,7 +65,7 @@ module("Acceptance | application", function (hooks) {
       .dom("[data-test-flash-notification]")
       .doesNotExist("no flash notification when session is valid");
 
-    this.server.db.mes[0] = this.server.create("me", { isLoggedIn: false });
+    this.server.schema.mes.first().update("isLoggedIn", false);
 
     await waitFor("[data-test-flash-notification]");
 

--- a/web/tests/acceptance/authenticated/all-test.ts
+++ b/web/tests/acceptance/authenticated/all-test.ts
@@ -11,8 +11,8 @@ module("Acceptance | authenticated/all", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function () {
-    authenticateSession({});
+  hooks.beforeEach(async function () {
+    await authenticateSession({});
   });
 
   test("the page title is correct", async function (this: AuthenticatedAllRouteTestContext, assert) {

--- a/web/tests/acceptance/authenticated/dashboard-test.ts
+++ b/web/tests/acceptance/authenticated/dashboard-test.ts
@@ -11,8 +11,8 @@ module("Acceptance | authenticated/dashboard", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function () {
-    authenticateSession({});
+  hooks.beforeEach(async function () {
+    await authenticateSession({});
   });
 
   test("the page title is correct", async function (this: AuthenticatedDashboardRouteTestContext, assert) {

--- a/web/tests/acceptance/authenticated/document-test.ts
+++ b/web/tests/acceptance/authenticated/document-test.ts
@@ -11,8 +11,8 @@ module("Acceptance | authenticated/document", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function () {
-    authenticateSession({});
+  hooks.beforeEach(async function () {
+    await authenticateSession({});
   });
 
   test("the page title is correct (published doc)", async function (this: AuthenticatedDocumentRouteTestContext, assert) {

--- a/web/tests/acceptance/authenticated/drafts-test.ts
+++ b/web/tests/acceptance/authenticated/drafts-test.ts
@@ -11,8 +11,8 @@ module("Acceptance | authenticated/drafts", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function () {
-    authenticateSession({});
+  hooks.beforeEach(async function () {
+    await authenticateSession({});
   });
 
   test("the page title is correct", async function (this: AuthenticatedDraftRouteTestContext, assert) {

--- a/web/tests/acceptance/authenticated/my-test.ts
+++ b/web/tests/acceptance/authenticated/my-test.ts
@@ -11,8 +11,8 @@ module("Acceptance | authenticated/my", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function () {
-    authenticateSession({});
+  hooks.beforeEach(async function () {
+    await authenticateSession({});
   });
 
   test("the page title is correct", async function (this: AuthenticatedMyRouteTestContext, assert) {

--- a/web/tests/acceptance/authenticated/new/doc-test.ts
+++ b/web/tests/acceptance/authenticated/new/doc-test.ts
@@ -11,8 +11,8 @@ module("Acceptance | authenticated/new", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function () {
-    authenticateSession({});
+  hooks.beforeEach(async function () {
+    await authenticateSession({});
   });
 
   test("the page title is correct (RFC)", async function (this: AuthenticatedNewDocRouteTestContext, assert) {

--- a/web/tests/acceptance/authenticated/new/index-test.ts
+++ b/web/tests/acceptance/authenticated/new/index-test.ts
@@ -11,8 +11,8 @@ module("Acceptance | authenticated/new", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function () {
-    authenticateSession({});
+  hooks.beforeEach(async function () {
+    await authenticateSession({});
   });
 
   test("the page title is correct", async function (this: AuthenticatedNewRouteTestContext, assert) {

--- a/web/tests/acceptance/authenticated/results-test.ts
+++ b/web/tests/acceptance/authenticated/results-test.ts
@@ -11,8 +11,8 @@ module("Acceptance | authenticated/results", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function () {
-    authenticateSession({});
+  hooks.beforeEach(async function () {
+    await authenticateSession({});
   });
 
   test("the page title is correct", async function (this: AuthenticatedResultsRouteTestContext, assert) {

--- a/web/tests/acceptance/authenticated/settings-test.ts
+++ b/web/tests/acceptance/authenticated/settings-test.ts
@@ -11,8 +11,8 @@ module("Acceptance | authenticated/settings", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function () {
-    authenticateSession({});
+  hooks.beforeEach(async function () {
+    await authenticateSession({});
   });
 
   test("the page title is correct", async function (this: AuthenticatedSettingsRouteTestContext, assert) {


### PR DESCRIPTION
Sets `isLoggedIn: true` on our default `me` object in Mirage. Should fix the failed HEAD calls that were breaking some of our acceptance tests.