### PR TITLE
Configure a Mirage response for products

### DIFF
--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -201,10 +201,38 @@ export default function (mirageConfig) {
 
       /**
        * Used by /subscriptions to get all possible subscriptions.
-       * Also used by the NewDoc route to map the products to their abbreviations.
+       * Used by the NewDoc route to map the products to their abbreviations.
+       * Used by the sidebar to populate a draft's product/area dropdown.
        */
       this.get("/products", () => {
-        return;
+        let objects = this.schema.products.all().models.map((product) => {
+          return {
+            [product.attrs.name]: {
+              abbreviation: product.attrs.abbreviation,
+            },
+          };
+        });
+
+        // The objects currently look like:
+        // [
+        //  0: { "Labs": { abbreviation: "LAB" } },
+        //  1: { "Vault": { abbreviation: "VLT"} }
+        // ]
+
+        // We reformat them to match the API's response:
+        // {
+        //  "Labs": { abbreviation: "LAB" },
+        //  "Vault": { abbreviation: "VLT" }
+        // }
+
+        let formattedObjects = {};
+
+        objects.forEach((object) => {
+          let key = Object.keys(object)[0];
+          formattedObjects[key] = object[key];
+        });
+
+        return new Response(200, {}, formattedObjects);
       });
 
       // RecentlyViewedDocsService / fetchIndexID

--- a/web/mirage/factories/product.ts
+++ b/web/mirage/factories/product.ts
@@ -1,0 +1,6 @@
+import { Factory } from "miragejs";
+
+export default Factory.extend({
+  name: (i: number) => `Test Product ${i}`,
+  abbreviation: (i: number) => `TST-${i}`,
+});

--- a/web/mirage/models/product.ts
+++ b/web/mirage/models/product.ts
@@ -1,0 +1,5 @@
+import { Model } from "miragejs";
+
+export default Model.extend({
+  // Required for Mirage, even though it's empty
+});

--- a/web/tests/acceptance/authenticated/new/doc-test.ts
+++ b/web/tests/acceptance/authenticated/new/doc-test.ts
@@ -7,12 +7,13 @@ import { getPageTitle } from "ember-page-title/test-support";
 
 interface AuthenticatedNewDocRouteTestContext extends MirageTestContext {}
 
-module("Acceptance | authenticated/new", function (hooks) {
+module("Acceptance | authenticated/new/doc", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(async function () {
+  hooks.beforeEach(async function (this: AuthenticatedNewDocRouteTestContext) {
     await authenticateSession({});
+    this.server.createList("product", 5);
   });
 
   test("the page title is correct (RFC)", async function (this: AuthenticatedNewDocRouteTestContext, assert) {


### PR DESCRIPTION
Adds a Mirage response for the /products endpoint. May fix the errors we've been seeing in the new-doc-page-title tests.