### PR TITLE
Rename some Dropdown-related properties

### DIFF
--- a/web/app/components/header/facet-dropdown.hbs
+++ b/web/app/components/header/facet-dropdown.hbs
@@ -14,12 +14,12 @@
   <:item as |dd|>
     <dd.LinkTo
       @route={{this.currentRouteName}}
-      @query={{get-facet-query-hash @label dd.value dd.attrs.selected}}
+      @query={{get-facet-query-hash @label dd.value dd.attrs.isSelected}}
     >
       <X::DropdownList::CheckableItem
         @value={{dd.value}}
         @count={{dd.attrs.count}}
-        @isSelected={{dd.attrs.selected}}
+        @isSelected={{dd.attrs.isSelected}}
       />
     </dd.LinkTo>
   </:item>

--- a/web/app/components/header/facet-dropdown.hbs
+++ b/web/app/components/header/facet-dropdown.hbs
@@ -19,7 +19,7 @@
       <X::DropdownList::CheckableItem
         @value={{dd.value}}
         @count={{dd.attrs.count}}
-        @selected={{dd.attrs.selected}}
+        @isSelected={{dd.attrs.selected}}
       />
     </dd.LinkTo>
   </:item>

--- a/web/app/components/header/toolbar.ts
+++ b/web/app/components/header/toolbar.ts
@@ -30,7 +30,7 @@ export enum FacetName {
 export interface SortByFacets {
   [name: string]: {
     count: number;
-    selected: boolean;
+    isSelected: boolean;
   };
 }
 
@@ -128,11 +128,11 @@ export default class ToolbarComponent extends Component<ToolbarComponentSignatur
     return {
       Newest: {
         count: 0,
-        selected: this.currentSortByValue === SortByValue.DateDesc,
+        isSelected: this.currentSortByValue === SortByValue.DateDesc,
       },
       Oldest: {
         count: 0,
-        selected: this.currentSortByValue === SortByValue.DateAsc,
+        isSelected: this.currentSortByValue === SortByValue.DateAsc,
       },
     };
   }

--- a/web/app/components/inputs/badge-dropdown-list.hbs
+++ b/web/app/components/inputs/badge-dropdown-list.hbs
@@ -44,7 +44,7 @@
     {{else}}
       <dd.Action data-test-badge-dropdown-list-default-action>
         <X::DropdownList::CheckableItem
-          @selected={{dd.selected}}
+          @isSelected={{dd.isSelected}}
           @value={{dd.value}}
         />
       </dd.Action>

--- a/web/app/components/inputs/badge-dropdown-list.hbs
+++ b/web/app/components/inputs/badge-dropdown-list.hbs
@@ -44,7 +44,7 @@
     {{else}}
       <dd.Action data-test-badge-dropdown-list-default-action>
         <X::DropdownList::CheckableItem
-          @isSelected={{dd.isSelected}}
+          @isSelected={{dd.selected}}
           @value={{dd.value}}
         />
       </dd.Action>

--- a/web/app/components/inputs/badge-dropdown-list.hbs
+++ b/web/app/components/inputs/badge-dropdown-list.hbs
@@ -44,7 +44,7 @@
     {{else}}
       <dd.Action data-test-badge-dropdown-list-default-action>
         <X::DropdownList::CheckableItem
-          @isSelected={{dd.selected}}
+          @isSelected={{dd.isSelected}}
           @value={{dd.value}}
         />
       </dd.Action>

--- a/web/app/components/inputs/product-select/index.hbs
+++ b/web/app/components/inputs/product-select/index.hbs
@@ -19,7 +19,7 @@
           <dd.Action data-test-product-select-badge-dropdown-item>
             <Inputs::ProductSelect::Item
               @product={{dd.value}}
-              @selected={{dd.selected}}
+              @isSelected={{dd.isSelected}}
             />
           </dd.Action>
         </:item>
@@ -62,7 +62,7 @@
           <dd.Action class="pr-5">
             <Inputs::ProductSelect::Item
               @product={{dd.value}}
-              @selected={{dd.selected}}
+              @isSelected={{dd.isSelected}}
               @abbreviation={{dd.attrs.abbreviation}}
             />
           </dd.Action>

--- a/web/app/components/inputs/product-select/index.hbs
+++ b/web/app/components/inputs/product-select/index.hbs
@@ -19,7 +19,7 @@
           <dd.Action data-test-product-select-badge-dropdown-item>
             <Inputs::ProductSelect::Item
               @product={{dd.value}}
