### PR TITLE
Add `maybe-query` and `model-or-models` helpers

### DIFF
--- a/web/app/components/x/dropdown-list/link-to.hbs
+++ b/web/app/components/x/dropdown-list/link-to.hbs
@@ -1,7 +1,6 @@
-{{! TODO: add @model support }}
-
 <LinkTo
   data-test-x-dropdown-list-item-link-to
+  {{! @glint-ignore }}
   {{did-insert @registerElement}}
   {{on "mouseenter" @focusMouseTarget}}
   {{on "click" @onClick}}
@@ -10,7 +9,8 @@
   tabindex="-1"
   aria-checked={{@isAriaChecked}}
   @route={{@route}}
-  @query={{or @query (hash)}}
+  @query={{maybe-query @query}}
+  @models={{model-or-models @model @models}}
   class="x-dropdown-list-item-link {{if @isAriaSelected 'is-aria-selected'}}"
   ...attributes
 >

--- a/web/app/components/x/dropdown-list/link-to.ts
+++ b/web/app/components/x/dropdown-list/link-to.ts
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
 
 interface XDropdownListLinkToComponentSignature {
-  Element: HTMLButtonElement;
+  Element: HTMLAnchorElement;
   Args: {
     registerElement: () => void;
     focusMouseTarget: () => void;
@@ -12,8 +12,19 @@ interface XDropdownListLinkToComponentSignature {
     isAriaSelected: boolean;
     isAriaChecked: boolean;
     route: string;
-    query?: unknown;
+    query?: Record<string, unknown>;
+    model?: unknown;
+    models?: unknown[];
+  };
+  Blocks: {
+    default: [];
   };
 }
 
 export default class XDropdownListLinkToComponent extends Component<XDropdownListLinkToComponentSignature> {}
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry {
+    "x/dropdown-list/link-to": typeof XDropdownListLinkToComponent;
+  }
+}

--- a/web/app/helpers/maybe-query.ts
+++ b/web/app/helpers/maybe-query.ts
@@ -1,11 +1,28 @@
 import { helper } from "@ember/component/helper";
 
+export interface MaybeQuerySignature {
+  Args: {
+    Positional: [Record<string, unknown> | undefined];
+  };
+  Return: Record<string, unknown> | {};
+}
+
 /**
  * Supplies an empty object if no is query provided.
  * Avoids errors when passing empty `@query` values to LinkTos.
  * Workaround for https://github.com/emberjs/ember.js/issues/19693
  * Can be removed when we upgrade to Ember 3.28+
  */
-export default helper(([query]: [unknown | undefined | null]) => {
-  return query ? query : {};
-});
+const maybeQueryHelper = helper<MaybeQuerySignature>(
+  ([query]: [unknown | undefined]) => {
+    return query ? query : {};
+  }
+);
+
+export default maybeQueryHelper;
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry {
+    "maybe-query": typeof maybeQueryHelper;
+  }
+}

--- a/web/app/helpers/maybe-query.ts
+++ b/web/app/helpers/maybe-query.ts
@@ -1,0 +1,11 @@
+import { helper } from "@ember/component/helper";
+
+/**
+ * Supplies an empty object if no is query provided.
+ * Avoids errors when passing empty `@query` values to LinkTos.
+ * Workaround for https://github.com/emberjs/ember.js/issues/19693
+ * Can be removed when we upgrade to Ember 3.28+
+ */
+export default helper(([query]: [unknown | undefined | null]) => {
+  return query ? query : {};
+});

