### PR TITLE
Add delay option to tooltip

### DIFF
--- a/web/app/modifiers/tooltip.ts
+++ b/web/app/modifiers/tooltip.ts
@@ -22,7 +22,7 @@ import Ember from "ember";
 import { set } from "mockdate";
 import simpleTimeout from "hermes/utils/simple-timeout";
 
-const DEFAULT_DELAY = Ember.testing ? 0 : 400;
+const DEFAULT_DELAY = Ember.testing ? 0 : 275;
 
 /**
  * A modifier that attaches a tooltip to a reference element on hover or focus.

--- a/web/app/modifiers/tooltip.ts
+++ b/web/app/modifiers/tooltip.ts
@@ -121,7 +121,7 @@ export default class TooltipModifier extends Modifier<TooltipModifierSignature> 
   @tracked tooltip: HTMLElement | null = null;
 
   /**
-   * The state of the tooltip as it transitions to and from closed and open.
+   * The state of the tooltip as it transitions between closed and open.
    * Used in tests to assert that intermediary states are rendered.
    */
   @tracked state: TooltipState = TooltipState.Closed;

--- a/web/app/modifiers/tooltip.ts
+++ b/web/app/modifiers/tooltip.ts
@@ -212,6 +212,7 @@ export default class TooltipModifier extends Modifier<TooltipModifierSignature> 
       await timeout(this.delay);
     }
 
+    // Used in tests to assert intermediary states
     if (this._useTestDelay) {
       await simpleTimeout(10);
     }

--- a/web/tests/integration/modifiers/tooltip-test.ts
+++ b/web/tests/integration/modifiers/tooltip-test.ts
@@ -1,15 +1,15 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
-import { render, triggerEvent } from "@ember/test-helpers";
+import { render, triggerEvent, waitUntil } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import htmlElement from "hermes/utils/html-element";
+import { wait } from "ember-animated/.";
 
 module("Integration | Modifier | tooltip", function (hooks) {
   setupRenderingTest(hooks);
 
   test("it renders", async function (assert) {
     await render(hbs`
-      {{! @glint-nocheck: not typesafe yet }}
       <div data-test-div {{tooltip "more information"}}>
         Hover or focus me
       </div>
@@ -76,7 +76,6 @@ module("Integration | Modifier | tooltip", function (hooks) {
 
   test("it takes a placement argument", async function (assert) {
     await render(hbs`
-      {{! @glint-nocheck: not typesafe yet }}
       <div class="w-full h-full grid place-items-center">
         <div>
           <div data-test-one {{tooltip "more information"}}>
@@ -113,5 +112,43 @@ module("Integration | Modifier | tooltip", function (hooks) {
         "left-end",
         "tooltip can be custom placed"
       );
+  });
+
+  test("it can open on a delay", async function (assert) {
+    await render(hbs`
+      <div class="tip" {{tooltip "more information" _isTestingDelay=true}}>
+        Hover or focus me
+      </div>
+    `);
+
+    let state = htmlElement(".tip").getAttribute("data-tooltip-state");
+
+    assert.equal(state, "closed", "tooltip is closed by default");
+
+    await triggerEvent(".tip", "mouseenter");
+
+    assert.equal(
+      htmlElement(".tip").getAttribute("data-tooltip-state"),
+      "opening",
+      "tooltip is in its opening state"
+    );
+
+    await waitUntil(() => {
+      return htmlElement(".tip").getAttribute("data-tooltip-state") === "open";
+    });
+
+    assert.equal(
+      htmlElement(".tip").getAttribute("data-tooltip-state"),
+      "open",
+      "tooltip is open"
+    );
+
+    await triggerEvent(".tip", "mouseleave");
+
+    assert.equal(
+      htmlElement(".tip").getAttribute("data-tooltip-state"),
+      "closed",
+      "tooltip is in its closing state"
+    );
   });
 });

--- a/web/tests/integration/modifiers/tooltip-test.ts
+++ b/web/tests/integration/modifiers/tooltip-test.ts
@@ -123,32 +123,20 @@ module("Integration | Modifier | tooltip", function (hooks) {
 
     let state = htmlElement(".tip").getAttribute("data-tooltip-state");
 
-    assert.equal(state, "closed", "tooltip is closed by default");
+    assert.equal(state, "closed");
 
     await triggerEvent(".tip", "mouseenter");
 
-    assert.equal(
-      htmlElement(".tip").getAttribute("data-tooltip-state"),
-      "opening",
-      "tooltip is in its opening state"
-    );
+    const tip = htmlElement(".tip");
+
+    assert.equal(tip.getAttribute("data-tooltip-state"), "opening");
 
     await waitUntil(() => {
-      return htmlElement(".tip").getAttribute("data-tooltip-state") === "open";
+      return tip.getAttribute("data-tooltip-state") === "open";
     });
-
-    assert.equal(
-      htmlElement(".tip").getAttribute("data-tooltip-state"),
-      "open",
-      "tooltip is open"
-    );
 
     await triggerEvent(".tip", "mouseleave");
 
-    assert.equal(
-      htmlElement(".tip").getAttribute("data-tooltip-state"),
-      "closed",
-      "tooltip is in its closing state"
-    );
+    assert.equal(tip.getAttribute("data-tooltip-state"), "closed");
   });
 });

--- a/web/tests/integration/modifiers/tooltip-test.ts
+++ b/web/tests/integration/modifiers/tooltip-test.ts
@@ -116,7 +116,7 @@ module("Integration | Modifier | tooltip", function (hooks) {
 
   test("it can open on a delay", async function (assert) {
     await render(hbs`
-      <div class="tip" {{tooltip "more information" _isTestingDelay=true}}>
+      <div class="tip" {{tooltip "more information" _useTestDelay=true}}>
         Hover or focus me
       </div>
     `);


### PR DESCRIPTION
Adds a `delay` property to the tooltip modifier with a default of 275ms. 