-              @isSelected={{dd.selected}}
+              @isSelected={{dd.isSelected}}
             />
           </dd.Action>
         </:item>
@@ -62,7 +62,7 @@
           <dd.Action class="pr-5">
             <Inputs::ProductSelect::Item
               @product={{dd.value}}
-              @isSelected={{dd.selected}}
+              @isSelected={{dd.isSelected}}
               @abbreviation={{dd.attrs.abbreviation}}
             />
           </dd.Action>

--- a/web/app/components/inputs/product-select/item.hbs
+++ b/web/app/components/inputs/product-select/item.hbs
@@ -23,7 +23,7 @@
     </span>
   {{/if}}
 
-  {{#if @selected}}
+  {{#if @isSelected}}
     <FlightIcon
       data-test-product-select-item-selected
       @name="check"

--- a/web/app/components/inputs/product-select/item.hbs
+++ b/web/app/components/inputs/product-select/item.hbs
@@ -1,4 +1,3 @@
-{{!  @glint-nocheck - not typesafe yet }}
 <div
   data-test-product-select-item
   class="relative flex w-full product-select-item"

--- a/web/app/components/inputs/product-select/item.ts
+++ b/web/app/components/inputs/product-select/item.ts
@@ -4,7 +4,7 @@ interface InputsProductSelectItemComponentSignature {
   Element: HTMLDivElement;
   Args: {
     product: string;
-    selected: boolean;
+    isSelected?: boolean;
     abbreviation?: boolean;
   };
 }

--- a/web/app/components/x/dropdown-list/checkable-item.hbs
+++ b/web/app/components/x/dropdown-list/checkable-item.hbs
@@ -1,9 +1,9 @@
 {{! @glint-nocheck - not typesafe yet}}
 <FlightIcon
   data-test-x-dropdown-list-checkable-item-check
-  data-test-is-checked={{@selected}}
+  data-test-is-checked={{@isSelected}}
   @name="check"
-  class="check mr-2.5 {{if @selected 'visible' 'invisible'}}"
+  class="check mr-2.5 {{if @isSelected 'visible' 'invisible'}}"
 />
 <div class="x-dropdown-list-item-value">
   {{@value}}

--- a/web/app/components/x/dropdown-list/checkable-item.ts
+++ b/web/app/components/x/dropdown-list/checkable-item.ts
@@ -2,7 +2,7 @@ import Component from "@glimmer/component";
 
 interface XDropdownListCheckableItemComponentSignature {
   Args: {
-    selected: boolean;
+    isSelected?: boolean;
     value: string;
     count?: number;
   };

--- a/web/app/components/x/dropdown-list/item.hbs
+++ b/web/app/components/x/dropdown-list/item.hbs
@@ -61,7 +61,7 @@
           contentID=@contentID
           value=@value
           attrs=@attributes
-          selected=@isSelected
+          isSelected=@isSelected
         )
       }}
     </MaybeListItem>

--- a/web/app/components/x/dropdown-list/item.hbs
+++ b/web/app/components/x/dropdown-list/item.hbs
@@ -44,7 +44,7 @@
             "x/dropdown-list/action"
             role=@listItemRole
             isAriaSelected=this.isAriaSelected
-            isAriaChecked=@selected
+            isAriaChecked=@isSelected
             registerElement=this.registerElement
             focusMouseTarget=this.focusMouseTarget
             onClick=this.onClick
@@ -53,7 +53,7 @@
             "x/dropdown-list/link-to"
             role=@listItemRole
             isAriaSelected=this.isAriaSelected
-            isAriaChecked=@selected
+            isAriaChecked=@isSelected
             registerElement=this.registerElement
             focusMouseTarget=this.focusMouseTarget
             onClick=this.onClick
@@ -61,7 +61,7 @@
           contentID=@contentID
           value=@value
           attrs=@attributes
-          selected=@selected
+          selected=@isSelected
         )
       }}
     </MaybeListItem>

