### PR TITLE
Add new configurations to FloatingUI component

### DIFF
--- a/web/app/components/floating-u-i/content.ts
+++ b/web/app/components/floating-u-i/content.ts
@@ -18,6 +18,7 @@ interface FloatingUIContentSignature {
   Args: {
     anchor: HTMLElement;
     id: string;
+    // TODO: Move "none" logic to a parent component.
     placement?: Placement | "none";
     renderOut?: boolean;
     offset?: OffsetOptions;

--- a/web/app/components/floating-u-i/content.ts
+++ b/web/app/components/floating-u-i/content.ts
@@ -18,8 +18,8 @@ interface FloatingUIContentSignature {
   Args: {
     anchor: HTMLElement;
     id: string;
-    // TODO: Move "none" logic to a parent component.
-    placement?: Placement | "none";
+    // TODO: Move null logic to a parent component.
+    placement?: Placement | null;
     renderOut?: boolean;
     offset?: OffsetOptions;
   };
@@ -42,8 +42,8 @@ export default class FloatingUIContent extends Component<FloatingUIContentSignat
   @action didInsert(e: HTMLElement) {
     this._content = e;
 
-    if (this.args.placement === "none") {
-      this.content.setAttribute("data-floating-ui-placement", "none");
+    if (this.args.placement === null) {
+      this.content.removeAttribute("data-floating-ui-placement");
       this.content.classList.add("non-floating-content");
       this.cleanup = () => {};
       return;

--- a/web/app/components/floating-u-i/content.ts
+++ b/web/app/components/floating-u-i/content.ts
@@ -18,7 +18,7 @@ interface FloatingUIContentSignature {
   Args: {
     anchor: HTMLElement;
     id: string;
-    placement?: Placement;
+    placement?: Placement | "none";
     renderOut?: boolean;
     offset?: OffsetOptions;
   };
@@ -41,10 +41,19 @@ export default class FloatingUIContent extends Component<FloatingUIContentSignat
   @action didInsert(e: HTMLElement) {
     this._content = e;
 
+    if (this.args.placement === "none") {
+      this.content.setAttribute("data-floating-ui-placement", "none");
+      this.content.classList.add("non-floating-content");
+      this.cleanup = () => {};
+      return;
+    }
+
     let updatePosition = async () => {
+      let placement = this.args.placement || "bottom-start";
+
       computePosition(this.args.anchor, this.content, {
-        platform: platform,
-        placement: this.args.placement || "bottom-start",
+        platform,
+        placement: placement as Placement,
         middleware: [offset(this.offset), flip(), shift()],
       }).then(({ x, y, placement }) => {
         this.content.setAttribute("data-floating-ui-placement", placement);

--- a/web/app/components/floating-u-i/index.ts
+++ b/web/app/components/floating-u-i/index.ts
@@ -24,6 +24,7 @@ interface FloatingUIComponentSignature {
   Element: HTMLDivElement;
   Args: {
     renderOut?: boolean;
+    // TODO: Move "none" logic to a parent component.
     placement?: Placement | "none";
     disableClose?: boolean;
     offset?: OffsetOptions;

--- a/web/app/components/floating-u-i/index.ts
+++ b/web/app/components/floating-u-i/index.ts
@@ -24,8 +24,8 @@ interface FloatingUIComponentSignature {
   Element: HTMLDivElement;
   Args: {
     renderOut?: boolean;
-    // TODO: Move "none" logic to a parent component.
-    placement?: Placement | "none";
+    // TODO: Move null logic to a parent component.
+    placement?: Placement | null;
     disableClose?: boolean;
     offset?: OffsetOptions;
   };

--- a/web/app/components/floating-u-i/index.ts
+++ b/web/app/components/floating-u-i/index.ts
@@ -24,7 +24,8 @@ interface FloatingUIComponentSignature {
   Element: HTMLDivElement;
   Args: {
     renderOut?: boolean;
-    placement?: Placement;
+    placement?: Placement | "none";
+    disableClose?: boolean;
     offset?: OffsetOptions;
   };
   Blocks: {
@@ -38,7 +39,7 @@ export default class FloatingUIComponent extends Component<FloatingUIComponentSi
 
   @tracked _anchor: HTMLElement | null = null;
   @tracked content: HTMLElement | null = null;
-  @tracked contentIsShown: boolean = false;
+  @tracked contentIsShown: boolean = this.args.disableClose || false;
 
   get anchor() {
     assert("_anchor must exist", this._anchor);
@@ -65,7 +66,9 @@ export default class FloatingUIComponent extends Component<FloatingUIComponentSi
   }
 
   @action hideContent() {
-    this.contentIsShown = false;
+    if (this.args.disableClose !== true) {
+      this.contentIsShown = false;
+    }
   }
 }
 

--- a/web/app/styles/components/floating-u-i/content.scss
+++ b/web/app/styles/components/floating-u-i/content.scss
@@ -1,11 +1,13 @@
 .hermes-floating-ui-content {
-  @apply absolute;
+  &:not(.non-floating-content) {
+    @apply absolute;
 
-  /* These positioning styles are overwritten by FloatingUI,
+    /* These positioning styles are overwritten by FloatingUI,
    * but they ensure that the tooltip isn't added to the bottom of the page,
    * where it could cause a reflow. This is especially important because
    * the Google Docs iframe responds to layout changes and might
    * otherwise jitter when a tooltip opened.
    */
-  @apply top-0 left-0;
+    @apply top-0 left-0;
+  }
 }

--- a/web/tests/integration/components/floating-u-i/content-test.ts
+++ b/web/tests/integration/components/floating-u-i/content-test.ts
@@ -211,7 +211,6 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
             Attach
           </div>
           <FloatingUI::Content
-            style="width: 100px"
             @id="1"
             @anchor={{html-element '.anchor'}}
             @placement="none"
@@ -230,7 +229,20 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
       "content is not positioned"
     );
 
-    await this.pauseTest();
+    assert.true(
+      content.classList.contains("non-floating-content"),
+      "content has the `non-floating-content` class"
+    );
+
+    assert.true(content.style.position === "static", "content is static");
+
+    const inlineStyle = content.getAttribute("style");
+
+    assert.strictEqual(
+      inlineStyle,
+      null,
+      "content not positioned by floatingUI"
+    );
   });
 
   todo("it runs a cleanup function on teardown", async function (assert) {

--- a/web/tests/integration/components/floating-u-i/content-test.ts
+++ b/web/tests/integration/components/floating-u-i/content-test.ts
@@ -230,7 +230,10 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
       "content has the `non-floating-content` class"
     );
 
-    assert.true(content.style.position === "static", "content is static");
+    assert.true(
+      getComputedStyle(content).position === "static",
+      "content is static"
+    );
 
     const inlineStyle = content.getAttribute("style");
 

--- a/web/tests/integration/components/floating-u-i/content-test.ts
+++ b/web/tests/integration/components/floating-u-i/content-test.ts
@@ -6,6 +6,7 @@ import htmlElement from "hermes/utils/html-element";
 import { OffsetOptions } from "@floating-ui/dom";
 
 const DEFAULT_CONTENT_OFFSET = 5;
+const CONTENT_SELECTOR = ".hermes-floating-ui-content";
 
 interface FloatingUIComponentTestContext extends TestContext {
   renderOut?: boolean;
@@ -35,17 +36,17 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
     `);
 
     assert
-      .dom(".container .hermes-floating-ui-content")
+      .dom(`.container ${CONTENT_SELECTOR}`)
       .exists("content is rendered inline by default");
 
     this.set("renderOut", true);
 
     assert
-      .dom(".container .hermes-floating-ui-content")
+      .dom(`.container ${CONTENT_SELECTOR}`)
       .doesNotExist("content is rendered outside its container");
 
     assert
-      .dom(".ember-application .hermes-floating-ui-content")
+      .dom(`.ember-application ${CONTENT_SELECTOR}`)
       .exists("content is rendered in the root element");
   });
 
@@ -88,7 +89,7 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
     `);
 
     let anchor = htmlElement(".anchor");
-    let content = htmlElement(".hermes-floating-ui-content");
+    let content = htmlElement(CONTENT_SELECTOR);
 
     setVariables(anchor, content);
 
@@ -125,7 +126,7 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
     `);
 
     anchor = htmlElement(".anchor");
-    content = htmlElement(".hermes-floating-ui-content");
+    content = htmlElement(CONTENT_SELECTOR);
 
     setVariables(anchor, content);
 
@@ -156,7 +157,7 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
     `);
 
     let anchor = htmlElement(".anchor");
-    let content = htmlElement(".hermes-floating-ui-content");
+    let content = htmlElement(CONTENT_SELECTOR);
     let contentWidth = content.offsetWidth;
     let contentRight = content.offsetLeft + contentWidth;
     let anchorLeft = anchor.offsetLeft;
@@ -191,7 +192,7 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
     `);
 
     anchor = htmlElement(".anchor");
-    content = htmlElement(".hermes-floating-ui-content");
+    content = htmlElement(CONTENT_SELECTOR);
     contentWidth = content.offsetWidth;
     contentRight = content.offsetLeft + contentWidth;
     anchorLeft = anchor.offsetLeft;
@@ -203,7 +204,7 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
     );
   });
 
-  test('it can be positioned "none"', async function (assert) {
+  test("it can ignore dynamic positioning", async function (assert) {
     await render(hbs`
       <div class="anchor">
         Attach
@@ -211,19 +212,17 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
       <FloatingUI::Content
         @id="1"
         @anchor={{html-element '.anchor'}}
-        @placement="none"
+        @placement={{null}}
       >
         Content
       </FloatingUI::Content>
     `);
 
-    let content = htmlElement(".hermes-floating-ui-content");
+    assert
+      .dom(CONTENT_SELECTOR)
+      .doesNotHaveAttribute("data-floating-ui-placement");
 
-    assert.equal(
-      content.getAttribute("data-floating-ui-placement"),
-      "none",
-      "content is not positioned"
-    );
+    const content = htmlElement(CONTENT_SELECTOR);
 
     assert.true(
       content.classList.contains("non-floating-content"),

--- a/web/tests/integration/components/floating-u-i/content-test.ts
+++ b/web/tests/integration/components/floating-u-i/content-test.ts
@@ -203,22 +203,18 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
     );
   });
 
-  test('it can be positioned "none"', async function (this: FloatingUIComponentTestContext, assert) {
+  test('it can be positioned "none"', async function (assert) {
     await render(hbs`
-      <div class="grid place-items-center w-full h-full">
-        <div>
-          <div class="anchor" style="width: 100px">
-            Attach
-          </div>
-          <FloatingUI::Content
-            @id="1"
-            @anchor={{html-element '.anchor'}}
-            @placement="none"
-          >
-            Content
-          </FloatingUI::Content>
-        </div>
+      <div class="anchor">
+        Attach
       </div>
+      <FloatingUI::Content
+        @id="1"
+        @anchor={{html-element '.anchor'}}
+        @placement="none"
+      >
+        Content
+      </FloatingUI::Content>
     `);
 
     let content = htmlElement(".hermes-floating-ui-content");

--- a/web/tests/integration/components/floating-u-i/content-test.ts
+++ b/web/tests/integration/components/floating-u-i/content-test.ts
@@ -1,25 +1,31 @@
 import { module, test, todo } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
-import { render } from "@ember/test-helpers";
+import { TestContext, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import htmlElement from "hermes/utils/html-element";
+import { OffsetOptions } from "@floating-ui/dom";
 
 const DEFAULT_CONTENT_OFFSET = 5;
+
+interface FloatingUIComponentTestContext extends TestContext {
+  renderOut?: boolean;
+  offset?: OffsetOptions;
+}
 
 module("Integration | Component | floating-u-i/content", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("it can be rendered inline or outside", async function (assert) {
-    this.set("renderOut", undefined);
+  test("it can be rendered inline or outside", async function (this: FloatingUIComponentTestContext, assert) {
+    this.set("renderOut", false);
 
-    await render(hbs`
-      {{! @glint-nocheck: not typesafe yet }}
+    await render<FloatingUIComponentTestContext>(hbs`
       <div class="anchor">
         Attach here
       </div>
 
       <div class="container">
         <FloatingUI::Content
+          @id="1"
           @anchor={{html-element '.anchor'}}
           @renderOut={{this.renderOut}}
         >
@@ -43,7 +49,7 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
       .exists("content is rendered in the root element");
   });
 
-  test("it is positioned by floating-ui", async function (assert) {
+  test("it is positioned by floating-ui", async function (this: FloatingUIComponentTestContext, assert) {
     let contentWidth = 0;
     let anchorWidth = 0;
     let contentLeft = 0;
@@ -63,8 +69,7 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
 
     // Center the anchor so the content can be flexibly positioned
 
-    await render(hbs`
-      {{! @glint-nocheck: not typesafe yet }}
+    await render<FloatingUIComponentTestContext>(hbs`
       <div class="grid place-items-center w-full h-full">
         <div>
           <div class="anchor" style="width: 100px">
@@ -72,6 +77,7 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
           </div>
           <FloatingUI::Content
             style="width: 100px"
+            @id="1"
             @anchor={{html-element '.anchor'}}
             @placement="left"
           >
@@ -100,8 +106,7 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
 
     this.clearRender();
 
-    await render(hbs`
-      {{! @glint-nocheck: not typesafe yet }}
+    await render<FloatingUIComponentTestContext>(hbs`
       <div class="grid place-items-center w-full h-full">
         <div>
           <div class="anchor" style="width: 100px">
@@ -109,6 +114,7 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
           </div>
           <FloatingUI::Content
             style="width: 100px"
+            @id="1"
             @anchor={{html-element '.anchor'}}
             @placement="right"
           >
@@ -130,9 +136,8 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
     );
   });
 
-  test("it can use a custom offset", async function (assert) {
+  test("it can use a custom offset", async function (this: FloatingUIComponentTestContext, assert) {
     await render(hbs`
-      {{! @glint-nocheck: not typesafe yet }}
       <div class="grid place-items-center w-full h-full">
         <div>
           <div class="anchor" style="width: 100px">
@@ -140,6 +145,7 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
           </div>
           <FloatingUI::Content
             style="width: 100px"
+            @id="1"
             @anchor={{html-element '.anchor'}}
             @placement="left"
           >
@@ -165,8 +171,7 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
     this.clearRender();
     this.set("offset", 10);
 
-    await render(hbs`
-      {{! @glint-nocheck: not typesafe yet }}
+    await render<FloatingUIComponentTestContext>(hbs`
       <div class="grid place-items-center w-full h-full">
         <div>
           <div class="anchor" style="width: 100px">
@@ -174,6 +179,7 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
           </div>
           <FloatingUI::Content
             style="width: 100px"
+            @id="1"
             @anchor={{html-element '.anchor'}}
             @placement="left"
             @offset={{this.offset}}
@@ -195,6 +201,36 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
       anchorLeft - 10,
       "content is offset by the passed-in value"
     );
+  });
+
+  test('it can be positioned "none"', async function (this: FloatingUIComponentTestContext, assert) {
+    await render(hbs`
+      <div class="grid place-items-center w-full h-full">
+        <div>
+          <div class="anchor" style="width: 100px">
+            Attach
+          </div>
+          <FloatingUI::Content
+            style="width: 100px"
+            @id="1"
+            @anchor={{html-element '.anchor'}}
+            @placement="none"
+          >
+            Content
+          </FloatingUI::Content>
+        </div>
+      </div>
+    `);
+
+    let content = htmlElement(".hermes-floating-ui-content");
+
+    assert.equal(
+      content.getAttribute("data-floating-ui-placement"),
+      "none",
+      "content is not positioned"
+    );
+
+    await this.pauseTest();
   });
 
   todo("it runs a cleanup function on teardown", async function (assert) {

--- a/web/tests/integration/components/floating-u-i/index-test.ts
+++ b/web/tests/integration/components/floating-u-i/index-test.ts
@@ -11,7 +11,6 @@ module("Integration | Component | floating-u-i/index", function (hooks) {
     this.set("renderOut", undefined);
 
     await render(hbs`
-      {{! @glint-nocheck: not typesafe yet }}
       <FloatingUI>
         <:anchor as |f|>
           <Action

--- a/web/tests/integration/components/floating-u-i/index-test.ts
+++ b/web/tests/integration/components/floating-u-i/index-test.ts
@@ -61,4 +61,32 @@ module("Integration | Component | floating-u-i/index", function (hooks) {
       .dom(".content")
       .doesNotExist("the API is also available to the content block");
   });
+
+  test("the close action can be disabled", async function (assert) {
+    await render(hbs`
+      <FloatingUI @disableClose={{true}}>
+        <:anchor as |f|>
+          <Action
+            {{on "click" f.showContent}}
+            {{did-insert f.registerAnchor}}
+          >
+            Open
+          </Action>
+        </:anchor>
+        <:content as |f|>
+          <Action {{on "click" f.hideContent}} class="close-button">
+            Close
+          </Action>
+        </:content>
+      </FloatingUI>
+    `);
+
+    await click(".open-button");
+
+    assert.dom(".content").exists();
+
+    await click(".close-button");
+
+    assert.dom(".content").exists('the "close" action was disabled');
+  });
 });

--- a/web/tests/integration/components/floating-u-i/index-test.ts
+++ b/web/tests/integration/components/floating-u-i/index-test.ts
@@ -67,6 +67,7 @@ module("Integration | Component | floating-u-i/index", function (hooks) {
       <FloatingUI @disableClose={{true}}>
         <:anchor as |f|>
           <Action
+            class="open-button"
             {{on "click" f.showContent}}
             {{did-insert f.registerAnchor}}
           >
@@ -83,10 +84,10 @@ module("Integration | Component | floating-u-i/index", function (hooks) {
 
     await click(".open-button");
 
-    assert.dom(".content").exists();
+    assert.dom(".close-button").exists();
 
     await click(".close-button");
 
-    assert.dom(".content").exists('the "close" action was disabled');
+    assert.dom(".close-button").exists('the "close" action was disabled');
   });
 });


### PR DESCRIPTION
- Adds a `null` placement option to ignore dynamic positioning.
- Adds a `disableClose` argument

These are admittedly roundabout ways of extending the DropdownList components to work in non-popover contexts. I intend to improve this in future iterations, after the dust of #219 has settled.