### PR TITLE
Tweak ProductSelect placeholder text and element width

### DIFF
--- a/web/app/components/inputs/product-select/index.hbs
+++ b/web/app/components/inputs/product-select/index.hbs
@@ -40,8 +40,11 @@
           >
             <FlightIcon @name={{or (get-product-id @selected) "folder"}} />
 
-            <span class="product-select-selected-value">
-              {{or @selected "--"}}
+            <span
+              class="product-select-selected-value
+                {{unless @selected 'text-color-foreground-faint'}}"
+            >
+              {{or @selected "Select a product/area"}}
             </span>
 
             {{#if this.selectedProductAbbreviation}}

--- a/web/app/styles/components/inputs/product-select/index.scss
+++ b/web/app/styles/components/inputs/product-select/index.scss
@@ -3,7 +3,7 @@
 }
 
 .product-select-default-toggle {
-  @apply min-w-[250px] relative flex items-center justify-start leading-none;
+  @apply min-w-[300px] relative flex items-center justify-start leading-none;
 }
 
 .product-select-toggle-abbreviation {

--- a/web/tests/acceptance/authenticated/new/doc-test.ts
+++ b/web/tests/acceptance/authenticated/new/doc-test.ts
@@ -40,7 +40,7 @@ module("Acceptance | authenticated/new/doc", function (hooks) {
     const thumbnailBadgeSelector = "[data-test-doc-thumbnail-product-badge]";
 
     assert.dom(toggleSelector).exists();
-    assert.dom(`${toggleSelector} span`).hasText("--");
+    assert.dom(`${toggleSelector} span`).hasText("Select a product/area");
     assert
       .dom(`${toggleSelector} .flight-icon`)
       .hasAttribute("data-test-icon", "folder");

--- a/web/tests/integration/components/inputs/product-select/index-test.ts
+++ b/web/tests/integration/components/inputs/product-select/index-test.ts
@@ -80,7 +80,9 @@ module("Integration | Component | inputs/product-select", function (hooks) {
         @onChange={{this.onChange}}
       />
     `);
-    assert.dom(".product-select-selected-value").hasText("--");
+    assert
+      .dom(".product-select-selected-value")
+      .hasText("Select a product/area");
   });
 
   test("it displays the products in a dropdown list with abbreviations", async function (this: InputsProductSelectContext, assert) {


### PR DESCRIPTION
Changes the ProductSelect's placeholder text from "--" to "Select a product/area." Updates the button width to be consistent with the PeopleSelect below it.