--- a/web/app/components/x/dropdown-list/item.ts
+++ b/web/app/components/x/dropdown-list/item.ts
@@ -10,7 +10,7 @@ interface XDropdownListItemComponentSignature {
   Args: {
     value: string;
     attributes?: unknown;
-    selected: boolean;
+    isSelected: boolean;
     focusedItemIndex: number;
     listItemRole: string;
     hideDropdown: () => void;

--- a/web/app/components/x/dropdown-list/items.hbs
+++ b/web/app/components/x/dropdown-list/items.hbs
@@ -21,7 +21,7 @@
             @value={{item}}
             @contentID={{@contentID}}
             @attributes={{attrs}}
-            @selected={{eq @selected item}}
+            @isSelected={{eq @selected item}}
             @focusedItemIndex={{@focusedItemIndex}}
             @listItemRole={{@listItemRole}}
             @hideDropdown={{@hideContent}}

--- a/web/app/routes/authenticated/drafts.ts
+++ b/web/app/routes/authenticated/drafts.ts
@@ -121,7 +121,7 @@ export default class DraftsRoute extends Route {
         Object.entries(facets).forEach(([name, facet]) => {
           /**
            * e.g., name === "product"
-           * e.g., facet === { "Vault": { count: 1, selected: false }}
+           * e.g., facet === { "Vault": { count: 1, isSelected: false }}
            */
           this.algolia.markSelected(facet, params[name]);
         });

--- a/web/app/services/algolia.ts
+++ b/web/app/services/algolia.ts
@@ -129,7 +129,7 @@ export default class AlgoliaService extends Service {
         let newVal: FacetRecord = {};
         let mapper = (count: number) => ({
           count,
-          selected: false,
+          isSelected: false,
         });
         for (let prop in val) {
           /**
@@ -140,7 +140,7 @@ export default class AlgoliaService extends Service {
           if (valProp) {
             /**
              * Use the mapper to transform the count into a `FacetDropdownObjectDetails` object:
-             * { "meg@hashicorp.com": { count: 10, selected: false }}
+             * { "meg@hashicorp.com": { count: 10, isSelected: false }}
              */
             newVal[prop] = mapper(valProp);
           }
@@ -153,11 +153,11 @@ export default class AlgoliaService extends Service {
     /**
      * e.g., entries === {
      *  owners: {
-     *   "meg@hashicorp.com": { count: 10, selected: false },
+     *   "meg@hashicorp.com": { count: 10, isSelected: false },
      *  },
      *  status: {
-     *    Obsolete: { count: 4, selected: false },
-     *    Approved: { count: 6, selected: false },
+     *    Obsolete: { count: 4, isSelected: false },
+     *    Approved: { count: 6, isSelected: false },
      *  }, and so on ...
      * }
      */
@@ -170,8 +170,8 @@ export default class AlgoliaService extends Service {
   markSelected = (facet: FacetRecord, selection?: string[]): void => {
     /**
      * e.g., facet === {
-     *  Obsolete: { count: 4, selected: false },
-     *  Approved: { count: 6, selected: false },
+     *  Obsolete: { count: 4, isSelected: false },
+     *  Approved: { count: 6, isSelected: false },
      * }
      */
     if (selection) {
@@ -179,10 +179,10 @@ export default class AlgoliaService extends Service {
        * e.g., selection === ["Approved"]
        */
       for (let param of selection) {
-        (facet[param] as FacetDropdownObjectDetails).selected = true;
+        (facet[param] as FacetDropdownObjectDetails).isSelected = true;
       }
       /**
-       * e.g., facet["Approved"] === { count: 6, selected: true }
+       * e.g., facet["Approved"] === { count: 6, isSelected: true }
        */
     }
   };
@@ -289,7 +289,7 @@ export default class AlgoliaService extends Service {
         Object.entries(facets).forEach(([name, facet]) => {
           /**
            * e.g., name === "owner"
-           * e.g., facet === { "meg@hashicorp.com": { count: 1, selected: false }}
+           * e.g., facet === { "meg@hashicorp.com": { count: 1, isSelected: false }}
            */
           this.markSelected(facet, params[name]);
         });

--- a/web/app/types/facets.d.ts
+++ b/web/app/types/facets.d.ts
@@ -1,25 +1,25 @@
 import { FacetName } from "hermes/components/header/toolbar";
 
 /**
- * E.g., { docType: { "API": { count: 1, selected: false }}}
+ * E.g., { docType: { "API": { count: 1, isSelected: false }}}
  */
 export type FacetDropdownGroups = {
   [name in FacetName]: FacetDropdownObjects;
 };
 
 /**
- * E.g., { "API": { count: 1, selected: false }}
+ * E.g., { "API": { count: 1, isSelected: false }}
  */
 export interface FacetDropdownObjects {
   [key: string]: FacetDropdownObjectDetails;
 }
 
 /**
- * E.g., {count: 1, selected: false}
+ * E.g., {count: 1, isSelected: false}
  */
 export type FacetDropdownObjectDetails = {
   count: number;
-  selected: boolean;
+  isSelected: boolean;
 };
 
 export type FacetRecord = Record<string, FacetDropdownObjectDetails>;

--- a/web/app/utils/facets.js
+++ b/web/app/utils/facets.js
@@ -23,7 +23,7 @@ export const mapKeys = (obj, mapper) =>
  * to an object that has count and selected properties
  */
 export const statefulFacet = (facet) =>
-  mapKeys(facet, (count) => ({ count, selected: false }));
+  mapKeys(facet, (count) => ({ count, isSelected: false }));
 
 export const markSelected = (facet, selection) =>
-  (selection || []).forEach((param) => (facet[param].selected = true));
+  (selection || []).forEach((param) => (facet[param].isSelected = true));

--- a/web/tests/integration/components/header/toolbar-test.ts
+++ b/web/tests/integration/components/header/toolbar-test.ts
@@ -7,14 +7,14 @@ import { SortByLabel } from "hermes/components/header/toolbar";
 
 const FACETS = {
   docType: {
-    RFC: { count: 1, selected: false },
+    RFC: { count: 1, isSelected: false },
   },
   owners: {
-    ["mishra@hashicorp.com"]: { count: 8, selected: false },
+    ["mishra@hashicorp.com"]: { count: 8, isSelected: false },
   },
-  product: { Labs: { count: 9, selected: false } },
+  product: { Labs: { count: 9, isSelected: false } },
   status: {
-    Approved: { count: 3, selected: false },
+    Approved: { count: 3, isSelected: false },
   },
 };
 
@@ -88,7 +88,7 @@ module("Integration | Component | header/toolbar", function (hooks) {
     let statusFacets: FacetDropdownObjects = {};
 
     STATUS_NAMES.forEach((status) => {
-      statusFacets[status] = { count: 1, selected: false };
+      statusFacets[status] = { count: 1, isSelected: false };
     });
 
     this.set("facets", { status: statusFacets });

--- a/web/tests/integration/components/inputs/badge-dropdown-list-test.ts
+++ b/web/tests/integration/components/inputs/badge-dropdown-list-test.ts
@@ -108,7 +108,7 @@ module(
           <:item as |dd|>
             <dd.Action>
               {{dd.value}}
-              {{#if dd.selected}}
+              {{#if dd.isSelected}}
                 <span>(selected)</span>
               {{/if}}
             </dd.Action>

--- a/web/tests/integration/components/inputs/badge-dropdown-list-test.ts
+++ b/web/tests/integration/components/inputs/badge-dropdown-list-test.ts
@@ -107,7 +107,7 @@ module(
           <:item as |dd|>
             <dd.Action>
               {{dd.value}}
-              {{#if dd.selected}}
+              {{#if dd.isSelected}}
                 <span>(selected)</span>
               {{/if}}
             </dd.Action>

--- a/web/tests/integration/components/inputs/badge-dropdown-list-test.ts
+++ b/web/tests/integration/components/inputs/badge-dropdown-list-test.ts
@@ -80,7 +80,6 @@ module(
         ["Waypoint", "Labs", "Boundary"],
         "correct list items are rendered"
       );
-
       assert
         .dom(
           `${ITEM_SELECTOR}:nth-child(2) [data-test-x-dropdown-list-checkable-item-check]`
@@ -108,7 +107,7 @@ module(
           <:item as |dd|>
             <dd.Action>
               {{dd.value}}
-              {{#if dd.isSelected}}
+              {{#if dd.selected}}
                 <span>(selected)</span>
               {{/if}}
             </dd.Action>

--- a/web/tests/integration/components/inputs/product-select/item-test.ts
+++ b/web/tests/integration/components/inputs/product-select/item-test.ts
@@ -19,13 +19,13 @@ module(
 
     test("it functions as expected", async function (this: InputsProductSelectItemContext, assert) {
       this.set("product", "Vault");
-      this.set("selected", false);
+      this.set("isSelected", false);
 
       await render(hbs`
       {{! @glint-nocheck: not typesafe yet }}
       <Inputs::ProductSelect::Item
         @product={{this.product}}
-        @isSelected={{this.selected}}
+        @isSelected={{this.isSelected}}
       />
     `);
 
@@ -51,7 +51,7 @@ module(
         .doesNotExist("check icon only rendered when selected");
 
       this.set("product", "Engineering");
-      this.set("selected", true);
+      this.set("isSelected", true);
 
       assert
         .dom("[data-test-product-select-item-icon]")
@@ -60,7 +60,6 @@ module(
           "folder",
           "the correct product icon is shown"
         );
-
     });
   }
 );

--- a/web/tests/integration/components/inputs/product-select/item-test.ts
+++ b/web/tests/integration/components/inputs/product-select/item-test.ts
@@ -7,7 +7,7 @@ import { MirageTestContext } from "ember-cli-mirage/test-support";
 
 interface InputsProductSelectItemContext extends MirageTestContext {
   product: string;
-  selected: boolean;
+  isSelected?: boolean;
   abbreviation?: boolean;
 }
 
@@ -25,7 +25,7 @@ module(
       {{! @glint-nocheck: not typesafe yet }}
       <Inputs::ProductSelect::Item
         @product={{this.product}}
-        @selected={{this.selected}}
+        @isSelected={{this.selected}}
       />
     `);
 

--- a/web/tests/integration/components/x/dropdown-list/checkable-item-test.ts
+++ b/web/tests/integration/components/x/dropdown-list/checkable-item-test.ts
@@ -10,12 +10,12 @@ module("Integration | Component | x/dropdown-list", function (hooks) {
   setupRenderingTest(hooks);
 
   test("it renders as expected", async function (assert) {
-    this.set("selected", false);
+    this.set("isSelected", false);
     this.set("count", null);
 
     await render(hbs`
       <X::DropdownList::CheckableItem
-        @isSelected={{this.selected}}
+        @isSelected={{this.isSelected}}
         @value="foo"
         @count={{this.count}}
       />
@@ -25,7 +25,7 @@ module("Integration | Component | x/dropdown-list", function (hooks) {
     assert.dom(".x-dropdown-list-item-value").hasText("foo");
     assert.dom(COUNT_SELECTOR).doesNotExist();
 
-    this.set("selected", true);
+    this.set("isSelected", true);
 
     assert.dom(CHECK_SELECTOR).hasClass("visible");
 

--- a/web/tests/integration/components/x/dropdown-list/checkable-item-test.ts
+++ b/web/tests/integration/components/x/dropdown-list/checkable-item-test.ts
@@ -15,7 +15,7 @@ module("Integration | Component | x/dropdown-list", function (hooks) {
 
     await render(hbs`
       <X::DropdownList::CheckableItem
-        @selected={{this.selected}}
+        @isSelected={{this.selected}}
         @value="foo"
         @count={{this.count}}
       />

--- a/web/tests/integration/components/x/dropdown-list/index-test.ts
+++ b/web/tests/integration/components/x/dropdown-list/index-test.ts
@@ -16,18 +16,18 @@ import htmlElement from "hermes/utils/html-element";
 // TODO: Replace with Mirage factories
 
 export const SHORT_ITEM_LIST = {
-  Filter01: { count: 1, selected: false },
-  Filter02: { count: 1, selected: false },
-  Filter03: { count: 1, selected: false },
+  Filter01: { count: 1, isSelected: false },
+  Filter02: { count: 1, isSelected: false },
+  Filter03: { count: 1, isSelected: false },
 };
 
 export const LONG_ITEM_LIST = {
   ...SHORT_ITEM_LIST,
-  Filter04: { count: 1, selected: false },
-  Filter05: { count: 1, selected: false },
-  Filter06: { count: 1, selected: false },
-  Filter07: { count: 1, selected: false },
-  Filter08: { count: 1, selected: false },
+  Filter04: { count: 1, isSelected: false },
+  Filter05: { count: 1, isSelected: false },
+  Filter06: { count: 1, isSelected: false },
+  Filter07: { count: 1, isSelected: false },
+  Filter08: { count: 1, isSelected: false },
 };
 
 const CONTAINER_CLASS = "x-dropdown-list";
@@ -648,7 +648,7 @@ module("Integration | Component | x/dropdown-list", function (hooks) {
     this.set("items", {
       "View all items": {
         count: 1,
-        selected: false,
+        isSelected: false,
         itemShouldRenderOut: true,
       },
       ...SHORT_ITEM_LIST,


### PR DESCRIPTION
Changes the name of some `selected` properties to `isSelected` to differentiate them from other `selected` properties. 

In the context of DropdownLists, we use `selected` in two ways: 

1. "Among a list, which item(s) [are] selected?"
2. "Is this item selected?"

It's hard to remember which one is which, so I'm renaming the latter cases.

Here's a quick visualization of the changes:
![CleanShot 2023-06-22 at 10 01 34@2x](https://github.com/hashicorp-forge/hermes/assets/754957/ad1b8f86-7342-447d-9727-ca5913963907)