### PR TITLE
Move refreshRoute into `finally` block

### DIFF
--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -282,8 +282,9 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
     } catch (error: unknown) {
       this.maybeShowFlashError(error as Error, "Unable to save document");
       throw error;
+    } finally {
+      this.refreshRoute();
     }
-    this.refreshRoute();
   });
 
   requestReview = task(async () => {


### PR DESCRIPTION
Moves the `refreshRoute` call in `patchDocument` to the `finally` block, so it runs even if the task throws an error. This will effectively catch any status changes (e.g., whether it's locked) and update the UI accordingly.