### PR TITLE
Return a full user for `/me` response

### DIFF
--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -148,6 +148,12 @@ export default function (mirageConfig) {
         } else {
           // Otherwise, create and return a new user.
           return schema.mes.create({
+            id: "1",
+            name: "Test User",
+            email: "testuser@example.com",
+            given_name: "Test",
+            picture: "",
+            subscriptions: [],
             isLoggedIn: true,
           }).attrs;
         }


### PR DESCRIPTION
Populates a full user by default for the `/me` response in Mirage.