### PR TITLE
Added Dockerfile based on Ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.4
+# do not forget to set env on host: `export DOCKER_BUILDKIT=1`
+FROM ubuntu:22.04 as frontend-builder
+# Build frontend using NodeJS 16.x
+WORKDIR /app
+RUN apt-get update
+
+RUN apt-get -y install curl make gcc
+RUN curl -sL https://deb.nodesource.com/setup_16.x  | bash -
+RUN apt-get -y install nodejs
+
+RUN corepack enable
+RUN corepack prepare yarn@stable --activate
+RUN yarn set version stable
+
+COPY --link . .
+
+RUN make web/install-deps
+RUN make web/build
+
+
+FROM ubuntu:22.04 as backend-builder
+# Build backend using golang
+
+WORKDIR /app
+RUN apt-get update
+RUN apt-get -y install golang-1.18 golang-go ca-certificates make git
+
+COPY --link go.mod go.sum ./
+
+# update trusted certificates to the latest version
+RUN update-ca-certificates
+RUN go mod download
+
+COPY --link . .
+COPY --link --from=frontend-builder /app/web/dist /app/web/dist
+RUN make bin
+
+
+FROM ubuntu:22.04 as hermes
+# Copy frontend and backend files from previous build stages and set ENTRYPOINT
+
+WORKDIR /app
+COPY --from=backend-builder /app/hermes hermes
+RUN chmod +x hermes
+
+ENTRYPOINT ["./hermes"]


### PR DESCRIPTION
Hello all,
first of all, thanks for the project!

We would like to use the app in production and we need secured images due to the requirements. I have seen the PR with proposed alternative based on alpine. 
Current PR is based on Ubuntu 22.04, which provides secure patches and has less CVEs compared to alpine.
Dockerfile provide 3 stages to minimize the size, here is the final output:
```
hermes             latest            c2fbac354fb7   30 minutes ago   113MB
```

Closes #8


example to run:
```
docker run hermes
Usage: hermes [--version] [--help] <command> [<args>]

Available commands are:
    indexer    Run the indexer
    server     Run the server
    version    Print the version of the binary

```

