### PR TITLE
Fix a couple ProductAreaDropdown bugs

### DIFF
--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -236,29 +236,31 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
     });
   }
 
-  updateProduct = restartableTask(async (product: string) => {
-    this.product = product;
-    await this.save.perform("product", this.product);
-  });
+  updateProduct = restartableTask(
+    async (product: string, productAbbreviation: string) => {
+      this.product = product;
+      // TODO: Allow multiple parameters to be patched at once
+      await this.save.perform("product", this.product);
+      await this.save.perform("productAbbreviation", productAbbreviation);
+    }
+  );
 
-  save = task(async (field, val) => {
+  save = task(async (field: string, val: string | HermesUser[]) => {
     if (field && val) {
-      let targetField = field;
-      assert("targetField must exist", targetField);
-      const oldVal = targetField;
-      targetField = cleanString(val);
+      let serializedValue;
+
+      if (typeof val === "string") {
+        serializedValue = cleanString(val);
+      } else {
+        serializedValue = val.map((p: HermesUser) => p.email);
+      }
 
       try {
-        const serializedValue = this.emailFields.includes(field)
-          ? val.map((p: HermesUser) => p.email)
-          : val;
-
         await this.patchDocument.perform({
-          [field]: cleanString(serializedValue),
+          [field]: serializedValue,
         });
       } catch (err) {
-        // revert field value on failure
-        targetField = oldVal;
+        (this as any)[field] = val;
       }
     }
   });

--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -15,7 +15,6 @@ import { AuthenticatedUser } from "hermes/services/authenticated-user";
 import { HermesDocument, HermesUser } from "hermes/types/document";
 import { assert } from "@ember/debug";
 import Route from "@ember/routing/route";
-import { ProductArea } from "../inputs/product-select";
 
 interface DocumentSidebarComponentSignature {
   Args: {
@@ -241,6 +240,7 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
     async (product: string) => {
       this.product = product;
       await this.save.perform("product", this.product);
+      // productAbbreviation is computed by the back end
     }
   );
 

--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -260,7 +260,9 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
           [field]: serializedValue,
         });
       } catch (err) {
+        // revert field value on failure
         (this as any)[field] = val;
+        console.error(err);
       }
     }
   });

--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -15,6 +15,7 @@ import { AuthenticatedUser } from "hermes/services/authenticated-user";
 import { HermesDocument, HermesUser } from "hermes/types/document";
 import { assert } from "@ember/debug";
 import Route from "@ember/routing/route";
