### PR TITLE
Lock documents on other types of suggestions in the header

### DIFF
--- a/internal/indexer/refresh_headers.go
+++ b/internal/indexer/refresh_headers.go
@@ -89,7 +89,11 @@ func refreshDocumentHeaders(
 		}
 		lockedDocIDs = append(lockedDocIDs, d.GoogleFileID)
 	}
-	log.Info(fmt.Sprintf("locked document IDs: %v", lockedDocIDs))
+	if ft == draftsFolderType {
+		log.Info(fmt.Sprintf("locked draft document IDs: %v", lockedDocIDs))
+	} else {
+		log.Info(fmt.Sprintf("locked document IDs: %v", lockedDocIDs))
+	}
 
 	// Return if there are no updated documents.
 	if len(docs) == 0 {

--- a/pkg/hashicorpdocs/locked.go
+++ b/pkg/hashicorpdocs/locked.go
@@ -104,15 +104,37 @@ func containsSuggestionInHeader(doc *docs.Document) bool {
 
 	// Navigate through all table contents to look for suggestions.
 	for _, row := range t.TableRows {
+		if len(row.SuggestedDeletionIds) > 0 ||
+			len(row.SuggestedInsertionIds) > 0 ||
+			len(row.SuggestedTableRowStyleChanges) > 0 {
+			// We found a suggestion.
+			return true
+		}
 		for _, cell := range row.TableCells {
+			if len(cell.SuggestedDeletionIds) > 0 ||
+				len(cell.SuggestedInsertionIds) > 0 ||
+				len(cell.SuggestedTableCellStyleChanges) > 0 {
+				return true
+			}
 			for _, content := range cell.Content {
 				if para := content.Paragraph; para != nil {
+					if len(para.SuggestedBulletChanges) > 0 ||
+						len(para.SuggestedParagraphStyleChanges) > 0 ||
+						len(para.SuggestedPositionedObjectIds) > 0 {
+						return true
+					}
 					for _, elem := range para.Elements {
+						if auto := elem.AutoText; auto != nil {
+							if len(auto.SuggestedDeletionIds) > 0 ||
+								len(auto.SuggestedInsertionIds) > 0 ||
+								len(auto.SuggestedTextStyleChanges) > 0 {
+								return true
+							}
+						}
 						if txt := elem.TextRun; txt != nil {
 							if len(txt.SuggestedDeletionIds) > 0 ||
 								len(txt.SuggestedInsertionIds) > 0 ||
 								len(txt.SuggestedTextStyleChanges) > 0 {
-								// We found a suggestion.
 								return true
 							}
 						}

--- a/pkg/hashicorpdocs/locked.go
+++ b/pkg/hashicorpdocs/locked.go
@@ -104,6 +104,7 @@ func containsSuggestionInHeader(doc *docs.Document) bool {
 
 	// Navigate through all table contents to look for suggestions.
 	for _, row := range t.TableRows {
+		// Check table rows for suggestions.
 		if len(row.SuggestedDeletionIds) > 0 ||
 			len(row.SuggestedInsertionIds) > 0 ||
 			len(row.SuggestedTableRowStyleChanges) > 0 {
@@ -111,12 +112,14 @@ func containsSuggestionInHeader(doc *docs.Document) bool {
 			return true
 		}
 		for _, cell := range row.TableCells {
+			// Check table cells for suggestions.
 			if len(cell.SuggestedDeletionIds) > 0 ||
 				len(cell.SuggestedInsertionIds) > 0 ||
 				len(cell.SuggestedTableCellStyleChanges) > 0 {
 				return true
 			}
 			for _, content := range cell.Content {
+				// Check table cell content for suggestions.
 				if para := content.Paragraph; para != nil {
 					if len(para.SuggestedBulletChanges) > 0 ||
 						len(para.SuggestedParagraphStyleChanges) > 0 ||
@@ -124,6 +127,7 @@ func containsSuggestionInHeader(doc *docs.Document) bool {
 						return true
 					}
 					for _, elem := range para.Elements {
+						// Check table cell paragraphs for suggestions.
 						if auto := elem.AutoText; auto != nil {
 							if len(auto.SuggestedDeletionIds) > 0 ||
 								len(auto.SuggestedInsertionIds) > 0 ||


### PR DESCRIPTION
Builds on #182 to lock documents when there are other types of suggestions in the header (which causes the same issue: #181).