### PR TITLE
Configure Torii via the web config API

### DIFF
--- a/web/app/initializers/initialize-torii.js
+++ b/web/app/initializers/initialize-torii.js
@@ -1,0 +1,46 @@
+import bootstrapTorii from "torii/bootstrap/torii";
+import { configure } from "torii/configuration";
+import config from "../config/environment";
+import fetch from "fetch";
+
+/**
+ * This file overrides https://github.com/FMGSuite/torii/blob/8abbfe99b3a820470192e7cfcf7795be375d9b47/app/initializers/initialize-torii.js
+ *
+ * The initializer needed to be overridden to add functionality to fetch Google
+ * OAuth configuration from the backend API instead of baking it into the app.
+ */
+
+export function initialize(application) {
+  if (arguments[1]) {
+    // Ember < 2.1
+    application = arguments[1];
+  }
+
+  // Set Google OAuth config from the backend in production (and if not skipping
+  // Google auth).
+  if (config.environment === "production") {
+    fetch("/api/v1/web/config")
+      .then((response) => response?.json())
+      .then((json) => {
+        if (!json.skip_google_auth) {
+          config.torii.providers["google-oauth2-bearer-v2"].apiKey =
+            json.google_oauth2_client_id ?? "";
+          config.torii.providers["google-oauth2-bearer-v2"].hd =
+            json.google_oauth2_hd ?? "";
+        }
+      })
+      .catch((err) => {
+        console.log("Error fetching web config for auth: " + err);
+        throw err;
+      });
+  }
+
+  configure(config.torii || {});
+  bootstrapTorii(application);
+  application.inject("route", "torii", "service:torii");
+}
+
+export default {
+  name: "torii",
+  initialize,
+};

--- a/web/app/services/config.ts
+++ b/web/app/services/config.ts
@@ -14,9 +14,6 @@ export default class ConfigService extends Service {
     short_link_base_url: config.shortLinkBaseURL,
     skip_google_auth: config.skipGoogleAuth,
     google_analytics_tag_id: undefined,
-    // google_oauth2_client_id:
-    //   config.torii.providers["google-oauth2-bearer"].apiKey ?? "",
-    // google_oauth2_hd: config.torii.providers["google-oauth2-bearer"].hd ?? "",
   };
 
   setConfig(param) {


### PR DESCRIPTION
[Torii](https://github.com/FMGSuite/torii) only gets its configuration from the Ember environment config, which required these values to be set and then baked into the web app (which was a blocker for us being able to publish binaries for Hermes). This overrides the appropriate Torii initializer so it fetches the Google OAuth configuration from the web config API (for production builds).