Trivy vulnerability scan: 
<details>
```
hermes (ubuntu 22.04)

Total: 24 (UNKNOWN: 0, LOW: 16, MEDIUM: 8, HIGH: 0, CRITICAL: 0)

┌──────────────┬────────────────┬──────────┬──────────────────────────┬───────────────────┬─────────────────────────────────────────────────────────────┐
│   Library    │ Vulnerability  │ Severity │    Installed Version     │   Fixed Version   │                            Title                            │
├──────────────┼────────────────┼──────────┼──────────────────────────┼───────────────────┼─────────────────────────────────────────────────────────────┤
│ bash         │ CVE-2022-3715  │ LOW      │ 5.1-6ubuntu1             │                   │ a heap-buffer-overflow in valid_parameter_transform         │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2022-3715                   │
├──────────────┼────────────────┤          ├──────────────────────────┼───────────────────┼─────────────────────────────────────────────────────────────┤
│ coreutils    │ CVE-2016-2781  │          │ 8.32-4.1ubuntu1          │                   │ coreutils: Non-privileged session can escape to the parent  │
│              │                │          │                          │                   │ session in chroot                                           │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2016-2781                   │
├──────────────┼────────────────┤          ├──────────────────────────┼───────────────────┼─────────────────────────────────────────────────────────────┤
│ gpgv         │ CVE-2022-3219  │          │ 2.2.27-3ubuntu2.1        │                   │ denial of service issue (resource consumption) using        │
│              │                │          │                          │                   │ compressed packets                                          │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2022-3219                   │
├──────────────┼────────────────┤          ├──────────────────────────┼───────────────────┼─────────────────────────────────────────────────────────────┤
│ libc-bin     │ CVE-2016-20013 │          │ 2.35-0ubuntu3.1          │                   │ sha256crypt and sha512crypt through 0.6 allow attackers to  │
│              │                │          │                          │                   │ cause a denial of...                                        │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2016-20013                  │
├──────────────┤                │          │                          ├───────────────────┤                                                             │
│ libc6        │                │          │                          │                   │                                                             │
│              │                │          │                          │                   │                                                             │
│              │                │          │                          │                   │                                                             │
├──────────────┼────────────────┼──────────┼──────────────────────────┼───────────────────┼─────────────────────────────────────────────────────────────┤
│ libcap2      │ CVE-2023-2603  │ MEDIUM   │ 1:2.44-1build3           │                   │ Integer Overflow in _libcap_strdup()                        │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2023-2603                   │
│              ├────────────────┼──────────┤                          ├───────────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-2602  │ LOW      │                          │                   │ Memory Leak on pthread_create() Error                       │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2023-2602                   │
├──────────────┼────────────────┼──────────┼──────────────────────────┼───────────────────┼─────────────────────────────────────────────────────────────┤
│ libncurses6  │ CVE-2023-29491 │ MEDIUM   │ 6.3-2                    │ 6.3-2ubuntu0.1    │ Local users can trigger security-relevant memory corruption │
│              │                │          │                          │                   │ via malformed data                                          │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2023-29491                  │
│              ├────────────────┼──────────┤                          │                   ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-29458 │ LOW      │                          │                   │ ncurses: segfaulting OOB read                               │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2022-29458                  │
├──────────────┼────────────────┼──────────┤                          │                   ├─────────────────────────────────────────────────────────────┤
│ libncursesw6 │ CVE-2023-29491 │ MEDIUM   │                          │                   │ Local users can trigger security-relevant memory corruption │
│              │                │          │                          │                   │ via malformed data                                          │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2023-29491                  │
│              ├────────────────┼──────────┤                          │                   ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-29458 │ LOW      │                          │                   │ ncurses: segfaulting OOB read                               │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2022-29458                  │
├──────────────┼────────────────┤          ├──────────────────────────┼───────────────────┼─────────────────────────────────────────────────────────────┤
│ libpcre3     │ CVE-2017-11164 │          │ 2:8.39-13ubuntu0.22.04.1 │                   │ pcre: OP_KETRMAX feature in the match function in           │
│              │                │          │                          │                   │ pcre_exec.c                                                 │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2017-11164                  │
├──────────────┼────────────────┼──────────┼──────────────────────────┼───────────────────┼─────────────────────────────────────────────────────────────┤
│ libssl3      │ CVE-2023-2650  │ MEDIUM   │ 3.0.2-0ubuntu1.9         │ 3.0.2-0ubuntu1.10 │ Possible DoS translating ASN.1 object identifiers           │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2023-2650                   │
│              ├────────────────┼──────────┤                          │                   ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-1255  │ LOW      │                          │                   │ Input buffer over-read in AES-XTS implementation on 64 bit  │
│              │                │          │                          │                   │ ARM                                                         │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2023-1255                   │
├──────────────┼────────────────┼──────────┼──────────────────────────┼───────────────────┼─────────────────────────────────────────────────────────────┤
│ libtinfo6    │ CVE-2023-29491 │ MEDIUM   │ 6.3-2                    │ 6.3-2ubuntu0.1    │ Local users can trigger security-relevant memory corruption │
│              │                │          │                          │                   │ via malformed data                                          │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2023-29491                  │
│              ├────────────────┼──────────┤                          │                   ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-29458 │ LOW      │                          │                   │ ncurses: segfaulting OOB read                               │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2022-29458                  │
├──────────────┼────────────────┤          ├──────────────────────────┼───────────────────┼─────────────────────────────────────────────────────────────┤
│ libzstd1     │ CVE-2022-4899  │          │ 1.4.8+dfsg-3build1       │                   │ buffer overrun in util.c                                    │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2022-4899                   │
├──────────────┼────────────────┤          ├──────────────────────────┼───────────────────┼─────────────────────────────────────────────────────────────┤
│ login        │ CVE-2023-29383 │          │ 1:4.8.1-2ubuntu2.1       │                   │ Improper input validation in shadow-utils package utility   │
│              │                │          │                          │                   │ chfn                                                        │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2023-29383                  │
├──────────────┼────────────────┼──────────┼──────────────────────────┼───────────────────┼─────────────────────────────────────────────────────────────┤
│ ncurses-base │ CVE-2023-29491 │ MEDIUM   │ 6.3-2                    │ 6.3-2ubuntu0.1    │ Local users can trigger security-relevant memory corruption │
│              │                │          │                          │                   │ via malformed data                                          │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2023-29491                  │
│              ├────────────────┼──────────┤                          │                   ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-29458 │ LOW      │                          │                   │ ncurses: segfaulting OOB read                               │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2022-29458                  │
├──────────────┼────────────────┼──────────┤                          │                   ├─────────────────────────────────────────────────────────────┤
│ ncurses-bin  │ CVE-2023-29491 │ MEDIUM   │                          │                   │ Local users can trigger security-relevant memory corruption │
│              │                │          │                          │                   │ via malformed data                                          │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2023-29491                  │
│              ├────────────────┼──────────┤                          │                   ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-29458 │ LOW      │                          │                   │ ncurses: segfaulting OOB read                               │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2022-29458                  │
├──────────────┼────────────────┤          ├──────────────────────────┼───────────────────┼─────────────────────────────────────────────────────────────┤
│ passwd       │ CVE-2023-29383 │          │ 1:4.8.1-2ubuntu2.1       │                   │ Improper input validation in shadow-utils package utility   │
│              │                │          │                          │                   │ chfn                                                        │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2023-29383                  │
├──────────────┼────────────────┼──────────┼──────────────────────────┼───────────────────┼─────────────────────────────────────────────────────────────┤
│ perl-base    │ CVE-2023-31484 │ MEDIUM   │ 5.34.0-3ubuntu1.1        │                   │ CPAN.pm before 2.35 does not verify TLS certificates when   │
│              │                │          │                          │                   │ downloading ......                                          │
│              │                │          │                          │                   │ https://avd.aquasec.com/nvd/cve-2023-31484                  │
└──────────────┴────────────────┴──────────┴──────────────────────────┴───────────────────┴─────────────────────────────────────────────────────────────┘

app/hermes (gobinary)

Total: 2 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 1, CRITICAL: 0)

┌──────────────────┬────────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────┐
│     Library      │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                          Title                          │
├──────────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────┤
│ golang.org/x/net │ CVE-2022-41723 │ HIGH     │ v0.3.0            │ 0.7.0         │ avoid quadratic complexity in HPACK decoding            │
│                  │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-41723              │
│                  ├────────────────┼──────────┤                   ├───────────────┼─────────────────────────────────────────────────────────┤
│                  │ CVE-2022-41717 │ MEDIUM   │                   │ 0.4.0         │ excessive memory growth in a Go server accepting HTTP/2 │
│                  │                │          │                   │               │ requests                                                │
│                  │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-41717              │
└──────────────────┴────────────────┴──────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────┘
```
</details>