### PR TITLE
Use http.StatusOK for w.WriteHeader

### DIFF
--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -331,7 +331,7 @@ func (c *Command) Run(args []string) int {
 // healthHandler responds with the health of the service.
 func healthHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("OK"))
 	})
 }


### PR DESCRIPTION
Minor little fix, but keeps the `w.WriteHeader` the same as other implementations in the code, and also because using `200` without the constant value makes me sad.