### PR TITLE
Fixes typo on modal "check" links.

### DIFF
--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -552,7 +552,7 @@
                       <Hds::Link::Inline
                         @icon="external-link"
                         @iconPosition="trailing"
-                        @hrefIsExternal={{true}}
+                        @isHrefExternal={{true}}
                         @href={{link.url}}
                         class="no-underline text-body-100"
                       >


### PR DESCRIPTION
We were passing the wrong argument name to the component. (https://helios.hashicorp.design/components/button?tab=code#component-api)

