### PR TITLE
Move `design-system-components` import

### DIFF
--- a/web/app/styles/app.scss
+++ b/web/app/styles/app.scss
@@ -1,3 +1,5 @@
+@use "@hashicorp/design-system-components";
+
 @use "./typography";
 
 @use "components/action";
@@ -37,7 +39,6 @@
 
 @use "./ember-power-select-theme";
 
-@use "@hashicorp/design-system-components";
 @use "./error-404";
 @use "./hds-overrides";
 


### PR DESCRIPTION
Moves the HDS style import to the top of `app.scss`, to make overrides easier.