### PR TITLE
Continue getting other recently viewed docs on a database error

### DIFF
--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/hashicorp/go-hclog"
 )
 
 // contains returns true if a string is present in a slice of strings.
@@ -89,4 +91,21 @@ func parseResourceIDFromURL(url, apiPath string) (string, error) {
 
 	// Return resource ID.
 	return resultPath[0], nil
+}
+
+// respondError responds to an HTTP request and logs an error.
+func respondError(
+	w http.ResponseWriter, r *http.Request, l hclog.Logger,
+	httpCode int, userErrMsg, logErrMsg string, err error,
+	extraArgs ...interface{},
+) {
+	l.Error(logErrMsg,
+		append([]interface{}{
+			"error", err,
+			"method", r.Method,
+			"path", r.URL.Path,
+		}, extraArgs...)...,
+	)
+	errJSON := fmt.Sprintf(`{"error": "%s"}`, userErrMsg)
+	http.Error(w, errJSON, httpCode)
 }

--- a/internal/api/me_recently_viewed_docs.go
+++ b/internal/api/me_recently_viewed_docs.go
@@ -81,13 +81,15 @@ func MeRecentlyViewedDocsHandler(
 					},
 				}
 				if err := doc.Get(db); err != nil {
-					errResp(
-						http.StatusInternalServerError,
-						"Error getting document",
-						"error getting document in database",
-						err,
+					// Log error but continue trying to get other recently viewed
+					// documents (for a better UX).
+					l.Error("error getting document in database",
+						"error", err,
+						"method", r.Method,
+						"path", r.URL.Path,
+						"document_db_id", d.DocumentID,
 					)
-					return
+					continue
 				}
 
 				isDraft := false

--- a/internal/api/me_recently_viewed_docs.go
+++ b/internal/api/me_recently_viewed_docs.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/hashicorp-forge/hermes/internal/config"
@@ -23,14 +22,10 @@ func MeRecentlyViewedDocsHandler(
 ) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		errResp := func(httpCode int, userErrMsg, logErrMsg string, err error) {
-			l.Error(logErrMsg,
-				"method", r.Method,
-				"path", r.URL.Path,
-				"error", err,
-			)
-			errJSON := fmt.Sprintf(`{"error": "%s"}`, userErrMsg)
-			http.Error(w, errJSON, httpCode)
+		errResp := func(
+			httpCode int, userErrMsg, logErrMsg string, err error,
+			extraArgs ...interface{}) {
+			respondError(w, r, l, httpCode, userErrMsg, logErrMsg, err, extraArgs...)
 		}
 
 		// Authorize request.


### PR DESCRIPTION
#132 introduced getting recently viewed docs from the database, however if there is an error (currently possible with some docs in a bad state) when getting a doc, the API will return a 500. This PR instead just logs the error and continues attempting to get the other recently viewed docs, resulting in a better user experience of (hopefully) at least some other recently viewed docs being displayed on the dashboard instead of an error.

Additionally, it adds a helper function to enable us to get more consistent with our API error logging and responses.