### PR TITLE
Add `hermes-h4` style

### DIFF
--- a/web/app/components/header/toolbar.hbs
+++ b/web/app/components/header/toolbar.hbs
@@ -3,11 +3,9 @@
     <div class="x-container">
       <div class="flex justify-between w-full">
         <div class="flex items-center">
-          <div
-            class="mr-4 tracking-wide font-medium text-body-100 text-color-foreground-faint uppercase"
-          >
+          <h4 class="mr-4 hermes-h4">
             Filter by:
-          </div>
+          </h4>
           <div class="facets flex items-center space-x-1.5">
             <Header::FacetDropdown
               @label="Type"

--- a/web/app/styles/typography.scss
+++ b/web/app/styles/typography.scss
@@ -10,6 +10,10 @@
   @apply text-body-100;
 }
 
+.hermes-h4 {
+  @apply text-color-foreground-faint uppercase tracking-wide font-medium text-body-100;
+}
+
 .truncated-text-container {
   @apply truncate block font-regular text-body-100 text-color-foreground-faint;
 }


### PR DESCRIPTION
Gives the FILTER header the classname treatment so we can use its style elsewhere.