### PR TITLE
Reconfigure Ember Metrics / Google Analytics

### DIFF
--- a/web/app/metrics-adapters/google-analytics-four.ts
+++ b/web/app/metrics-adapters/google-analytics-four.ts
@@ -1,7 +1,6 @@
 import { inject as service } from "@ember/service";
 import ConfigService from "hermes/services/config";
 import GoogleAnalyticsFour from "ember-metrics/metrics-adapters/google-analytics-four";
-import { compact } from "ember-metrics/-private/utils/object-transforms";
 
 declare global {
   interface Window {
@@ -36,6 +35,6 @@ export default class GoogleAnalyticsFourAdapter extends GoogleAnalyticsFour {
     window.dataLayer = window.dataLayer || [];
 
     this.gtag("js", new Date());
-    this.gtag("config", GoogleAnalyticsTagID, compact(this.options));
+    this.gtag("config", GoogleAnalyticsTagID, this.options);
   }
 }

--- a/web/app/metrics-adapters/google-analytics-four.ts
+++ b/web/app/metrics-adapters/google-analytics-four.ts
@@ -17,7 +17,7 @@ export default class GoogleAnalyticsFourAdapter extends GoogleAnalyticsFour {
 
   /**
    * Modified from its parent class:
-   * https://github.com/adopted-ember-addons/ember-metrics/blob/master/addon/metrics-adapters/google-analytics-four.js#L24-L28
+   * https://github.com/adopted-ember-addons/ember-metrics/blob/master/addon/metrics-adapters/google-analytics-four.js#L11-L28
    */
   install(): void {
     const GoogleAnalyticsTagID = this.configSvc.config.google_analytics_tag_id;

--- a/web/app/metrics-adapters/google-analytics-four.ts
+++ b/web/app/metrics-adapters/google-analytics-four.ts
@@ -13,7 +13,7 @@ export default class GoogleAnalyticsFourAdapter extends GoogleAnalyticsFour {
 
   /**
    * Modified from its parent class:
-   * https://github.com/adopted-ember-addons/ember-metrics/blob/master/addon/metrics-adapters/google-analytics-four.js#L11-L28
+   * https://github.com/adopted-ember-addons/ember-metrics/blob/01bb65e68f565fc48c2fa252d17a1b7d3d099e68/addon/metrics-adapters/google-analytics-four.js#L11-L28
    */
   install(): void {
     const GoogleAnalyticsTagID =

--- a/web/app/metrics-adapters/google-analytics-four.ts
+++ b/web/app/metrics-adapters/google-analytics-four.ts
@@ -20,15 +20,16 @@ export default class GoogleAnalyticsFourAdapter extends GoogleAnalyticsFour {
     const GoogleAnalyticsTagID = this.configSvc.config.google_analytics_tag_id;
 
     if (!GoogleAnalyticsTagID) {
-      console.log("Google Analytics Tag ID not set");
       return;
     }
 
-      console.log("Google Analytics Tagged!!");
     this.options = {
       id: GoogleAnalyticsTagID,
       anonymize_ip: true,
     };
+
+    // The rest is copied from the parent class:
+    // https://github.com/adopted-ember-addons/ember-metrics/blob/master/addon/metrics-adapters/google-analytics-four.js#L24-L28
 
     this._injectScript(GoogleAnalyticsTagID);
 

--- a/web/app/metrics-adapters/google-analytics-four.ts
+++ b/web/app/metrics-adapters/google-analytics-four.ts
@@ -1,0 +1,40 @@
+import { inject as service } from "@ember/service";
+import ConfigService from "hermes/services/config";
+import GoogleAnalyticsFour from "ember-metrics/metrics-adapters/google-analytics-four";
+import { compact } from "ember-metrics/-private/utils/object-transforms";
+
+declare global {
+  interface Window {
+    dataLayer: any[];
+  }
+}
+
+export default class GoogleAnalyticsFourAdapter extends GoogleAnalyticsFour {
+  @service("config") declare configSvc: ConfigService;
+
+  constructor(config: any) {
+    super(config);
+  }
+
+  install(): void {
+    const GoogleAnalyticsTagID = this.configSvc.config.google_analytics_tag_id;
+
+    if (!GoogleAnalyticsTagID) {
+      console.log("Google Analytics Tag ID not set");
+      return;
+    }
+
+      console.log("Google Analytics Tagged!!");
+    this.options = {
+      id: GoogleAnalyticsTagID,
+      anonymize_ip: true,
+    };
+
+    this._injectScript(GoogleAnalyticsTagID);
+
+    window.dataLayer = window.dataLayer || [];
+
+    this.gtag("js", new Date());
+    this.gtag("config", GoogleAnalyticsTagID, compact(this.options));
+  }
+}

--- a/web/app/metrics-adapters/google-analytics-four.ts
+++ b/web/app/metrics-adapters/google-analytics-four.ts
@@ -15,6 +15,10 @@ export default class GoogleAnalyticsFourAdapter extends GoogleAnalyticsFour {
     super(config);
   }
 
+  /**
+   * Modified from its parent class:
+   * https://github.com/adopted-ember-addons/ember-metrics/blob/master/addon/metrics-adapters/google-analytics-four.js#L24-L28
+   */
   install(): void {
     const GoogleAnalyticsTagID = this.configSvc.config.google_analytics_tag_id;
 
@@ -26,9 +30,6 @@ export default class GoogleAnalyticsFourAdapter extends GoogleAnalyticsFour {
       id: GoogleAnalyticsTagID,
       anonymize_ip: true,
     };
-
-    // The rest is copied from the parent class:
-    // https://github.com/adopted-ember-addons/ember-metrics/blob/master/addon/metrics-adapters/google-analytics-four.js#L24-L28
 
     this._injectScript(GoogleAnalyticsTagID);
 

--- a/web/app/metrics-adapters/google-analytics-four.ts
+++ b/web/app/metrics-adapters/google-analytics-four.ts
@@ -1,6 +1,6 @@
 import { inject as service } from "@ember/service";
-import ConfigService from "hermes/services/config";
 import GoogleAnalyticsFour from "ember-metrics/metrics-adapters/google-analytics-four";
+import ConfigService from "hermes/services/config";
 
 declare global {
   interface Window {
@@ -11,16 +11,13 @@ declare global {
 export default class GoogleAnalyticsFourAdapter extends GoogleAnalyticsFour {
   @service("config") declare configSvc: ConfigService;
 
-  constructor(config: any) {
-    super(config);
-  }
-
   /**
    * Modified from its parent class:
    * https://github.com/adopted-ember-addons/ember-metrics/blob/master/addon/metrics-adapters/google-analytics-four.js#L11-L28
    */
   install(): void {
-    const GoogleAnalyticsTagID = this.configSvc.config.google_analytics_tag_id;
+    const GoogleAnalyticsTagID =
+      this.config.id || this.configSvc.config.google_analytics_tag_id;
 
     if (!GoogleAnalyticsTagID) {
       return;
@@ -28,6 +25,7 @@ export default class GoogleAnalyticsFourAdapter extends GoogleAnalyticsFour {
 
     this.options = {
       id: GoogleAnalyticsTagID,
+      send_page_view: true,
       anonymize_ip: true,
     };
 

--- a/web/app/routes/application.ts
+++ b/web/app/routes/application.ts
@@ -12,6 +12,7 @@ import window from "ember-window-mock";
 import { REDIRECT_STORAGE_KEY } from "hermes/services/session";
 import Transition from "@ember/routing/transition";
 import MetricsService from "hermes/services/metrics";
+import GoogleAnalyticsFourAdapter from "hermes/metrics-adapters/google-analytics-four";
 
 export default class ApplicationRoute extends Route {
   @service declare config: ConfigService;
@@ -20,16 +21,6 @@ export default class ApplicationRoute extends Route {
   @service declare session: SessionService;
   @service declare router: RouterService;
   @service declare metrics: MetricsService;
-
-  constructor() {
-    super(...arguments);
-
-    this.router.on("routeDidChange", () => {
-      if (this.config.config.google_analytics_tag_id) {
-        this.metrics.trackPage();
-      }
-    });
-  }
 
   /**
    * Catch-all for bubbled-up model errors.
@@ -77,13 +68,11 @@ export default class ApplicationRoute extends Route {
 
     await this.session.setup();
 
-    // Flags read from the environment and set properties on the service this
-    // could be done in an initializer, but this seems more natural these days
     this.flags.initialize();
 
-    // Get web config from backend if this is a production build.
+    // Set config from the backend in production
     if (config.environment === "production") {
-      return this.fetchSvc
+      await this.fetchSvc
         .fetch("/api/v1/web/config")
         .then((response) => response?.json())
         .then((json) => {
@@ -93,5 +82,8 @@ export default class ApplicationRoute extends Route {
           console.log("Error fetching and setting web config: " + err);
         });
     }
+
+    // Initialize the metrics service
+    this.metrics;
   }
 }

--- a/web/app/routes/application.ts
+++ b/web/app/routes/application.ts
@@ -11,7 +11,7 @@ import RouterService from "@ember/routing/router-service";
 import window from "ember-window-mock";
 import { REDIRECT_STORAGE_KEY } from "hermes/services/session";
 import Transition from "@ember/routing/transition";
-import EmberMetricsService from "ember-metrics/index";
+import MetricsService from "hermes/services/metrics";
 
 export default class ApplicationRoute extends Route {
   @service declare config: ConfigService;
@@ -19,13 +19,15 @@ export default class ApplicationRoute extends Route {
   @service declare flags: any;
   @service declare session: SessionService;
   @service declare router: RouterService;
-  @service declare metrics: EmberMetricsService;
+  @service declare metrics: MetricsService;
 
   constructor() {
     super(...arguments);
 
     this.router.on("routeDidChange", () => {
-      this.metrics.trackPage();
+      if (this.config.config.google_analytics_tag_id) {
+        this.metrics.trackPage();
+      }
     });
   }
 
@@ -79,8 +81,8 @@ export default class ApplicationRoute extends Route {
     // could be done in an initializer, but this seems more natural these days
     this.flags.initialize();
 
-    // Get web config from backend if this is a production build.
-    if (config.environment === "production") {
+    if (config.environment !== "production") {
+      console.log("dog");
       return this.fetchSvc
         .fetch("/api/v1/web/config")
         .then((response) => response?.json())

--- a/web/app/routes/application.ts
+++ b/web/app/routes/application.ts
@@ -81,8 +81,8 @@ export default class ApplicationRoute extends Route {
     // could be done in an initializer, but this seems more natural these days
     this.flags.initialize();
 
-    if (config.environment !== "production") {
-      console.log("dog");
+    // Get web config from backend if this is a production build.
+    if (config.environment === "production") {
       return this.fetchSvc
         .fetch("/api/v1/web/config")
         .then((response) => response?.json())

--- a/web/app/services/config.ts
+++ b/web/app/services/config.ts
@@ -12,6 +12,7 @@ export default class ConfigService extends Service {
     feature_flags: config.featureFlags,
     google_doc_folders: config.google.docFolders ?? "",
     short_link_base_url: config.shortLinkBaseURL,
+    google_analytics_tag_id: config.googleAnalyticsTagId
     // google_oauth2_client_id:
     //   config.torii.providers["google-oauth2-bearer"].apiKey ?? "",
     // google_oauth2_hd: config.torii.providers["google-oauth2-bearer"].hd ?? "",

--- a/web/app/services/metrics.ts
+++ b/web/app/services/metrics.ts
@@ -1,0 +1,25 @@
+import { getOwner, setOwner } from "@ember/application";
+import { assert } from "@ember/debug";
+import EmberMetricsService from "ember-metrics/services/metrics";
+import GoogleAnalyticsFourAdapter from "hermes/metrics-adapters/google-analytics-four";
+
+export default class MetricsService extends EmberMetricsService {
+  /**
+   * We extend EmberMetricsService to resolve a bug in its `_activateAdapter` method.
+   * https://github.com/adopted-ember-addons/ember-metrics/issues/541
+   */
+  _activateAdapter({
+    adapterClass,
+    config,
+  }: {
+    adapterClass: typeof GoogleAnalyticsFourAdapter;
+    config: {};
+  }) {
+    const adapter = new adapterClass(config);
+    let owner = getOwner(this);
+    assert("ember metrics expects an owner", owner);
+    setOwner(adapter, owner);
+    adapter.install();
+    return adapter;
+  }
+}

--- a/web/app/services/metrics.ts
+++ b/web/app/services/metrics.ts
@@ -1,9 +1,13 @@
 import { getOwner, setOwner } from "@ember/application";
 import { assert } from "@ember/debug";
+import { inject as service } from "@ember/service";
 import EmberMetricsService from "ember-metrics/services/metrics";
 import GoogleAnalyticsFourAdapter from "hermes/metrics-adapters/google-analytics-four";
+import ConfigService from "./config";
 
 export default class MetricsService extends EmberMetricsService {
+  @service("config") declare configSvc: ConfigService;
+
   /**
    * We extend EmberMetricsService to resolve a bug in its `_activateAdapter` method.
    * https://github.com/adopted-ember-addons/ember-metrics/issues/541

--- a/web/config/environment.js
+++ b/web/config/environment.js
@@ -11,8 +11,6 @@ const getEnv = (key, defaultValue) => {
   return value != null ? value : defaultValue;
 };
 
-const hasGoogleAnalyticsID = !!getEnv("GOOGLE_ANALYTICS_TAG_ID", null);
-
 module.exports = function (environment) {
   let ENV = {
     modulePrefix: "hermes",
@@ -34,20 +32,15 @@ module.exports = function (environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
     },
-    metricsAdapters: hasGoogleAnalyticsID
-      ? [
-          {
-            name: "GoogleAnalyticsFour",
-            environments: ["development", "production"],
-            config: {
-              id: getEnv("GOOGLE_ANALYTICS_TAG_ID"),
-              options: {
-                anonymize_ip: true,
-              },
-            },
-          },
-        ]
-      : [],
+    metricsAdapters: [
+      {
+        name: "GoogleAnalyticsFour",
+        environments: ["development", "production"],
+        config: {
+          // Configured in the GoogleAnalyticsFourAdapter
+        },
+      },
+    ],
 
     algolia: {
       appID: getEnv("ALGOLIA_APP_ID"),

--- a/web/config/environment.js
+++ b/web/config/environment.js
@@ -37,11 +37,10 @@ module.exports = function (environment) {
         name: "GoogleAnalyticsFour",
         environments: ["development", "production"],
         config: {
-          // Configured in the GoogleAnalyticsFourAdapter
+          id: getEnv("GOOGLE_ANALYTICS_TAG_ID", null),
         },
       },
     ],
-
     algolia: {
       appID: getEnv("ALGOLIA_APP_ID"),
       docsIndexName: getEnv("ALGOLIA_DOCS_INDEX_NAME", "docs"),

--- a/web/types/ember-metrics/metrics-adapters/google-analytics-four.d.ts
+++ b/web/types/ember-metrics/metrics-adapters/google-analytics-four.d.ts
@@ -1,0 +1,16 @@
+interface BaseMetricsAdapter {
+  constructor(config: any);
+  install(): void;
+}
+
+declare module "ember-metrics/metrics-adapters/google-analytics-four" {
+  export default class GoogleAnalyticsFourAdapter extends BaseMetricsAdapter {
+    options: any;
+
+    _injectScript(GoogleAnalyticsTagID: string): void;
+
+    gtag(...args: any[]): void;
+    install(): void;
+    constructor(config: any);
+  }
+}

--- a/web/types/ember-metrics/metrics-adapters/google-analytics-four.d.ts
+++ b/web/types/ember-metrics/metrics-adapters/google-analytics-four.d.ts
@@ -4,13 +4,14 @@ interface BaseMetricsAdapter {
 }
 
 declare module "ember-metrics/metrics-adapters/google-analytics-four" {
-  export default class GoogleAnalyticsFourAdapter extends BaseMetricsAdapter {
-    options: any;
-
-    _injectScript(GoogleAnalyticsTagID: string): void;
-
-    gtag(...args: any[]): void;
-    install(): void;
+  export default class GoogleAnalyticsFour extends BaseMetricsAdapter {
     constructor(config: any);
+    install(): void;
+    gtag(...args: any[]): void;
+    options: any;
+    config: {
+      id: string;
+    };
+    _injectScript(GoogleAnalyticsTagID: string): void;
   }
 }

--- a/web/types/ember-metrics/services/metrics.d.ts
+++ b/web/types/ember-metrics/services/metrics.d.ts
@@ -2,9 +2,10 @@
 
 import Service from "@ember/service";
 
-declare module "ember-metrics/index" {
+declare module "ember-metrics/services/metrics" {
   // Note: Incomplete types; only the methods we use are defined.
   export default class EmberMetricsService extends Service {
+    _activateAdapter({}): unknown;
     trackPage(): void;
   }
 }

--- a/web/types/ember-metrics/services/metrics.d.ts
+++ b/web/types/ember-metrics/services/metrics.d.ts
@@ -5,7 +5,10 @@ import Service from "@ember/service";
 declare module "ember-metrics/services/metrics" {
   // Note: Incomplete types; only the methods we use are defined.
   export default class EmberMetricsService extends Service {
+    _adapters: any;
+    _options: any;
     _activateAdapter({}): unknown;
+    _lookupAdapter(adapterName: string): any;
     trackPage(): void;
   }
 }


### PR DESCRIPTION
Updates `ember-metrics` to allow configuration via the ConfigService as an alternative to environment variables.