### PR TITLE
Change some more error logs to warnings

### DIFF
--- a/internal/api/drafts.go
+++ b/internal/api/drafts.go
@@ -10,16 +10,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/errs"
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
-	"github.com/hashicorp/go-hclog"
-	"gorm.io/gorm"
-
 	"github.com/hashicorp-forge/hermes/internal/config"
 	"github.com/hashicorp-forge/hermes/pkg/algolia"
 	gw "github.com/hashicorp-forge/hermes/pkg/googleworkspace"
 	hcd "github.com/hashicorp-forge/hermes/pkg/hashicorpdocs"
 	"github.com/hashicorp-forge/hermes/pkg/models"
+	"github.com/hashicorp/go-hclog"
+	"gorm.io/gorm"
 )
 
 type DraftsRequest struct {
@@ -455,13 +455,27 @@ func DraftsDocumentHandler(
 		baseDocObj := &hcd.BaseDoc{}
 		err = ar.Drafts.GetObject(docId, &baseDocObj)
 		if err != nil {
-			l.Error("error requesting base document object from Algolia",
-				"error", err,
-				"doc_id", docId,
-			)
-			http.Error(w, "Error accessing draft document",
-				http.StatusInternalServerError)
-			return
+			// Handle 404 from Algolia and only log a warning.
+			if _, is404 := errs.IsAlgoliaErrWithCode(err, 404); is404 {
+				l.Warn("base document object not found",
+					"error", err,
+					"path", r.URL.Path,
+					"method", r.Method,
+					"doc_id", docId,
+				)
+				http.Error(w, "Draft document not found", http.StatusNotFound)
+				return
+			} else {
+				l.Error("error requesting base document object from Algolia",
+					"error", err,
+					"path", r.URL.Path,
+					"method", r.Method,
+					"doc_id", docId,
+				)
+				http.Error(w, "Error accessing draft document",
+					http.StatusInternalServerError)
+				return
+			}
 		}
 
 		// Create new document object of the proper doc type.

--- a/internal/api/me_recently_viewed_docs.go
+++ b/internal/api/me_recently_viewed_docs.go
@@ -81,9 +81,11 @@ func MeRecentlyViewedDocsHandler(
 					},
 				}
 				if err := doc.Get(db); err != nil {
-					// Log error but continue trying to get other recently viewed
-					// documents (for a better UX).
-					l.Error("error getting document in database",
+					// If we get an error, log it but don't return an error response
+					// because this would degrade UX.
+					// TODO: change this log back to an error when this handles incomplete
+					// data in the database.
+					l.Warn("error getting document in database",
 						"error", err,
 						"method", r.Method,
 						"path", r.URL.Path,


### PR DESCRIPTION
Follow up to #159. This logs 404's when documents/drafts don't exist in Algolia as warnings instead of errors, and temporarily changes an error getting a recently viewed doc from the database to a warning as we work on being able to handle incomplete data.