### PR TITLE
WIP: Tweak front-end error messages

### DIFF
--- a/web/app/components/document/sidebar.js
+++ b/web/app/components/document/sidebar.js
@@ -186,7 +186,7 @@ export default class DocumentSidebar extends Component {
     if (!this.modalIsActive) {
       this.flashMessages.add({
         title,
-        message: error.message,
+        message: `${error}`,
         type: "critical",
         timeout: 6000,
         extendedTimeout: 1000,

--- a/web/app/routes/authenticated/document.js
+++ b/web/app/routes/authenticated/document.js
@@ -31,7 +31,7 @@ export default class DocumentRoute extends Route {
   showErrorMessage(err) {
     this.flashMessages.add({
       title: "Error fetching document",
-      message: err.message,
+      message: `${err}`,
       type: "critical",
       sticky: true,
       extendedTimeout: 1000,


### PR DESCRIPTION
Changes a couple error messages to show entire error rather than just its `message`.

We sometimes see cases like this where only a broad description is shown.
![image](https://github.com/hashicorp-forge/hermes/assets/754957/b3321415-7373-42da-bfb2-74f5b7febbda)

This PR should make the message more specific.