### PR TITLE
Log warning on error when updating recently viewed docs

### DIFF
--- a/internal/api/documents.go
+++ b/internal/api/documents.go
@@ -162,7 +162,9 @@ func DocumentHandler(
 				if err := updateRecentlyViewedDocs(email, docID, db, now); err != nil {
 					// If we get an error, log it but don't return an error response
 					// because this would degrade UX.
-					l.Error("error updating recently viewed docs",
+					// TODO: change this log back to an error when this handles incomplete
+					// data in the database.
+					l.Warn("error updating recently viewed docs",
 						"error", err,
 						"doc_id", docID,
 						"method", r.Method,

--- a/internal/api/drafts.go
+++ b/internal/api/drafts.go
@@ -554,7 +554,9 @@ func DraftsDocumentHandler(
 			if err := updateRecentlyViewedDocs(userEmail, docId, db, now); err != nil {
 				// If we get an error, log it but don't return an error response because
 				// this would degrade UX.
-				l.Error("error updating recently viewed docs",
+				// TODO: change this log back to an error when this handles incomplete
+				// data in the database.
+				l.Warn("error updating recently viewed docs",
 					"error", err,
 					"path", r.URL.Path,
 					"method", r.Method,


### PR DESCRIPTION
This PR temporarily changes these log lines to warnings while we work on addressing the errors when trying to update recently viewed docs for documents with incomplete data in the database.