### PR TITLE
Fix Glint imports

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.6.0",
+    "@gavant/glint-template-types": "^0.3.3",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "@glint/core": "^1.0.1",

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -20,5 +20,13 @@
   "glint": {
     "environment": "ember-loose"
   },
-  "include": ["app/**/*", "tests/**/*", "types/**/*"]
+  "include": [
+    "app/**/*",
+    "tests/**/*",
+    "types/**/*",
+    "node_modules/@gavant/glint-template-types/types/ember-concurrency/perform.d.ts",
+    "node_modules/@gavant/glint-template-types/types/ember-on-helper/on-document.d.ts",
+    "node_modules/@gavant/glint-template-types/types/ember-render-modifiers/*",
+    "node_modules/@gavant/glint-template-types/types/ember-truth-helpers/*"
+  ]
 }

--- a/web/types/glint/index.d.ts
+++ b/web/types/glint/index.d.ts
@@ -1,17 +1,28 @@
 import "@glint/environment-ember-loose";
+import PerformHelper from "ember-concurrency/helpers/perform";
+import OnDocumentHelper from "ember-on-helper/helpers/on-document";
+import DidInsertModifier from "ember-render-modifiers/modifiers/did-insert";
+import WillDestroyModifier from "ember-render-modifiers/modifiers/will-destroy";
+import AndHelper from "ember-truth-helpers/helpers/and";
+import EqHelper from "ember-truth-helpers/helpers/eq";
+import IsEmptyHelper from "ember-truth-helpers/helpers/is-empty";
+import LtHelper from "ember-truth-helpers/helpers/lt";
+import NotHelper from "ember-truth-helpers/helpers/not";
+import OrHelper from "ember-truth-helpers/helpers/or";
 import { FlightIconComponent } from "hds/flight-icon";
 
 declare module "@glint/environment-ember-loose/registry" {
   export default interface Registry {
-    "did-insert": typeof import("@gavant/glint-template-types/types/ember-render-modifiers/did-insert").default;
-    "on-document": typeof import("@gavant/glint-template-types/types/ember-on-helper/on-document").default;
-    perform: typeof import("@gavant/glint-template-types/types/ember-concurrency/perform").default;
-    or: typeof import("@gavant/glint-template-types/types/ember-truth-helpers/or").default;
-    eq: typeof import("@gavant/glint-template-types/types/ember-truth-helpers/eq").default;
-    and: typeof import("@gavant/glint-template-types/types/ember-truth-helpers/and").default;
-    not: typeof import("@gavant/glint-template-types/types/ember-truth-helpers/not").default;
-    "is-empty": typeof import("@gavant/glint-template-types/types/ember-truth-helpers/is-empty").default;
-
+    "did-insert": typeof DidInsertModifier;
+    "will-destroy": typeof WillDestroyModifier;
+    "on-document": typeof OnDocumentHelper;
+    perform: typeof PerformHelper;
+    or: typeof OrHelper;
+    eq: typeof EqHelper;
+    and: typeof AndHelper;
+    not: typeof NotHelper;
+    lt: typeof LtHelper
+    "is-empty": IsEmptyHelper;
     FlightIcon: FlightIconComponent;
   }
 }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1974,6 +1974,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gavant/glint-template-types@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "@gavant/glint-template-types@npm:0.3.3"
+  checksum: 9f80128b67635e93ecb951053812a2c2ce47119384941b76b5c446f2d920568642412ee049d6b1720bc6379adfa8d1b3edb2120112c32ab3862ec5edccde3ab6
+  languageName: node
+  linkType: hard
+
 "@glimmer/component@npm:^1.0.4, @glimmer/component@npm:^1.1.0, @glimmer/component@npm:^1.1.2":
   version: 1.1.2
   resolution: "@glimmer/component@npm:1.1.2"
@@ -11047,6 +11054,7 @@ __metadata:
     "@ember/optional-features": ^2.0.0
     "@ember/test-helpers": ^2.6.0
     "@floating-ui/dom": ^1.2.4
+    "@gavant/glint-template-types": ^0.3.3
     "@glimmer/component": ^1.0.4
     "@glimmer/tracking": ^1.0.4
     "@glint/core": ^1.0.1


### PR DESCRIPTION
Updates TSConfig and Glint registry to correctly import third-party types.

See https://github.com/Gavant/glint-template-types#use