### PR TITLE
Small updates for v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,6 @@ cp configs/config.hcl ./
 ### Build the Project
 
 ```sh
-# OAuth client ID of the “web application”
-export HERMES_WEB_GOOGLE_OAUTH2_CLIENT_ID=”{OAUTH_CLIENT_ID_HERE}”
-```
-
-```sh
 make build
 ```
 
@@ -123,6 +118,12 @@ make docker/postgres/start
 
 ```sh
 ./hermes server -config=config.hcl
+```
+
+### Run the Indexer
+
+```sh
+./hermes indexer -config=config.hcl
 ```
 
 NOTE: when not using a Google service account, this will automatically open a browser to authenticate the server to read and create documents, send emails, etc.
@@ -146,7 +147,7 @@ The server process serves web content. Of note, there are API endpoints for an a
 
 ### Indexer
 
-The indexer is a process that is run alongside the server that continually polls for published document updates and reindexes their content in Algolia for search. Additionally, it will rewrite the document headers with Hermes metadata in case they are manually changed to incorrect values. While not strictly required, it is recommended to run the indexer so the search index and Google Docs stay up-to-date.
+The indexer is a process that is run alongside the server that continually polls for published document updates and reindexes their content in Algolia for search. Additionally, it will rewrite the document headers with Hermes metadata in case they are manually changed to incorrect values. While not strictly required, it is recommended to run the indexer so search index data and Google Docs stay up-to-date.
 
 ### Frontend
 

--- a/internal/auth/oktaalb/oktaalb.go
+++ b/internal/auth/oktaalb/oktaalb.go
@@ -28,7 +28,7 @@ type Config struct {
 	AuthServerURL string `hcl:"auth_server_url,optional"`
 
 	// AWSRegion is the region of the AWS Application Load Balancer.
-	AWSRegion string `hcl:"aws_region"`
+	AWSRegion string `hcl:"aws_region,optional"`
 
 	// ClientID is the Okta client ID.
 	ClientID string `hcl:"client_id,optional"`

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -165,6 +165,10 @@ func (c *Command) Run(args []string) int {
 			c.UI.Error("error initializing server: Okta authorization server URL is required")
 			return 1
 		}
+		if cfg.Okta.AWSRegion == "" {
+			c.UI.Error("error initializing server: Okta AWS region is required")
+			return 1
+		}
 		if cfg.Okta.ClientID == "" {
 			c.UI.Error("error initializing server: Okta client ID is required")
 			return 1


### PR DESCRIPTION
This PR makes the `aws_region` parameter in the `okta` config block technically optional, and instead checks that the value is provided on server startup when Okta is enabled. It also makes some minor updates to the README including removing the Google auth environment variable, which used to be required at build time.