### PR TITLE
Fix PEOPLE CustomEditableField bug

### DIFF
--- a/web/app/components/custom-editable-field.hbs
+++ b/web/app/components/custom-editable-field.hbs
@@ -24,7 +24,7 @@
     <:editing as |F|>
       <Hds::Form::Textarea::Field
         @value={{F.value}}
-        name={{field}}
+        name={{@field}}
         {{auto-height-textarea}}
         {{on "blur" F.update}}
         data-test-custom-string-field-input
@@ -64,7 +64,7 @@
         class="multiselect--narrow"
         @selected={{this.people}}
         @onChange={{this.updateEmails}}
-        {{click-outside (fn F.update this.emails)}}
+        {{click-outside (fn F.update this.people)}}
         data-test-custom-people-field-input
       />
     </:editing>

--- a/web/app/components/custom-editable-field.hbs
+++ b/web/app/components/custom-editable-field.hbs
@@ -24,7 +24,7 @@
     <:editing as |F|>
       <Hds::Form::Textarea::Field
         @value={{F.value}}
-        name={{@field}}
+        name={{field}}
         {{auto-height-textarea}}
         {{on "blur" F.update}}
         data-test-custom-string-field-input


### PR DESCRIPTION
Fixes a bug causing the PEOPLE CustomEditableField to save an array of empty strings instead of email addresses.

A more thorough review of this component is coming soon (#240) 