### PR TITLE
Add most type definitions for most HDS components

### DIFF
--- a/web/app/components/modals/doc-created.hbs
+++ b/web/app/components/modals/doc-created.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{#if this.modalIsShown}}
   <Hds::Modal data-test-doc-created-modal as |M|>
     <M.Header>
@@ -17,7 +16,7 @@
         <Hds::Link::Inline
           @icon="external-link"
           @iconPosition="trailing"
-          @hrefIsExternal={{true}}
+          @isHrefExternal={{true}}
           @href="https://support.google.com/docs/answer/91588"
         >manage your notifications</Hds::Link::Inline>
         on Google.

--- a/web/types/glint/index.d.ts
+++ b/web/types/glint/index.d.ts
@@ -6,10 +6,29 @@ import WillDestroyModifier from "ember-render-modifiers/modifiers/will-destroy";
 import AndHelper from "ember-truth-helpers/helpers/and";
 import EqHelper from "ember-truth-helpers/helpers/eq";
 import IsEmptyHelper from "ember-truth-helpers/helpers/is-empty";
-import LtHelper from "ember-truth-helpers/helpers/lt";
 import NotHelper from "ember-truth-helpers/helpers/not";
 import OrHelper from "ember-truth-helpers/helpers/or";
 import { FlightIconComponent } from "hds/flight-icon";
+import { HdsButtonComponent } from "hds/button";
+import { HdsBadgeCountComponent } from "hds/badge-count";
+import { HdsFormTextInputBaseComponent } from "hds/form/text-input/base";
+import { HdsFormTextInputFieldComponent } from "hds/form/text-input/field";
+import { HdsAlertComponent } from "hds/alert";
+import { HdsLinkInlineComponent } from "hds/link/inline";
+import { HdsLinkStandaloneComponent } from "hds/link/standalone";
+import { HdsModalComponent } from "hds/modal";
+import { HdsFormCheckboxFieldComponent } from "hds/form/checkbox/fields";
+import { HdsFormTextareaFieldComponent } from "hds/form/textarea/field";
+import { HdsFormToggleBaseComponent } from "hds/form/toggle/base";
+import { HdsFormFieldComponent } from "hds/form/field";
+import { HdsToastComponent } from "hds/toast";
+import { HdsBadgeComponent } from "hds/badge";
+import { HdsButtonSetComponent } from "hds/button-set";
+import { HdsIconTileComponent } from "hds/icon-tile";
+import { HdsCardContainerComponent } from "hds/card/container";
+import { HdsTableTdComponent } from "hds/table/td";
+import { HdsTableTrComponent } from "hds/table/tr";
+import { HdsTableComponent } from "hds/table";
 
 declare module "@glint/environment-ember-loose/registry" {
   export default interface Registry {
@@ -21,8 +40,27 @@ declare module "@glint/environment-ember-loose/registry" {
     eq: typeof EqHelper;
     and: typeof AndHelper;
     not: typeof NotHelper;
-    lt: typeof LtHelper
     "is-empty": IsEmptyHelper;
     FlightIcon: FlightIconComponent;
+    "Hds::Button": HdsButtonComponent;
+    "Hds::BadgeCount": HdsBadgeCountComponent;
+    "Hds::Form::TextInput::Base": HdsFormTextInputBaseComponent;
+    "Hds::Form::TextInput::Field": HdsFormTextInputFieldComponent;
+    "Hds::Alert": HdsAlertComponent;
+    "Hds::Link::Inline": HdsLinkInlineComponent;
+    "Hds::Link::Standalone": HdsLinkStandaloneComponent;
+    "Hds::Modal": HdsModalComponent;
+    "Hds::Form::Checkbox::Field": HdsFormCheckboxFieldComponent;
+    "Hds::Form::Textarea::Field": HdsFormTextareaFieldComponent;
+    "Hds::Form::Toggle::Base": HdsFormToggleBaseComponent;
+    "Hds::Form::Field": HdsFormFieldComponent;
+    "Hds::Toast": HdsToastComponent;
+    "Hds::Badge": HdsBadgeComponent;
+    "Hds::ButtonSet": HdsButtonSetComponent;
+    "Hds::IconTile": HdsIconTileComponent;
+    "Hds::Card::Container": HdsCardContainerComponent;
+    "Hds::Table::Td": HdsTableTdComponent;
+    "Hds::Table::Tr": HdsTableTrComponent;
+    "Hds::Table": HdsTableComponent;
   }
 }

--- a/web/types/hds/_shared.ts
+++ b/web/types/hds/_shared.ts
@@ -1,0 +1,69 @@
+export interface HdsAnchorComponentArgs {
+  icon?: string;
+  iconPosition?: HdsIconPosition;
+  href?: string;
+  isHrefExternal?: boolean;
+  route?: string;
+  models?: unknown[];
+  model?: unknown;
+  query?: Record<string, unknown>;
+  "current-when"?: string;
+  replace?: boolean;
+}
+
+export type HdsAlertColor =
+  | "neutral"
+  | "highlight"
+  | "success"
+  | "warning"
+  | "critical";
+
+export type HdsBadgeColor =
+  | "neutral"
+  | "neutral-dark-more"
+  | "highlight"
+  | "critical"
+  | "success"
+  | "warning";
+export type HdsBadgeCountColor = "neutral" | "neutral-dark-more";
+export type HdsBadgeType = "filled" | "inverted" | "outlined";
+export type HdsButtonColor = "primary" | "secondary" | "tertiary" | "critical";
+
+export type HdsCardBackgroundColor = "neutral-primary" | "neutral-secondary";
+export type HdsComponentOverflow = "hidden" | "visible";
+export type HdsComponentSize = "small" | "medium" | "large";
+export type HdsComponentShadowLevel = "base" | "mid" | "high";
+
+export type HdsFormFieldLayout = "vertical" | "flag";
+
+export type HdsIconPosition = "leading" | "trailing";
+export type HdsIconTileColor =
+  | "neutral"
+  | "boundary"
+  | "consul"
+  | "nomad"
+  | "packer"
+  | "terraform"
+  | "vagrant"
+  | "vault"
+  | "waypoint";
+
+export type HdsLinkColor = "primary" | "secondary";
+
+export type HdsModalColor = "neutral" | "warning" | "critical";
+
+export type HdsProductLogoName =
+  | "hcp"
+  | "boundary"
+  | "consul"
+  | "nomad"
+  | "packer"
+  | "terraform"
+  | "vagrant"
+  | "vault"
+  | "waypoint";
+
+export type HdsTableDensity = "short" | "medium" | "tall";
+export type HdsTableHorizontalAlignment = "left" | "center" | "right";
+export type HdsTableSortOrder = "asc" | "desc";
+export type HdsTableVerticalAlignment = "top" | "middle";

--- a/web/types/hds/alert.d.ts
+++ b/web/types/hds/alert.d.ts
@@ -1,0 +1,33 @@
+// https://helios.hashicorp.design/components/alert?tab=code#component-api
+
+import { ComponentLike } from "@glint/template";
+import {
+  HdsButtonColor,
+  HdsIconPosition,
+  HdsComponentSize,
+  HdsAlertColor,
+} from "hds/_shared";
+
+interface HdsAlertComponentSignature {
+  Element: HTMLDivElement;
+  Args: {
+    type: "page" | "inline" | "compact";
+    color?: HdsAlertColor;
+    icon?: string | false;
+    onDismiss?: () => void;
+  };
+  Blocks: {
+    default: [
+      A: {
+        // TODO: Type these
+        Title: any;
+        Description: any;
+        Button: any;
+        "Link::Standalone": any;
+        Generic: any;
+      }
+    ];
+  };
+}
+
+export type HdsAlertComponent = ComponentLike<HdsAlertComponentSignature>;

--- a/web/types/hds/badge-count.d.ts
+++ b/web/types/hds/badge-count.d.ts
@@ -1,0 +1,18 @@
+//helios.hashicorp.design/components/badge-count?tab=code#component-api
+
+import { ComponentLike } from "@glint/template";
+import { HdsBadgeCountColor, HdsBadgeType } from "hds/_shared";
+import { HdsBadgeCountSize } from "hermes/types/HdsBadgeCountSize";
+
+interface HdsBadgeCountComponentSignature {
+  Element: HTMLDivElement;
+  Args: {
+    text: string;
+    size?: HdsBadgeCountSize;
+    type?: HdsBadgeType;
+    color?: HdsBadgeCountColor;
+  };
+}
+
+export type HdsBadgeCountComponent =
+  ComponentLike<HdsBadgeCountComponentSignature>;

--- a/web/types/hds/badge.d.ts
+++ b/web/types/hds/badge.d.ts
@@ -1,0 +1,22 @@
+// https://helios.hashicorp.design/components/badge?tab=code#component-api
+
+import { ComponentLike } from "@glint/template";
+import {
+  HdsBadgeColor,
+  HdsBadgeType,
+  HdsComponentSize,
+} from "hds/_shared";
+
+interface HdsBadgeComponentSignature {
+  Element: HTMLDivElement;
+  Args: {
+    color?: HdsBadgeColor;
+    type?: HdsBadgeType;
+    size?: HdsComponentSize;
+    text?: string;
+    icon?: string;
+    isIconOnly?: boolean;
+  };
+}
+
+export type HdsBadgeComponent = ComponentLike<HdsBadgeComponentSignature>;

--- a/web/types/hds/button-set.d.ts
+++ b/web/types/hds/button-set.d.ts
@@ -1,0 +1,11 @@
+// https://helios.hashicorp.design/components/button-set?tab=code#component-api
+
+import { ComponentLike } from "@glint/template";
+
+interface HdsButtonSetComponentSignature {
+  Element: HTMLDivElement;
+  Args: {};
+}
+
+export type HdsButtonSetComponent =
+  ComponentLike<HdsButtonSetComponentSignature>;

--- a/web/types/hds/button-set.d.ts
+++ b/web/types/hds/button-set.d.ts
@@ -5,6 +5,9 @@ import { ComponentLike } from "@glint/template";
 interface HdsButtonSetComponentSignature {
   Element: HTMLDivElement;
   Args: {};
+  Blocks: {
+    default: [];
+  }
 }
 
 export type HdsButtonSetComponent =

--- a/web/types/hds/button.d.ts
+++ b/web/types/hds/button.d.ts
@@ -1,0 +1,23 @@
+// https://helios.hashicorp.design/components/button?tab=code#component-api
+
+import { ComponentLike } from "@glint/template";
+import {
+  HdsButtonColor,
+  HdsIconPosition,
+  HdsComponentSize,
+  HdsAnchorComponentArgs,
+} from "hds/_shared";
+
+interface HdsButtonComponentSignature {
+  Element: HTMLButtonElement;
+  Args: HdsAnchorComponentArgs & {
+    text: string;
+    size?: HdsComponentSize;
+    color?: HdsButtonColor;
+    isIconOnly?: boolean;
+    isFullWidth?: boolean;
+    isRouteExternal?: boolean;
+  };
+}
+
+export type HdsButtonComponent = ComponentLike<HdsButtonComponentSignature>;

--- a/web/types/hds/card/container.d.ts
+++ b/web/types/hds/card/container.d.ts
@@ -1,0 +1,19 @@
+// https://helios.hashicorp.design/components/card?tab=code#component-api
+
+import { ComponentLike } from "@glint/template";
+import { HdsCardBackgroundColor, HdsComponentOverflow, HdsComponentShadowLevel } from "hds/_shared";
+
+interface HdsCardContainerComponentSignature {
+  Element: HTMLDivElement;
+  Args: {
+    level?: HdsComponentShadowLevel;
+    levelHover?: HdsComponentShadowLevel;
+    levelActive?: HdsComponentShadowLevel;
+    background?: HdsCardBackgroundColor;
+    hasBorder?: boolean;
+    overflow?: HdsComponentOverflow;
+  };
+}
+
+export type HdsCardContainerComponent =
+  ComponentLike<HdsCardContainerComponentSignature>;

--- a/web/types/hds/dropdown.d.ts
+++ b/web/types/hds/dropdown.d.ts
@@ -1,0 +1,22 @@
+// https://helios.hashicorp.design/components/toast?tab=code#component-api
+
+import { ComponentLike } from "@glint/template";
+import {
+  HdsBadgeColor,
+  HdsBadgeType,
+  HdsComponentSize,
+} from "hermes/enums/hds-components";
+
+interface HdsBadgeComponentSignature {
+  Element: HTMLDivElement;
+  Args: {
+    color?: HdsBadgeColor;
+    type?: HdsBadgeType;
+    size?: HdsComponentSize;
+    text?: string;
+    icon?: string;
+    isIconOnly?: boolean;
+  };
+}
+
+export type HdsBadgeComponent = ComponentLike<HdsBadgeComponentSignature>;

--- a/web/types/hds/form/checkbox/fields.d.ts
+++ b/web/types/hds/form/checkbox/fields.d.ts
@@ -1,0 +1,24 @@
+// https://helios.hashicorp.design/components/form/checkbox?tab=code#formcheckboxfield-1
+
+import { ComponentLike } from "@glint/template";
+
+interface HdsFormCheckboxFieldComponentSignature {
+  Element: HTMLInputElement;
+  Args: {
+    id?: string;
+    extraDescribedBy?: string;
+  };
+  Blocks: {
+    default: [
+      F: {
+        // TODO: Type these
+        Label: any;
+        Error: any;
+        HelperText: any;
+      }
+    ];
+  }
+}
+
+export type HdsFormCheckboxFieldComponent =
+  ComponentLike<HdsFormCheckboxFieldComponentSignature>;

--- a/web/types/hds/form/field.d.ts
+++ b/web/types/hds/form/field.d.ts
@@ -1,0 +1,29 @@
+// https://helios.hashicorp.design/components/form/primitives?tab=code#formfield-1
+
+import { ComponentLike } from "@glint/template";
+import { HdsFormFieldLayout } from "hds/_shared";
+
+interface HdsFormFieldComponentSignature {
+  Element: HTMLDivElement;
+  Args: {
+    layout?: HdsFormFieldLayout;
+    id?: string;
+    extraDescribedBy?: string;
+    isRequired?: boolean;
+    isOptional?: boolean;
+  };
+  Blocks: {
+    default: [
+      F: {
+        // TODO: Type these
+        Label: any;
+        HelperText: any;
+        Error: any;
+        Control: any;
+      }
+    ];
+  };
+}
+
+export type HdsFormFieldComponent =
+  ComponentLike<HdsFormFieldComponentSignature>;

--- a/web/types/hds/form/text-input/base.d.ts
+++ b/web/types/hds/form/text-input/base.d.ts
@@ -1,0 +1,16 @@
+// https://helios.hashicorp.design/components/form/text-input?tab=code#formtextinputbase-1
+import { ComponentLike } from "@glint/template";
+import { HdsFormTextInputArgs } from ".";
+
+export interface HdsFormTextInputBaseComponentSignature {
+  Element: HTMLInputElement;
+  Args: {
+    type: string;
+    value: string | number | Date;
+    isInvalid?: boolean;
+    width?: string;
+  };
+}
+
+export type HdsFormTextInputBaseComponent =
+  ComponentLike<HdsFormTextInputBaseComponentSignature>;

--- a/web/types/hds/form/text-input/field.d.ts
+++ b/web/types/hds/form/text-input/field.d.ts
@@ -1,0 +1,27 @@
+// https://helios.hashicorp.design/components/form/text-input?tab=code#formtextinputfield-1
+
+import { ComponentLike } from "@glint/template";
+import { HdsFormTextInputBaseSignature } from "./base";
+
+interface HdsFormTextInputFieldComponentSignature {
+  Element: HdsFormTextInputBaseComponentSignature["Element"];
+  Args: HdsFormTextInputBaseComponentSignature["Args"] & {
+    isRequired?: boolean;
+    isOptional?: boolean;
+    id?: string;
+    extraAriaDescribedBy?: string;
+  };
+  Blocks: {
+    default: [
+      F: {
+        // TODO: Type these
+        Label: any;
+        HelperText: any;
+        Error: any;
+      }
+    ];
+  };
+}
+
+export type HdsFormTextInputFieldComponent =
+  ComponentLike<HdsFormTextInputFieldComponentSignature>;

--- a/web/types/hds/form/textarea/field.d.ts
+++ b/web/types/hds/form/textarea/field.d.ts
@@ -1,0 +1,27 @@
+// https://helios.hashicorp.design/components/form/textarea?tab=code#formtextareafield-1
+
+import { ComponentLike } from "@glint/template";
+
+interface HdsFormTextareaFieldComponentSignature {
+  Element: HTMLTextAreaElement;
+  Args: {
+    id?: string;
+    isInvalid?: boolean;
+    isRequired?: boolean;
+    isOptional?: boolean;
+    extraAriaDescribedBy?: string;
+  };
+  Blocks: {
+    default: [
+      F: {
+        // TODO: Type these
+        Label: any;
+        HelperText: any;
+        Error: any;
+      }
+    ];
+  };
+}
+
+export type HdsFormTextareaFieldComponent =
+  ComponentLike<HdsFormTextareaFieldComponentSignature>;

--- a/web/types/hds/form/toggle/base.d.ts
+++ b/web/types/hds/form/toggle/base.d.ts
@@ -1,0 +1,21 @@
+// https://helios.hashicorp.design/components/form/toggle?tab=code#formtogglebase-1
+
+import { ComponentLike } from "@glint/template";
+
+interface HdsFormToggleBaseComponentSignature {
+  Element: HTMLInputElement;
+  Args: {};
+  Blocks: {
+    default: [
+      F: {
+        // TODO: Type these
+        Label: any;
+        HelperText: any;
+        Error: any;
+      }
+    ];
+  };
+}
+
+export type HdsFormToggleBaseComponent =
+  ComponentLike<HdsFormToggleBaseComponentSignature>;

--- a/web/types/hds/icon-tile.d.ts
+++ b/web/types/hds/icon-tile.d.ts
@@ -1,0 +1,21 @@
+// https://helios.hashicorp.design/components/icon-tile?tab=code#component-api
+
+import { ComponentLike } from "@glint/template";
+import {
+  HdsComponentSize,
+  HdsIconTileColor,
+  HdsProductLogoName,
+} from "hds/_shared";
+
+interface HdsIconTileComponentSignature {
+  Element: HTMLDivElement;
+  Args: {
+    size?: HdsComponentSize;
+    logo?: HdsProductLogoName;
+    icon?: string;
+    iconSecondary?: string;
+    color?: HdsIconTileColor;
+  };
+}
+
+export type HdsIconTileComponent = ComponentLike<HdsIconTileComponentSignature>;

--- a/web/types/hds/link/inline.d.ts
+++ b/web/types/hds/link/inline.d.ts
@@ -1,0 +1,20 @@
+// https://helios.hashicorp.design/components/link/inline?tab=code#component-api
+
+import { ComponentLike } from "@glint/template";
+import {
+  HdsAnchorComponentArgs,
+  HdsIconPosition,
+  HdsLinkColor,
+} from "hds/_shared";
+
+export interface HdsLinkComponentSignature {
+  Element: HTMLAnchorElement;
+  Args: HdsAnchorComponentArgs & {
+    color?: HdsLinkColor;
+  };
+  Blocks: {
+    default: [];
+  };
+}
+
+export type HdsLinkInlineComponent = ComponentLike<HdsLinkComponentSignature>;

--- a/web/types/hds/link/standalone.d.ts
+++ b/web/types/hds/link/standalone.d.ts
@@ -1,0 +1,17 @@
+// https://helios.hashicorp.design/components/link/standalone?tab=code#component-api
+
+import { ComponentLike } from "@glint/template";
+import { HdsLinkComponentSignature } from "./inline";
+import { HdsComponentSize } from "hds/_shared";
+
+interface HdsLinkStandaloneComponentSignature {
+  Element: HdsLinkComponentSignature["Element"];
+  Args: HdsLinkComponentSignature["Args"] & {
+    text: string;
+    size?: HdsComponentSize;
+  };
+  Blocks: HdsLinkComponentSignature["Blocks"];
+}
+
+export type HdsLinkStandaloneComponent =
+  ComponentLike<HdsLinkStandaloneSignature>;

--- a/web/types/hds/modal.d.ts
+++ b/web/types/hds/modal.d.ts
@@ -1,0 +1,32 @@
+// https://helios.hashicorp.design/components/modal?tab=code#component-api
+
+import { ComponentLike } from "@glint/template";
+import {
+  HdsComponentSize,
+  HdsIconPosition,
+  HdsLinkColor,
+  HdsModalColor,
+} from "hds/_shared";
+
+export interface HdsModalComponentSignature {
+  Element: HTMLDialogElement;
+  Args: {
+    size?: HdsComponentSize;
+    color?: HdsModalColor;
+    onOpen?: () => void;
+    onClose?: () => void;
+    isDismissDisabled?: boolean;
+  };
+  Blocks: {
+    default: [
+      M: {
+        // TODO: Type these
+        Header: any;
+        Body: any;
+        Footer: any;
+      }
+    ];
+  };
+}
+
+export type HdsModalComponent = ComponentLike<HdsModalComponentSignature>;

--- a/web/types/hds/table/index.d.ts
+++ b/web/types/hds/table/index.d.ts
@@ -1,0 +1,35 @@
+// https://helios.hashicorp.design/components/table?tab=code#table
+
+import { ComponentLike } from "@glint/template";
+import {
+  HdsTableDensity,
+  HdsTableSortOrder,
+  HdsTableVerticalAlignment,
+} from "hds/_shared";
+
+interface HdsTableComponentSignature {
+  Element: HTMLTableElement;
+  Args: {
+    sortBy?: string;
+    sortOrder?: HdsTableSortOrder;
+    isStriped?: boolean;
+    isFixedLayout?: boolean;
+    density?: HdsTableDensity;
+    valign?: HdsTableVerticalAlignment;
+    caption?: string;
+    identityKey?: string;
+    sortedMessageText?: string;
+    onSort?: () => void;
+
+    // TODO: Type these
+    model?: any;
+    columns?: any;
+  };
+  Blocks: {
+    // TODO: Type these
+    head: any;
+    body: any;
+  };
+}
+
+export type HdsTableComponent = ComponentLike<HdsTableComponentSignature>;

--- a/web/types/hds/table/td.d.ts
+++ b/web/types/hds/table/td.d.ts
@@ -1,0 +1,13 @@
+// https://helios.hashicorp.design/components/table?tab=code#tabletd
+
+import { ComponentLike } from "@glint/template";
+import { HdsTableHorizontalAlignment } from "hds/_shared";
+
+interface HdsTableTdComponentSignature {
+  Element: HTMLTableDataCellElement;
+  Args: {
+    align?: HdsTableHorizontalAlignment;
+  };
+}
+
+export type HdsTableTdComponent = ComponentLike<HdsTableTdComponentSignature>;

--- a/web/types/hds/table/tr.d.ts
+++ b/web/types/hds/table/tr.d.ts
@@ -1,0 +1,10 @@
+// https://helios.hashicorp.design/components/table?tab=code#tabletr
+
+import { ComponentLike } from "@glint/template";
+
+interface HdsTableTrComponentSignature {
+  Element: HTMLTableRowElement;
+  Args: {};
+}
+
+export type HdsTableTrComponent = ComponentLike<HdsTableTrComponentSignature>;

--- a/web/types/hds/toast.d.ts
+++ b/web/types/hds/toast.d.ts
@@ -1,0 +1,12 @@
+// https://helios.hashicorp.design/components/toast?tab=code#component-api
+
+import { ComponentLike } from "@glint/template";
+import { HdsAlertComponent } from "./alert";
+
+interface HdsToastComponentSignature {
+  Element: HTMLDivElement;
+  Args: HdsAlertComponent["Args"];
+  Blocks: HdsAlertComponent["Blocks"];
+}
+
+export type HdsToastComponent = ComponentLike<HdsToastComponentSignature>;


### PR DESCRIPTION
Adds mostly complete types for most of the HDS components we're using. For templates already type-checked by Glint, this removes many VSCode underlines and will allow make it much easier to remove `@glint-nocheck` declarations.

I generally skipped the component-like block yields for now, but hopefully we can make time to add them soon.