### PR TITLE
Lock documents in a bad state

### DIFF
--- a/internal/api/documents.go
+++ b/internal/api/documents.go
@@ -148,6 +148,26 @@ func DocumentHandler(
 			// Set custom editable fields.
 			docObj.SetCustomEditableFields()
 
+			// Get document from database.
+			doc := models.Document{
+				GoogleFileID: docID,
+			}
+			if err := doc.Get(db); err != nil {
+				l.Error("error getting document from database",
+					"error", err,
+					"path", r.URL.Path,
+					"method", r.Method,
+					"doc_id", docID,
+				)
+				http.Error(w, "Error requesting document",
+					http.StatusInternalServerError)
+				return
+			}
+
+			// Set locked value for response to value from the database (this value
+			// isn't stored in Algolia).
+			docObj.SetLocked(doc.Locked)
+
 			// Write response.
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
@@ -225,6 +245,24 @@ func DocumentHandler(
 				l.Error("error decoding document patch request", "error", err)
 				http.Error(w, fmt.Sprintf("Bad request: %q", err),
 					http.StatusBadRequest)
+				return
+			}
+
+			// Check if document is locked.
+			locked, err := hcd.IsLocked(docID, db, s)
+			if err != nil {
+				l.Error("error checking document locked status",
+					"error", err,
+					"path", r.URL.Path,
+					"method", r.Method,
+					"doc_id", docID,
+				)
+				http.Error(w, "Error getting document status", http.StatusNotFound)
+				return
+			}
+			// Don't continue if document is locked.
+			if locked {
+				http.Error(w, "Document is locked", http.StatusLocked)
 				return
 			}
 

--- a/internal/api/drafts.go
+++ b/internal/api/drafts.go
@@ -554,6 +554,26 @@ func DraftsDocumentHandler(
 			// Set custom editable fields.
 			docObj.SetCustomEditableFields()
 
+			// Get document from database.
+			doc := models.Document{
+				GoogleFileID: docId,
+			}
+			if err := doc.Get(db); err != nil {
+				l.Error("error getting document draft from database",
+					"error", err,
+					"path", r.URL.Path,
+					"method", r.Method,
+					"doc_id", docId,
+				)
+				http.Error(w, "Error requesting document draft",
+					http.StatusInternalServerError)
+				return
+			}
+
+			// Set locked value for response to value from the database (this value
+			// isn't stored in Algolia).
+			docObj.SetLocked(doc.Locked)
+
 			// Write response.
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
@@ -693,6 +713,24 @@ func DraftsDocumentHandler(
 				// Set product abbreviation because we use this later to update the
 				// doc number in the Algolia object.
 				productAbbreviation = p.Abbreviation
+			}
+
+			// Check if document is locked.
+			locked, err := hcd.IsLocked(docId, db, s)
+			if err != nil {
+				l.Error("error checking document locked status",
+					"error", err,
+					"method", r.Method,
+					"path", r.URL.Path,
+					"doc_id", docId,
+				)
+				http.Error(w, "Error getting document status", http.StatusNotFound)
+				return
+			}
+			// Don't continue if document is locked.
+			if locked {
+				http.Error(w, "Document is locked", http.StatusLocked)
+				return
 			}
 
 			// Compare contributors in request and stored object in Algolia

--- a/internal/api/reviews.go
+++ b/internal/api/reviews.go
@@ -46,6 +46,24 @@ func ReviewHandler(
 				return
 			}
 
+			// Check if document is locked.
+			locked, err := hcd.IsLocked(docID, db, s)
+			if err != nil {
+				l.Error("error checking document locked status",
+					"error", err,
+					"path", r.URL.Path,
+					"method", r.Method,
+					"doc_id", docID,
+				)
+				http.Error(w, "Error getting document status", http.StatusNotFound)
+				return
+			}
+			// Don't continue if document is locked.
+			if locked {
+				http.Error(w, "Document is locked", http.StatusLocked)
+				return
+			}
+
 			// Get base document object from Algolia so we can determine the doc type.
 			baseDocObj := &hcd.BaseDoc{}
 			err = ar.Drafts.GetObject(docID, &baseDocObj)

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -262,7 +262,7 @@ func (c *Command) Run(args []string) int {
 		{"/1/indexes/",
 			algolia.AlgoliaProxyHandler(algoSearch, cfg.Algolia, c.Log)},
 		{"/api/v1/approvals/",
-			api.ApprovalHandler(cfg, c.Log, algoSearch, algoWrite, goog)},
+			api.ApprovalHandler(cfg, c.Log, algoSearch, algoWrite, goog, db)},
 		{"/api/v1/document-types", api.DocumentTypesHandler(*cfg, c.Log)},
 		{"/api/v1/documents/",
 			api.DocumentHandler(cfg, c.Log, algoSearch, algoWrite, goog, db)},

--- a/internal/indexer/refresh_headers.go
+++ b/internal/indexer/refresh_headers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp-forge/hermes/pkg/algolia"
 	hcd "github.com/hashicorp-forge/hermes/pkg/hashicorpdocs"
+	"github.com/hashicorp-forge/hermes/pkg/models"
 	"google.golang.org/api/drive/v3"
 )
 
@@ -54,6 +55,25 @@ func refreshDocumentHeaders(
 	)
 	if err != nil {
 		return fmt.Errorf("error getting updated documents in folder: %w", err)
+	}
+
+	// Add any locked documents to the slice of documents to refresh.
+	lockedDocs := models.Documents{}
+	switch ft {
+	case draftsFolderType:
+		lockedDocs.Find(idx.Database,
+			"locked = ? AND status = ?", true, models.WIPDocumentStatus)
+	case documentsFolderType:
+		lockedDocs.Find(idx.Database,
+			// All document statuses > WIPDocumentStatus are for published documents.
+			"locked = ? AND status > ?", true, models.WIPDocumentStatus)
+	}
+	for _, d := range lockedDocs {
+		f, err := idx.GoogleWorkspaceService.GetFile(d.GoogleFileID)
+		if err != nil {
+			return fmt.Errorf("error getting file (%s): %w", d.GoogleFileID, err)
+		}
+		docs = append(docs, f)
 	}
 
 	// Return if there are no updated documents.
@@ -118,6 +138,20 @@ func refreshDocumentHeader(
 ) {
 	algo := idx.AlgoliaClient
 	log := idx.Logger
+
+	// Check if document is locked.
+	locked, err := hcd.IsLocked(file.Id, idx.Database, idx.GoogleWorkspaceService)
+	if err != nil {
+		log.Error("error checking document locked status",
+			"error", err,
+			"google_file_id", file.Id,
+		)
+		os.Exit(1)
+	}
+	// Don't continue if document is locked.
+	if locked {
+		return
+	}
 
 	// Get base document object from Algolia so we can determine the document
 	// type.

--- a/pkg/hashicorpdocs/basedoc.go
+++ b/pkg/hashicorpdocs/basedoc.go
@@ -56,6 +56,9 @@ type BaseDoc struct {
 	// TODO: LinkedDocs is not used yet.
 	LinkedDocs []string `json:"linkedDocs,omitempty"`
 
+	// Locked is true if the document is locked for editing.
+	Locked bool `json:"locked,omitempty"`
+
 	// MetaTags contains metadata tags that can be used for filtering in Algolia.
 	MetaTags []string `json:"_tags,omitempty"`
 
@@ -178,6 +181,10 @@ func (d *BaseDoc) SetFileRevision(revisionID, revisionName string) {
 	} else {
 		d.FileRevisions[revisionID] = revisionName
 	}
+}
+
+func (d *BaseDoc) SetLocked(l bool) {
+	d.Locked = l
 }
 
 func (d *BaseDoc) SetModifiedTime(i int64) {

--- a/pkg/hashicorpdocs/common.go
+++ b/pkg/hashicorpdocs/common.go
@@ -44,6 +44,7 @@ type Doc interface {
 	SetContent(s string)
 	SetDocNumber(string)
 	SetFileRevision(string, string)
+	SetLocked(bool)
 	SetModifiedTime(int64)
 	SetStatus(string)
 

--- a/pkg/hashicorpdocs/locked.go
+++ b/pkg/hashicorpdocs/locked.go
@@ -1,0 +1,107 @@
+package hashicorpdocs
+
+import (
+	"fmt"
+
+	"github.com/hashicorp-forge/hermes/pkg/googleworkspace"
+	"github.com/hashicorp-forge/hermes/pkg/models"
+	"google.golang.org/api/docs/v1"
+	"gorm.io/gorm"
+)
+
+// IsLocked checks if a document contains one or more suggestions in the header,
+// locks/unlocks the document accordingly, and returns the lock status.
+func IsLocked(
+	fileID string, db *gorm.DB, goog *googleworkspace.Service) (bool, error) {
+
+	// Get document from database.
+	doc := models.Document{
+		GoogleFileID: fileID,
+	}
+	if err := doc.Get(db); err != nil {
+		return false, fmt.Errorf("error getting document from database: %w", err)
+	}
+
+	// Find out if the document header contains a suggestion. Deleting text which
+	// contains a suggestion currently causes a Google internal API error so we
+	// need to lock the document.
+	gDoc, err := goog.GetDoc(fileID)
+	if err != nil {
+		return false, fmt.Errorf("error getting Google Doc: %w", err)
+	}
+
+	hasSuggestion := containsSuggestionInHeader(gDoc)
+	if hasSuggestion {
+		// Lock document if it's not already locked.
+		if !doc.Locked {
+			doc.Locked = true
+			if err := doc.Upsert(db); err != nil {
+				return false, fmt.Errorf(
+					"error upserting document in database to lock it: %w", err)
+			}
+		}
+	} else {
+		// Unlock document if it was locked and doesn't contain a suggestion in the
+		// header anymore.
+		if doc.Locked {
+			doc.Locked = false
+			if err := db.Model(&doc).
+				// We need to update using select because false is a zero value.
+				Select("locked").
+				Updates(models.Document{Locked: false}).
+				Error; err != nil {
+				return false, fmt.Errorf(
+					"error updating document in database to unlock it: %w", err)
+			}
+		}
+	}
+
+	return doc.Locked, nil
+}
+
+// containsSuggestionInHeader returns true if a Google Doc contains one or more
+// suggestions in the document header.
+func containsSuggestionInHeader(doc *docs.Document) bool {
+	// Find the first table in the document (hopefully it's the doc header).
+	var (
+		startIndex int64
+		t          *docs.Table
+	)
+	elems := doc.Body.Content
+	for _, e := range elems {
+		if e.Table != nil {
+			t = e.Table
+			startIndex = e.StartIndex
+
+			break
+		}
+	}
+	// startIndex should be 2, but we'll allow a little leeway in case someone
+	// accidentally added a newline or something.
+	if t == nil || startIndex >= 5 {
+		// We didn't find a header table.
+		return false
+	}
+
+	// Navigate through all table contents to look for suggestions.
+	for _, row := range t.TableRows {
+		for _, cell := range row.TableCells {
+			for _, content := range cell.Content {
+				if para := content.Paragraph; para != nil {
+					for _, elem := range para.Elements {
+						if txt := elem.TextRun; txt != nil {
+							if len(txt.SuggestedDeletionIds) > 0 ||
+								len(txt.SuggestedInsertionIds) > 0 ||
+								len(txt.SuggestedTextStyleChanges) > 0 {
+								// We found a suggestion.
+								return true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/models/document.go
+++ b/pkg/models/document.go
@@ -45,6 +45,9 @@ type Document struct {
 	// Imported is true if the document was not created through the application.
 	Imported bool
 
+	// Locked is true if the document cannot be updated (may be in a bad state).
+	Locked bool
+
 	// Owner is the owner of the document.
 	Owner   *User `gorm:"default:null;not null"`
 	OwnerID *uint `gorm:"default:null"`

--- a/pkg/models/document.go
+++ b/pkg/models/document.go
@@ -131,9 +131,11 @@ func (d *Document) Create(db *gorm.DB) error {
 
 // Find finds all documents from database db with the provided query, and
 // assigns them to the receiver.
-func (d *Documents) Find(db *gorm.DB, query string) error {
+func (d *Documents) Find(
+	db *gorm.DB, query interface{}, queryArgs ...interface{}) error {
+
 	return db.
-		Where(query).
+		Where(query, queryArgs...).
 		Preload(clause.Associations).
 		Find(&d).Error
 }

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -364,7 +364,7 @@
                 >
                   {{if
                     this.docStateIsBad
-                    "Editing is locked"
+                    "Document is locked"
                     "Read-only headers"
                   }}
                   <FlightIcon
@@ -375,7 +375,7 @@
                 <p class="mb-1.5">
                   {{if
                     this.docStateIsBad
-                    "Weʼre sorry; a bug is preventing us from editing this document."
+                    "Due to a Google API bug, all suggestions must be removed from the document header to unlock."
                     "Weʼre unable to edit the metadata of files created offsite."
                   }}
                 </p>
@@ -384,9 +384,9 @@
                 <Hds::Link::Standalone
                   @icon="arrow-right"
                   @iconPosition="trailing"
-                  @text="See issues on GitHub"
+                  @text="See the issue on GitHub"
                   @size="small"
-                  @href="https://github.com/hashicorp-forge/hermes/issues"
+                  @href="https://github.com/hashicorp-forge/hermes/issues/181"
                 />
               {{else}}
                 <div class="text-body-100 text-color-foreground-faint">

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -351,26 +351,48 @@
     </div> --}}
 
     {{#if this.userHasEditPrivileges}}
-      <div class="sidebar-footer">
-        {{#if (not @document.appCreated)}}
+      <div
+        class="sidebar-footer
+          {{if (or (not @document.appCreated) this.docStateIsBad) 'locked'}}"
+      >
+        {{#if (or (not @document.appCreated) this.docStateIsBad)}}
           <div class="px-3 -mb-1">
             <div class="w-full pt-3.5 border-t border-color-border-primary">
               <div class="text-body-200 text-color-foreground-faint">
                 <h5
                   class="text-body-200 font-semibold text-color-foreground-primary flex items-center mb-1"
                 >
-                  Read-only headers
+                  {{if
+                    this.docStateIsBad
+                    "Editing is locked"
+                    "Read-only headers"
+                  }}
                   <FlightIcon
                     @name="lock"
                     class="shrink-0 text-color-foreground-faint -mt-px ml-1.5"
                   />
                 </h5>
                 <p class="mb-1.5">
-                  Weʼre unable to edit the metadata of files created offsite.
+                  {{if
+                    this.docStateIsBad
+                    "Weʼre sorry; a bug is preventing us from editing this document."
+                    "Weʼre unable to edit the metadata of files created offsite."
+                  }}
                 </p>
               </div>
-              <div class="text-[12px] opacity-60 italic">Create docs in-app for
-                best results</div>
+              {{#if this.docStateIsBad}}
+                <Hds::Link::Standalone
+                  @icon="arrow-right"
+                  @iconPosition="trailing"
+                  @text="See issues on GitHub"
+                  @size="small"
+                  @href="https://github.com/hashicorp-forge/hermes/issues"
+                />
+              {{else}}
+                <div class="text-body-100 text-color-foreground-faint">
+                  Create docs in-app for best results.
+                </div>
+              {{/if}}
             </div>
           </div>
         {{else}}

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -353,9 +353,9 @@
     {{#if this.userHasEditPrivileges}}
       <div
         class="sidebar-footer
-          {{if (or (not @document.appCreated) this.docStateIsBad) 'locked'}}"
+          {{if this.editingIsDisabled 'locked'}}"
       >
-        {{#if (or (not @document.appCreated) this.docStateIsBad)}}
+        {{#if this.editingIsDisabled}}
           <div class="px-3 -mb-1">
             <div class="w-full pt-3.5 border-t border-color-border-primary">
               <div class="text-body-200 text-color-foreground-faint">
@@ -363,7 +363,7 @@
                   class="text-body-200 font-semibold text-color-foreground-primary flex items-center mb-1"
                 >
                   {{if
-                    this.docStateIsBad
+                    this.docIsLocked
                     "Document is locked"
                     "Read-only headers"
                   }}
@@ -374,13 +374,13 @@
                 </h5>
                 <p class="mb-1.5">
                   {{if
-                    this.docStateIsBad
+                    this.docIsLocked
                     "Due to a Google API bug, all suggestions must be removed from the document header to unlock."
                     "Weʼre unable to edit the metadata of files created offsite."
                   }}
                 </p>
               </div>
-              {{#if this.docStateIsBad}}
+              {{#if this.docIsLocked}}
                 <Hds::Link::Standalone
                   @icon="arrow-right"
                   @iconPosition="trailing"

--- a/web/app/components/document/sidebar.js
+++ b/web/app/components/document/sidebar.js
@@ -50,7 +50,7 @@ export default class DocumentSidebar extends Component {
   @tracked userHasScrolled = false;
   @tracked body = null;
 
-  get docStateIsBad() {
+  get docIsLocked() {
     return this.args.document?.locked;
   }
 
@@ -164,8 +164,8 @@ export default class DocumentSidebar extends Component {
   }
 
   get editingIsDisabled() {
-    if (!this.args.document.appCreated || this.docStateIsBad) {
-      // true is the doc wasn't appCreated or is in a bad state
+    if (!this.args.document.appCreated || this.docIsLocked) {
+      // true is the doc wasn't appCreated or is in a locked state
       return true;
     } else if (this.isDraft || this.docIsInReview || this.docIsApproved) {
       // true is the doc is a draft/in review/approved and the user is not an owner, contributor, or approver

--- a/web/app/components/document/sidebar.js
+++ b/web/app/components/document/sidebar.js
@@ -235,7 +235,7 @@ export default class DocumentSidebar extends Component {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(fields),
       });
-    } catch {
+    } catch (error) {
       this.maybeShowFlashError(error, "Unable to save document");
       throw error;
     }

--- a/web/app/components/document/sidebar.js
+++ b/web/app/components/document/sidebar.js
@@ -51,8 +51,7 @@ export default class DocumentSidebar extends Component {
   @tracked body = null;
 
   get docStateIsBad() {
-    // TODO: Need a criteria for when a document is uneditable.
-    return false;
+    return this.args.document?.locked;
   }
 
   get customEditableFields() {
@@ -165,8 +164,8 @@ export default class DocumentSidebar extends Component {
   }
 
   get editingIsDisabled() {
-    if (!this.args.document.appCreated) {
-      // true is the doc wasn't appCreated or if the doc is Approved
+    if (!this.args.document.appCreated || this.docStateIsBad) {
+      // true is the doc wasn't appCreated or is in a bad state
       return true;
     } else if (this.isDraft || this.docIsInReview || this.docIsApproved) {
       // true is the doc is a draft/in review/approved and the user is not an owner, contributor, or approver

--- a/web/app/components/document/sidebar.js
+++ b/web/app/components/document/sidebar.js
@@ -50,6 +50,11 @@ export default class DocumentSidebar extends Component {
   @tracked userHasScrolled = false;
   @tracked body = null;
 
+  get docStateIsBad() {
+    // TODO: Need a criteria for when a document is uneditable.
+    return false;
+  }
+
   get customEditableFields() {
     let customEditableFields = this.args.document.customEditableFields || {};
     for (const field in customEditableFields) {

--- a/web/app/styles/components/sidebar.scss
+++ b/web/app/styles/components/sidebar.scss
@@ -81,5 +81,9 @@
 
   .sidebar-footer {
     @apply w-full bg-color-page-faint shrink-0 py-4 px-3.5;
+
+    &.locked {
+      @apply pt-0;
+    }
   }
 }


### PR DESCRIPTION
Due to #181, we cannot refresh document headers when they contain a suggestion, so this PR locks documents in this state. The indexer will then always attempt to reindex locked documents on every run and unlock+reindex them if the suggestions in the header are removed. API calls that replace the document header have been updated to first check if the document is locked and will return a Locked HTTP status if this is the case.

For the frontend parts, this builds on @jeffdaley's work in #178 and updates the messaging a bit. Oh, and I couldn't take that `ReferenceError: error is not defined` message when requesting a review fails anymore, so I tracked that 🐛 down.

Bottom of sidebar when a document is locked:
<img width="265" alt="image" src="https://github.com/hashicorp-forge/hermes/assets/1489080/41739bb0-43b3-4653-88bf-8e255b676a73">
