### PR TITLE
Conditionally disable keyboardNav

### DIFF
--- a/web/app/components/x/dropdown-list/index.hbs
+++ b/web/app/components/x/dropdown-list/index.hbs
@@ -103,6 +103,8 @@
                 data-test-x-dropdown-list-input
                 {{did-insert this.registerAndFocusInput}}
                 {{on "input" this.onInput}}
+                {{on "focusin" this.enableKeyboardNav}}
+                {{on "focusout" this.disableKeyboardNav}}
                 @value={{this.query}}
                 @type="search"
                 placeholder="Filter..."
@@ -121,7 +123,6 @@
             {{#if (has-block "header")}}
               {{yield to="header"}}
             {{/if}}
-            {{log this.shownItems}}
             <X::DropdownList::Items
               @contentID={{f.contentID}}
               @query={{this.query}}
@@ -139,6 +140,7 @@
               @hideContent={{f.hideContent}}
               @scrollContainer={{this.scrollContainer}}
               @listIsShown={{@listIsShown}}
+              @keyboardNavIsEnabled={{this.keyboardNavIsEnabled}}
             >
               <:no-matches>
                 {{#if (has-block "no-matches")}}

--- a/web/app/components/x/dropdown-list/index.hbs
+++ b/web/app/components/x/dropdown-list/index.hbs
@@ -103,7 +103,7 @@
                 data-test-x-dropdown-list-input
                 {{did-insert this.registerAndFocusInput}}
                 {{on "input" this.onInput}}
-                {{on "focusin" this.enableKeyboardNav}}
+                {{on "focusin" this.maybeEnableKeyboardNav}}
                 {{on "focusout" this.disableKeyboardNav}}
                 @value={{this.query}}
                 @type="search"

--- a/web/app/components/x/dropdown-list/index.ts
+++ b/web/app/components/x/dropdown-list/index.ts
@@ -174,7 +174,7 @@ export default class XDropdownListComponent extends Component<XDropdownListCompo
    * The action to enable keyboard navigation, if allowed by the parent component.
    * Called when the filter input is focused.
    */
-  @action protected enableKeyboardNav() {
+  @action protected maybeEnableKeyboardNav() {
     if (this.args.keyboardNavIsEnabled === false) {
       return;
     }
@@ -209,7 +209,6 @@ export default class XDropdownListComponent extends Component<XDropdownListCompo
    * Used to assign ids to the menu items.
    */
   @action protected didInsertContent() {
-    console.log("isKeyboard", this.args.keyboardNavIsEnabled);
     assert(
       "didInsertContent expects a _scrollContainer",
       this._scrollContainer

--- a/web/app/components/x/dropdown-list/index.ts
+++ b/web/app/components/x/dropdown-list/index.ts
@@ -80,6 +80,12 @@ interface XDropdownListComponentSignature {
      * even in cases where the list is long enough to show it.
      */
     inputIsShown?: boolean;
+
+    /**
+     * Whether the keyboard should be used to navigate the list,
+     * as determined by the parent component.
+     */
+    keyboardNavIsEnabled?: boolean;
     onItemClick?: (value: any, attributes: any) => void;
   };
   Blocks: {
@@ -111,6 +117,8 @@ export default class XDropdownListComponent extends Component<XDropdownListCompo
   @tracked protected query: string = "";
   @tracked protected listItemRole = this.inputIsShown ? "option" : "menuitem";
   @tracked protected focusedItemIndex = -1;
+  @tracked protected keyboardNavIsEnabled =
+    this.args.keyboardNavIsEnabled ?? true;
 
   /**
    * An asserted-true reference to the scroll container.
@@ -163,6 +171,25 @@ export default class XDropdownListComponent extends Component<XDropdownListCompo
   }
 
   /**
+   * The action to enable keyboard navigation, if allowed by the parent component.
+   * Called when the filter input is focused.
+   */
+  @action protected enableKeyboardNav() {
+    if (this.args.keyboardNavIsEnabled === false) {
+      return;
+    }
+    this.keyboardNavIsEnabled = true;
+  }
+
+  /**
+   * The action to disable keyboard navigation.
+   * Called when the filter input loses focus.
+   */
+  @action protected disableKeyboardNav() {
+    this.keyboardNavIsEnabled = false;
+  }
+
+  /**
    * The action performed when the filter input is inserted.
    * Registers the input locally and focuses it for the user.
    */
@@ -182,6 +209,7 @@ export default class XDropdownListComponent extends Component<XDropdownListCompo
    * Used to assign ids to the menu items.
    */
   @action protected didInsertContent() {
+    console.log("isKeyboard", this.args.keyboardNavIsEnabled);
     assert(
       "didInsertContent expects a _scrollContainer",
       this._scrollContainer

--- a/web/app/components/x/dropdown-list/items.ts
+++ b/web/app/components/x/dropdown-list/items.ts
@@ -14,6 +14,7 @@ interface XDropdownListItemsComponentSignature {
       inputIsShown?: boolean;
       scrollContainer: HTMLElement;
       listIsShown?: boolean;
+      keyboardNavIsEnabled?: boolean;
       onInput: (event: Event) => void;
       registerScrollContainer: (element: HTMLElement) => void;
     };
@@ -62,6 +63,18 @@ export default class XDropdownListItemsComponent extends Component<XDropdownList
    * Enter selects the focused item.
    */
   @action protected maybeKeyboardNavigate(event: KeyboardEvent) {
+    if (this.args.keyboardNavIsEnabled === false) {
+      switch (event.key) {
+        case "ArrowDown":
+        case "ArrowUp":
+        case "Enter":
+          event.preventDefault();
+          return;
+        default:
+          return;
+      }
+    }
+
     if (event.key === "ArrowDown") {
       event.preventDefault();
       this.args.setFocusedItemIndex(FocusDirection.Next);

--- a/web/tests/integration/components/x/dropdown-list/index-test.ts
+++ b/web/tests/integration/components/x/dropdown-list/index-test.ts
@@ -179,6 +179,54 @@ module("Integration | Component | x/dropdown-list", function (hooks) {
       .hasAttribute("aria-activedescendant", FIRST_ITEM_ID);
   });
 
+  test("keyboard navigation can be disabled", async function (assert) {
+    this.set("items", SHORT_ITEM_LIST);
+
+    await render<XDropdownListComponentTestContext>(hbs`
+      <X::DropdownList @items={{this.items}} @keyboardNavIsEnabled={{false}}>
+        <:anchor as |dd|>
+          <dd.ToggleButton @text="Toggle" data-test-toggle />
+        </:anchor>
+        <:item as |dd|>
+          <dd.Action>Item</dd.Action>
+        </:item>
+      </X::DropdownList>
+    `);
+
+    await click(TOGGLE_BUTTON_SELECTOR);
+
+    await triggerKeyEvent("[data-test-toggle]", "keydown", "ArrowDown");
+
+    assert
+      .dom("#" + FIRST_ITEM_ID)
+      .doesNotHaveAttribute("aria-selected", "no item is selected");
+  });
+
+  test("keyboard navigation stops when the filter input loses focus", async function (assert) {
+    this.set("items", LONG_ITEM_LIST);
+
+    await render<XDropdownListComponentTestContext>(hbs`
+      <X::DropdownList @items={{this.items}}>
+        <:anchor as |dd|>
+          <dd.ToggleButton @text="Toggle" data-test-toggle/>
+        </:anchor>
+        <:item as |dd|>
+          <dd.Action>Item</dd.Action>
+        </:item>
+      </X::DropdownList>
+    `);
+
+    await click(TOGGLE_BUTTON_SELECTOR);
+
+    await click(".x-dropdown-list-input-container");
+
+    await triggerKeyEvent("[data-test-toggle]", "keydown", "ArrowDown");
+
+    assert
+      .dom("#" + FIRST_ITEM_ID)
+      .doesNotHaveAttribute("aria-selected", "no item is selected");
+  });
+
   test("the component's filter properties are reset on close", async function (assert) {
     this.set("items", LONG_ITEM_LIST);
     await render<XDropdownListComponentTestContext>(hbs`


### PR DESCRIPTION
Improves how keyboard navigation is handled by the DropdownList components.

Now, when the filterBar loses focus, we automatically disable keyboard navigation. Generally, when the filterBar loses focus, it's because the popover is closing, however, there are rare cases where this is not the case, e.g., when clicking very specific non-interactive slivers of the facet dropdowns.

It can also be disabled as an invocation argument in case this logic needs to come from elsewhere. 