### PR TITLE
Fix Toolbar Dropdown offsets

### DIFF
--- a/web/app/components/header/facet-dropdown.hbs
+++ b/web/app/components/header/facet-dropdown.hbs
@@ -2,6 +2,8 @@
 <X::DropdownList
   @items={{@facets}}
   @listIsOrdered={{true}}
+  @offset={{hash mainAxis=3 crossAxis=-5}}
+  @renderOut={{true}}
   class="facet-dropdown-popover"
   {{! @glint-ignore: not typesafe yet }}
   ...attributes

--- a/web/app/components/header/sort-dropdown.hbs
+++ b/web/app/components/header/sort-dropdown.hbs
@@ -4,6 +4,7 @@
   data-test-header-sort-by-dropdown
   @items={{@facets}}
   @placement={{@dropdownPlacement}}
+  @renderOut={{true}}
 >
   <:anchor as |dd|>
     <dd.ToggleButton

--- a/web/app/components/x/dropdown-list/index.ts
+++ b/web/app/components/x/dropdown-list/index.ts
@@ -17,6 +17,7 @@ interface XDropdownListComponentSignature {
     placement?: Placement;
     isSaving?: boolean;
     offset?: OffsetOptions;
+    renderOut?: boolean;
     onItemClick: (value: any, attributes: any) => void;
   };
   // TODO: Replace using Glint's `withBoundArgs` types

--- a/web/app/styles/components/x/dropdown/list-item.scss
+++ b/web/app/styles/components/x/dropdown/list-item.scss
@@ -27,8 +27,8 @@
     }
   }
 
-  &.sort-icon {
-    @apply ml-3 mr-4;
+  .sort-icon {
+    @apply mx-3;
   }
 }
 


### PR DESCRIPTION
- Fixes a regression where the Toolbar dropdowns were inheriting margins from their parent class.
- Fixes icon spacing in the SortBy dropdown