### PR TITLE
Fix logic to update recently viewed documents

### DIFF
--- a/internal/api/drafts.go
+++ b/internal/api/drafts.go
@@ -567,20 +567,24 @@ func DraftsDocumentHandler(
 				return
 			}
 
-			// Update recently viewed docs for the user.
-			if err := updateRecentlyViewedDocs(userEmail, docId, db, now); err != nil {
-				// If we get an error, log it but don't return an error response because
-				// this would degrade UX.
-				// TODO: change this log back to an error when this handles incomplete
-				// data in the database.
-				l.Warn("error updating recently viewed docs",
-					"error", err,
-					"path", r.URL.Path,
-					"method", r.Method,
-					"doc_id", docId,
-				)
-				return
-
+			// Update recently viewed documents if this is a document view event. The
+			// Add-To-Recently-Viewed header is set in the request from the frontend
+			// to differentiate between document views and requests to only retrieve
+			// document metadata.
+			if r.Header.Get("Add-To-Recently-Viewed") != "" {
+				if err := updateRecentlyViewedDocs(userEmail, docId, db, now); err != nil {
+					// If we get an error, log it but don't return an error response because
+					// this would degrade UX.
+					// TODO: change this log back to an error when this handles incomplete
+					// data in the database.
+					l.Warn("error updating recently viewed docs",
+						"error", err,
+						"path", r.URL.Path,
+						"method", r.Method,
+						"doc_id", docId,
+					)
+					return
+				}
 			}
 
 			l.Info("retrieved document draft", "doc_id", docId)

--- a/web/app/routes/authenticated/document.js
+++ b/web/app/routes/authenticated/document.js
@@ -46,8 +46,16 @@ export default class DocumentRoute extends Route {
     if (params.draft) {
       try {
         doc = await this.fetchSvc
-          .fetch("/api/v1/drafts/" + params.document_id)
+          .fetch("/api/v1/drafts/" + params.document_id, {
+            method: "GET",
+            headers: {
+              // We set this header to differentiate between document views and
+              // requests to only retrieve document metadata.
+              "Add-To-Recently-Viewed": "true",
+            },
+          })
           .then((r) => r.json());
+
         doc.isDraft = params.draft;
         draftFetched = true;
       } catch (err) {


### PR DESCRIPTION
Users' recently viewed documents were not being updated correctly in all cases. Taking a look at this logic again, I found that we weren't gating the updates of recently viewed docs for draft documents on when the `Add-To-Recently-Viewed` header is present (like we do for non-draft docs), which could potentially have strange consequences. Also the logic to update recently viewed docs itself wasn't sorting results correctly, which I believe was the main cause for the incorrect behavior.