--- a/web/app/helpers/maybe-query.ts
+++ b/web/app/helpers/maybe-query.ts
@@ -11,7 +11,7 @@ export interface MaybeQuerySignature {
  * Supplies an empty object if no is query provided.
  * Avoids errors when passing empty `@query` values to LinkTos.
  * Workaround for https://github.com/emberjs/ember.js/issues/19693
- * Can be removed when we upgrade to Ember 3.28+
+ * Can be removed when we upgrade to Ember 4.0.
  */
 const maybeQueryHelper = helper<MaybeQuerySignature>(
   ([query]: [unknown | undefined]) => {

--- a/web/app/helpers/model-or-models.ts
+++ b/web/app/helpers/model-or-models.ts
@@ -1,0 +1,36 @@
+import { helper } from "@ember/component/helper";
+import { assert } from "@ember/debug";
+
+export interface ModelOrModelsSignature {
+  Args: {
+    Positional: [unknown | undefined, Array<unknown> | undefined];
+  };
+  Return: Array<unknown>;
+}
+
+/**
+ * Returns the model or models based on the arguments passed.
+ * Allows a LinkTo-based component to support all model scenarios (including no models)
+ * without hitting internal assertions.
+ */
+const modelOrModelsHelper = helper<ModelOrModelsSignature>(
+  ([model, models]: [unknown | undefined, Array<unknown> | undefined]) => {
+    assert(
+      "You can't pass both `@model` and `@models` to a LinkTo",
+      !model || !models
+    );
+    if (models) {
+      return models;
+    } else {
+      return model ? [model] : [];
+    }
+  }
+);
+
+export default modelOrModelsHelper;
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry {
+    "model-or-models": typeof modelOrModelsHelper;
+  }
+}

--- a/web/app/helpers/model-or-models.ts
+++ b/web/app/helpers/model-or-models.ts
@@ -3,9 +3,9 @@ import { assert } from "@ember/debug";
 
 export interface ModelOrModelsSignature {
   Args: {
-    Positional: [unknown | undefined, Array<unknown> | undefined];
+    Positional: [unknown | undefined, unknown[] | undefined];
   };
-  Return: Array<unknown>;
+  Return: unknown[];
 }
 
 /**

--- a/web/tests/integration/helpers/maybe-query-test.ts
+++ b/web/tests/integration/helpers/maybe-query-test.ts
@@ -1,0 +1,46 @@
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+import { TestContext, find, render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+
+interface MaybeQueryTestContext extends TestContext {
+  query?: Record<string, unknown>;
+}
+
+module("Integration | Helper | maybe-query", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("it accepts a valid query object", async function (this: MaybeQueryTestContext, assert) {
+    this.query = { product: ["waypoint"] };
+
+    await render<MaybeQueryTestContext>(hbs`
+      <LinkTo
+        @route="authenticated.all"
+        @query={{maybe-query this.query}}
+      >
+       Link
+      </LinkTo>
+    `);
+
+    assert.equal(
+      find("a")?.getAttribute("href"),
+      "/all?product=%5B%22waypoint%22%5D",
+      "the passed-in query is used"
+    );
+  });
+
+  test("it accepts an undefined query", async function (this: MaybeQueryTestContext, assert) {
+    this.query = undefined;
+
+    await render<MaybeQueryTestContext>(hbs`
+      <LinkTo
+        @route="authenticated.all"
+        @query={{maybe-query this.query}}
+      >
+        Link
+      </LinkTo>
+    `);
+
+    assert.equal(find("a")?.getAttribute("href"), "/all");
+  });
+});

--- a/web/tests/integration/helpers/model-or-models-test.ts
+++ b/web/tests/integration/helpers/model-or-models-test.ts
@@ -1,0 +1,78 @@
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+import { TestContext, find, render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+
+interface TestModel {
+  id: number;
+  name: string;
+}
+
+interface ModelOrModelsTestContext extends TestContext {
+  model?: TestModel;
+  models?: TestModel[];
+}
+
+module("Integration | Helper | model-or-models", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("it accepts a single model", async function (this: ModelOrModelsTestContext, assert) {
+    this.set("model", { id: 1, name: "foo" });
+
+    await render<ModelOrModelsTestContext>(hbs`
+        <LinkTo
+          @route="authenticated.document"
+          @models={{model-or-models this.model this.models}}
+        >
+          Click me
+        </LinkTo>
+    `);
+
+    assert.equal(
+      find("a")?.getAttribute("href"),
+      "/document/1",
+      "it renders the correct href"
+    );
+  });
+
+  test("it accepts an array of models", async function (this: ModelOrModelsTestContext, assert) {
+    this.set("models", [
+      { id: 1, name: "foo" },
+      { id: 2, name: "bar" },
+    ]);
+
+    /**
+     * LinkTos, even in testing scenarios, require valid routes and models,
+     * and since our app has no multi-model routes, we can't test this
+     * using the href attribute. (Ember drops the `href` attribute if
+     * the models are invalid.) So we use a loop instead.
+     */
+    await render<ModelOrModelsTestContext>(hbs`
+      <div>
+        {{#each (model-or-models this.model this.models) as |model|}}
+          {{! @glint-nocheck }}
+          {{model.name}}
+        {{/each}}
+      </div>
+    `);
+
+    assert.dom("div").hasText("foo bar", "it renders the correct models");
+  });
+
+  test("it handles the no-model scenario", async function (this: ModelOrModelsTestContext, assert) {
+    await render<ModelOrModelsTestContext>(hbs`
+        <LinkTo
+          @route="authenticated.dashboard"
+          @models={{model-or-models this.model this.models}}
+        >
+          Click me
+        </LinkTo>
+    `);
+
+    assert.equal(
+      find("a")?.getAttribute("href"),
+      "/dashboard",
+      "it renders the correct href"
+    );
+  });
+});

--- a/web/tests/integration/helpers/model-or-models-test.ts
+++ b/web/tests/integration/helpers/model-or-models-test.ts
@@ -50,7 +50,7 @@ module("Integration | Helper | model-or-models", function (hooks) {
     await render<ModelOrModelsTestContext>(hbs`
       <div>
         {{#each (model-or-models this.model this.models) as |model|}}
-          {{! @glint-nocheck }}
+          {{! @glint-ignore }}
           {{model.name}}
         {{/each}}
       </div>

--- a/web/types/glint/index.d.ts
+++ b/web/types/glint/index.d.ts
@@ -1,0 +1,1 @@
+import "@glint/environment-ember-loose";


### PR DESCRIPTION
Introduces two LinkTo-focused helpers to make the DropdownList::LinkTo component more flexible.

Example usage:
```
<LinkTo
    {{! fall back to an empty hash if @query is undefined }}
    @query={{maybe-query @query}}
    
    {{! fall back to an empty array if no models are provided }}
    @models={{model-or-models @model @models}}
```
