### PR TITLE
Tweak TextInput definition: Make `type` property optional

### DIFF
--- a/web/types/hds/form/text-input/base.d.ts
+++ b/web/types/hds/form/text-input/base.d.ts
@@ -1,11 +1,12 @@
 // https://helios.hashicorp.design/components/form/text-input?tab=code#formtextinputbase-1
+
 import { ComponentLike } from "@glint/template";
 import { HdsFormTextInputArgs } from ".";
 
 export interface HdsFormTextInputBaseComponentSignature {
   Element: HTMLInputElement;
   Args: {
-    type: string;
+    type?: string;
     value: string | number | Date;
     isInvalid?: boolean;
     width?: string;


### PR DESCRIPTION
Makes the `type` property on the base TextInput an optional argument. (It defaults to "text.")