### PR TITLE
Add id reference values to DropdownList components; DropdownList cleanup

### DIFF
--- a/web/app/components/floating-u-i/content.hbs
+++ b/web/app/components/floating-u-i/content.hbs
@@ -8,6 +8,7 @@
     {{will-destroy this.cleanup}}
     {{did-insert this.didInsert}}
     data-test-floating-ui-placement={{@placement}}
+    data-anchored-to={{@id}}
     id="floating-ui-content-{{@id}}"
     class="hermes-floating-ui-content"
     ...attributes

--- a/web/app/components/floating-u-i/content.ts
+++ b/web/app/components/floating-u-i/content.ts
@@ -15,6 +15,7 @@ import { tracked } from "@glimmer/tracking";
 interface FloatingUIContentSignature {
   Args: {
     anchor: HTMLElement;
+    id: string;
     placement?: Placement;
     renderOut?: boolean;
   };

--- a/web/app/components/floating-u-i/index.ts
+++ b/web/app/components/floating-u-i/index.ts
@@ -26,6 +26,9 @@ export default class FloatingUIComponent extends Component<FloatingUIComponentSi
 
   @action registerAnchor(e: HTMLElement) {
     this._anchor = e;
+
+    // Set a value we can use to test that the content component has the correct ID.
+    this._anchor.setAttribute("data-anchor-id", this.contentID);
   }
 
   @action toggleContent() {

--- a/web/app/components/x/dropdown-list/index.ts
+++ b/web/app/components/x/dropdown-list/index.ts
@@ -97,6 +97,7 @@ export default class XDropdownListComponent extends Component<
      */
     this.input.focus({ preventScroll: true });
   }
+
   /**
    * The action run when the content div is inserted.
    * Used to assign ids to the menu items.
@@ -158,6 +159,9 @@ export default class XDropdownListComponent extends Component<
     if (event.key === "ArrowUp" || event.key === "ArrowDown") {
       event.preventDefault();
       showContent();
+
+      // Prevent the event from bubbling to the contentBody's keydown listener.
+      event.stopPropagation();
 
       // Wait for menuItemIDs to be set by `didInsertContent`.
       schedule("afterRender", () => {

--- a/web/app/styles/components/x/dropdown/list.scss
+++ b/web/app/styles/components/x/dropdown/list.scss
@@ -15,7 +15,7 @@
 }
 
 .x-dropdown-list-scroll-container {
-  @apply overflow-auto w-full relative;
+  @apply overflow-auto w-full relative rounded-b-md;
 }
 
 .x-dropdown-list-empty-state {


### PR DESCRIPTION
Adds a couple things I missed in #151 

Most notably, the `data-anchor-id` and `data-anchored-to` values that [we're testing here](https://github.com/hashicorp-forge/hermes/blob/main/web/tests/integration/components/x/dropdown-list/index-test.ts#L567-L580) are now actually being assigned.
