### PR TITLE
Add `TruncatedText` component

### DIFF
--- a/web/app/components/truncated-text.hbs
+++ b/web/app/components/truncated-text.hbs
@@ -1,4 +1,11 @@
+{{!
+  Truncates a single line of text with a small, gray, regularly weighted ellipsis.
+  Reduces the visual emphasis of ellipses when working with medium-sized, dark, bold text.
+  Not recommended for display type in its current configuration.
+ }}
+
 {{! @glint-ignore - element helper not yet typed }}
+
 {{#let (element (or @tagName "p")) as |Container|}}
   <Container class="truncated-text-container">
     <span class="overflow-hidden" ...attributes>

--- a/web/app/components/truncated-text.hbs
+++ b/web/app/components/truncated-text.hbs
@@ -1,0 +1,8 @@
+{{! @glint-ignore - element helper not yet typed }}
+{{#let (element (or @tagName "p")) as |Container|}}
+  <Container class="truncated-text-container">
+    <span class="overflow-hidden" ...attributes>
+      {{yield}}
+    </span>
+  </Container>
+{{/let}}

--- a/web/app/components/truncated-text.ts
+++ b/web/app/components/truncated-text.ts
@@ -1,0 +1,19 @@
+import Component from "@glimmer/component";
+
+interface TruncatedTextComponentSignature {
+  Element: HTMLSpanElement;
+  Args: {
+    tagName?: string;
+  };
+  Blocks: {
+    default: [];
+  };
+}
+
+export default class TruncatedTextComponent extends Component<TruncatedTextComponentSignature> {}
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry {
+    TruncatedText: typeof TruncatedTextComponent;
+  }
+}

--- a/web/app/styles/typography.scss
+++ b/web/app/styles/typography.scss
@@ -9,3 +9,7 @@
 .hermes-form-helper-text {
   @apply text-body-100;
 }
+
+.truncated-text-container {
+  @apply truncate block font-regular text-body-100 text-color-foreground-faint;
+}

--- a/web/tests/integration/components/truncated-text-test.ts
+++ b/web/tests/integration/components/truncated-text-test.ts
@@ -1,0 +1,57 @@
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+import { find, render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import { assert as emberAssert } from "@ember/debug";
+
+const CONTAINER_SELECTOR = ".truncated-text-container";
+
+module("Integration | Component | truncated-text", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("it truncates text", async function (assert) {
+    await render(hbs`
+      <div style="width:275px">
+        <TruncatedText style="font-size:28px;">
+          This is a very long text that should be truncated
+        </TruncatedText>
+      </div>
+    `);
+
+    // TODO: Take Percy screenshot
+
+    // <p> tag is used if no `tagName` is provided
+    const container = find(`p${CONTAINER_SELECTOR}`);
+    const text = find(`${CONTAINER_SELECTOR} > span`);
+
+    emberAssert(
+      "container must be an HTMLElement",
+      container instanceof HTMLElement
+    );
+    emberAssert("text must be an HTMLElement", text instanceof HTMLElement);
+
+    const containerWidth = container.offsetWidth;
+    const textWidth = text.offsetWidth;
+
+    assert.equal(containerWidth, 275);
+    assert.true(containerWidth < textWidth);
+
+    const containerFontSize = window.getComputedStyle(container).fontSize;
+    const textFontSize = window.getComputedStyle(text).fontSize;
+
+    assert.equal(containerFontSize, "13px"); // text-body-100 size
+    assert.equal(textFontSize, "28px");
+  });
+
+  test("it truncates text with a custom tag", async function (assert) {
+    await render(hbs`
+      <div style="width:275px">
+        <TruncatedText @tagName="h1" style="font-size:28px;">
+          This is a very long text that should be truncated
+        </TruncatedText>
+      </div>
+    `);
+
+    assert.dom(`h1${CONTAINER_SELECTOR}`).exists("renders a custom tag");
+  });
+});


### PR DESCRIPTION
Adds a component to truncate bold text with a subtle ellipses.

<img width="205" alt="CleanShot 2023-06-26 at 10 54 59@2x" src="https://github.com/hashicorp-forge/hermes/assets/754957/e561f667-a7d1-4ef6-a643-e6c67992a395">