+import { ProductArea } from "../inputs/product-select";
 
 interface DocumentSidebarComponentSignature {
   Args: {
@@ -237,11 +238,11 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
   }
 
   updateProduct = restartableTask(
-    async (product: string, productAbbreviation: string) => {
+    async (product: string, productArea: ProductArea) => {
       this.product = product;
       // TODO: Allow multiple parameters to be patched at once
       await this.save.perform("product", this.product);
-      await this.save.perform("productAbbreviation", productAbbreviation);
+      await this.save.perform("productAbbreviation", productArea.abbreviation);
     }
   );
 

--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -238,11 +238,9 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
   }
 
   updateProduct = restartableTask(
-    async (product: string, productArea: ProductArea) => {
+    async (product: string) => {
       this.product = product;
-      // TODO: Allow multiple parameters to be patched at once
       await this.save.perform("product", this.product);
-      await this.save.perform("productAbbreviation", productArea.abbreviation);
     }
   );
 

--- a/web/app/components/inputs/product-select/index.ts
+++ b/web/app/components/inputs/product-select/index.ts
@@ -12,7 +12,7 @@ interface InputsProductSelectSignature {
   Element: HTMLDivElement;
   Args: {
     selected?: string;
-    onChange: (value: string, attributes: ProductArea) => void;
+    onChange: (value: string, attributes?: ProductArea) => void;
     formatIsBadge?: boolean;
     placement?: Placement;
     isSaving?: boolean;
@@ -52,7 +52,7 @@ export default class InputsProductSelectComponent extends Component<InputsProduc
     return selectedProduct.abbreviation;
   }
 
-  @action onChange(newValue: any, attributes: ProductArea) {
+  @action onChange(newValue: any, attributes?: ProductArea) {
     this.selected = newValue;
     this.args.onChange(newValue, attributes);
   }

--- a/web/app/components/inputs/product-select/index.ts
+++ b/web/app/components/inputs/product-select/index.ts
@@ -12,7 +12,7 @@ interface InputsProductSelectSignature {
   Element: HTMLDivElement;
   Args: {
     selected?: string;
-    onChange: (value: string) => void;
+    onChange: (value: string, attributes: ProductArea) => void;
     formatIsBadge?: boolean;
     placement?: Placement;
     isSaving?: boolean;
@@ -23,7 +23,7 @@ type ProductAreas = {
   [key: string]: ProductArea;
 };
 
-type ProductArea = {
+export type ProductArea = {
   abbreviation: string;
   perDocDataType: unknown;
 };
@@ -43,17 +43,18 @@ export default class InputsProductSelectComponent extends Component<InputsProduc
     return icon;
   }
 
-  get selectedProductAbbreviation(): string | undefined {
+  get selectedProductAbbreviation(): string | null {
     if (!this.selected) {
-      return undefined;
+      return null;
     }
-    assert("products must be loaded", this.products);
-    return this.products[this.selected]?.abbreviation;
+    const selectedProduct = this.products?.[this.selected];
+    assert("products must be loaded", selectedProduct);
+    return selectedProduct.abbreviation;
   }
 
-  @action onChange(newValue: any) {
+  @action onChange(newValue: any, attributes: ProductArea) {
     this.selected = newValue;
-    this.args.onChange(newValue);
+    this.args.onChange(newValue, attributes);
   }
 
   protected fetchProducts = task(async () => {

--- a/web/app/components/inputs/product-select/index.ts
+++ b/web/app/components/inputs/product-select/index.ts
@@ -48,7 +48,7 @@ export default class InputsProductSelectComponent extends Component<InputsProduc
       return null;
     }
     const selectedProduct = this.products?.[this.selected];
-    assert("products must be loaded", selectedProduct);
+    assert("selected product must exist", selectedProduct);
     return selectedProduct.abbreviation;
   }
 

--- a/web/app/components/new/doc-form.ts
+++ b/web/app/components/new/doc-form.ts
@@ -12,6 +12,7 @@ import { HermesUser } from "hermes/types/document";
 import FlashService from "ember-cli-flash/services/flash-messages";
 import { assert } from "@ember/debug";
 import cleanString from "hermes/utils/clean-string";
+import { ProductArea } from "../inputs/product-select";
 
 interface DocFormErrors {
   title: string | null;
@@ -174,10 +175,10 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
 
   @action protected onProductSelect(
     productName: string,
-    productAbbreviation: string
+    attributes: ProductArea
   ) {
     this.productArea = productName;
-    this.productAbbreviation = productAbbreviation;
+    this.productAbbreviation = attributes.abbreviation;
   }
 
   /**

--- a/web/app/components/new/doc-form.ts
+++ b/web/app/components/new/doc-form.ts
@@ -179,6 +179,7 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
   ) {
     this.productArea = productName;
     this.productAbbreviation = attributes.abbreviation;
+    this.maybeValidate();
   }
 
   /**

--- a/web/app/components/x/dropdown-list/index.ts
+++ b/web/app/components/x/dropdown-list/index.ts
@@ -16,7 +16,7 @@ interface XDropdownListComponentSignature {
     selected: any;
     placement?: Placement;
     isSaving?: boolean;
-    onItemClick: (value: any) => void;
+    onItemClick: (value: any, attributes: any) => void;
   };
   Blocks: {
     default: [];

--- a/web/app/components/x/dropdown-list/item.ts
+++ b/web/app/components/x/dropdown-list/item.ts
@@ -14,7 +14,7 @@ interface XDropdownListItemComponentSignature {
     focusedItemIndex: number;
     listItemRole: string;
     hideDropdown: () => void;
-    onItemClick?: (value: any) => void;
+    onItemClick?: (value: any, attributes: any) => void;
     setFocusedItemIndex: (
       focusDirection: FocusDirection | number,
       maybeScrollIntoView?: boolean
@@ -82,7 +82,7 @@ export default class XDropdownListItemComponent extends Component<XDropdownListI
 
   @action onClick() {
     if (this.args.onItemClick) {
-      this.args.onItemClick(this.args.value);
+      this.args.onItemClick(this.args.value, this.args.attributes);
     }
 
     /**

--- a/web/app/components/x/dropdown-list/items.ts
+++ b/web/app/components/x/dropdown-list/items.ts
@@ -16,7 +16,7 @@ interface XDropdownListItemsComponentSignature {
     listItemRole: string;
     scrollContainer: HTMLElement;
     onInput: () => void;
-    onItemClick: () => void;
+    onItemClick: (value: any, attributes?: any) => void;
     registerScrollContainer?: (e: HTMLElement) => void;
     setFocusedItemIndex: (direction: FocusDirection) => void;
     hideContent: () => void;

--- a/web/tests/integration/components/inputs/product-select/index-test.ts
+++ b/web/tests/integration/components/inputs/product-select/index-test.ts
@@ -23,6 +23,11 @@ module("Integration | Component | inputs/product-select", function (hooks) {
 
   hooks.beforeEach(async function (this: InputsProductSelectContext) {
     this.server.createList("product", 3);
+    this.server.create("product", {
+      name: "Vault",
+      abbreviation: "VLT",
+    });
+
     this.set("selected", "Vault");
     this.set("onChange", () => {});
   });
@@ -96,7 +101,7 @@ module("Integration | Component | inputs/product-select", function (hooks) {
 
     await click(DEFAULT_DROPDOWN_SELECTOR);
 
-    assert.dom(LIST_ITEM_SELECTOR).exists({ count: 3 });
+    assert.dom(LIST_ITEM_SELECTOR).exists({ count: 4 });
 
     let firstListItem = this.element.querySelector(LIST_ITEM_SELECTOR);
     assert.dom(firstListItem).hasText("Test Product 0 TP0");
@@ -108,7 +113,6 @@ module("Integration | Component | inputs/product-select", function (hooks) {
     await render(hbs`
       {{! @glint-nocheck: not typesafe yet }}
       <Inputs::ProductSelect
-        @selected={{this.selected}}
         @onChange={{this.onChange}}
       />
     `);


### PR DESCRIPTION
- Adds validation to the form when you select a product (i.e., the "Create Doc on Google" enables on ProductAreaSelect)
- Saves the `productAbbreviation` when creating a new doc (by way of new `attributes` support in `X::DropdownList`
- Improves the revert-on-error logic