### PR TITLE
Bug fix: no recently viewed docs can cause dashboard to not load

### DIFF
--- a/web/app/services/recently-viewed-docs.ts
+++ b/web/app/services/recently-viewed-docs.ts
@@ -50,7 +50,7 @@ export default class RecentlyViewedDocsService extends Service {
         "/api/v1/me/recently-viewed-docs"
       );
 
-      this.index = await fetchResponse?.json();
+      this.index = (await fetchResponse?.json()) || [];
 
       assert("fetchAll expects index", this.index);
 


### PR DESCRIPTION
We should add a test for this case, but want to fix this quickly for our users.