### PR TITLE
Add spinner to Related Resources search

### DIFF
--- a/web/app/components/document/sidebar/related-resources.hbs
+++ b/web/app/components/document/sidebar/related-resources.hbs
@@ -53,5 +53,6 @@
     @allowAddingExternalLinks={{@allowAddingExternalLinks}}
     @search={{perform this.search}}
     @searchErrorIsShown={{this.searchErrorIsShown}}
+    @searchIsRunning={{this.search.isRunning}}
   />
 {{/if}}

--- a/web/app/components/document/sidebar/related-resources.ts
+++ b/web/app/components/document/sidebar/related-resources.ts
@@ -180,69 +180,80 @@ export default class DocumentSidebarRelatedResourcesComponent extends Component<
    * the dropdown with the correct menu item IDs.
    * Runs whenever the input value changes.
    */
-  protected search = restartableTask(async (dd: any, query: string) => {
-    let index =
-      this.configSvc.config.algolia_docs_index_name + "_createdTime_desc";
+  protected search = restartableTask(
+    async (dd: any, query: string, shouldIgnoreDelay?: boolean) => {
+      let index =
+        this.configSvc.config.algolia_docs_index_name + "_createdTime_desc";
 
-    // Make sure the current document is omitted from the results
-    let filterString = `(NOT objectID:"${this.args.objectID}")`;
+      // Make sure the current document is omitted from the results
+      let filterString = `(NOT objectID:"${this.args.objectID}")`;
 
-    // And if there are any related documents, omit those too
-    if (this.relatedDocuments.length) {
-      let relatedDocIDs = this.relatedDocuments.map((doc) => doc.googleFileID);
+      // And if there are any related documents, omit those too
+      if (this.relatedDocuments.length) {
+        let relatedDocIDs = this.relatedDocuments.map(
+          (doc) => doc.googleFileID
+        );
 
-      filterString = filterString.slice(0, -1) + " ";
+        filterString = filterString.slice(0, -1) + " ";
 
-      filterString += `AND NOT objectID:"${relatedDocIDs.join(
-        '" AND NOT objectID:"'
-      )}")`;
-    }
+        filterString += `AND NOT objectID:"${relatedDocIDs.join(
+          '" AND NOT objectID:"'
+        )}")`;
+      }
 
-    // If there are search filters, e.g., "doctype:RFC" add them to the query
-    if (this.args.searchFilters) {
-      filterString += ` AND (${this.args.searchFilters})`;
-    }
+      // If there are search filters, e.g., "doctype:RFC" add them to the query
+      if (this.args.searchFilters) {
+        filterString += ` AND (${this.args.searchFilters})`;
+      }
 
-    try {
-      let algoliaResponse = await this.algolia.searchIndex
-        .perform(index, query, {
-          hitsPerPage: 4,
-          filters: filterString,
-          attributesToRetrieve: [
-            "title",
-            "product",
-            "docNumber",
-            "docType",
-            "status",
-            "owners",
-          ],
+      try {
+        let algoliaResponse = await this.algolia.searchIndex
+          .perform(index, query, {
+            hitsPerPage: 4,
+            filters: filterString,
+            attributesToRetrieve: [
+              "title",
+              "product",
+              "docNumber",
+              "docType",
+              "status",
+              "owners",
+            ],
 
-          // https://www.algolia.com/doc/guides/managing-results/rules/merchandising-and-promoting/in-depth/optional-filters/
-          // Include any optional search filters, e.g., "product:Terraform"
-          // to give a higher ranking to results that match the filter.
-          optionalFilters: this.args.optionalSearchFilters,
-        })
-        .then((response) => response);
-      if (algoliaResponse) {
-        this._algoliaResults = algoliaResponse.hits as HermesDocument[];
-        if (dd) {
-          dd.resetFocusedItemIndex();
+            // https://www.algolia.com/doc/guides/managing-results/rules/merchandising-and-promoting/in-depth/optional-filters/
+            // Include any optional search filters, e.g., "product:Terraform"
+            // to give a higher ranking to results that match the filter.
+            optionalFilters: this.args.optionalSearchFilters,
+          })
+          .then((response) => response);
+        if (algoliaResponse) {
+          this._algoliaResults = algoliaResponse.hits as HermesDocument[];
+          if (dd) {
+            dd.resetFocusedItemIndex();
+          }
         }
+        if (dd) {
+          next(() => {
+            dd.scheduleAssignMenuItemIDs();
+          });
+        }
+        this.searchErrorIsShown = false;
+
+        if (!shouldIgnoreDelay) {
+          // This will show the "loading" spinner for some additional time
+          // unless the task is restarted. This is to prevent the spinner
+          // from flashing when the user types and results return quickly.
+          await timeout(Ember.testing ? 0 : 200);
+        }
+      } catch (e: unknown) {
+        // This will trigger the "no matches" block,
+        // which is where we're displaying the error.
+        this._algoliaResults = null;
+        this.searchErrorIsShown = true;
+        console.error(e);
       }
-      if (dd) {
-        next(() => {
-          dd.scheduleAssignMenuItemIDs();
-        });
-      }
-      this.searchErrorIsShown = false;
-    } catch (e: unknown) {
-      // This will trigger the "no matches" block,
-      // which is where we're displaying the error.
-      this._algoliaResults = null;
-      this.searchErrorIsShown = true;
-      console.error(e);
     }
-  });
+  );
 
   /**
    * The action run when the "add resource" plus button is clicked.

--- a/web/app/components/document/sidebar/related-resources/add.hbs
+++ b/web/app/components/document/sidebar/related-resources/add.hbs
@@ -23,24 +23,34 @@
         class="non-floating-list"
       >
         <:anchor as |dd|>
-          <Hds::Form::TextInput::Base
-            data-test-related-resources-search-input
-            {{did-insert dd.registerAnchor}}
-            {{did-insert (fn this.didInsertInput dd)}}
-            {{on "input" (fn this.onInput dd)}}
-            {{on "keydown" (fn this.onInputKeydown dd)}}
-            {{on "focusin" this.enableKeyboardNav}}
-            {{on "focusout" this.disableKeyboardNav}}
-            @type="search"
-            @value={{this.query}}
-            name="related-resources-search"
-            size="25"
-            placeholder={{@inputPlaceholder}}
-            aria-label={{@inputPlaceholder}}
-            aria-controls={{dd.ariaControls}}
-            aria-expanded={{dd.contentIsShown}}
-            aria-haspopup="listbox"
-          />
+          <div class="relative">
+
+            <Hds::Form::TextInput::Base
+              data-test-related-resources-search-input
+              {{did-insert dd.registerAnchor}}
+              {{did-insert (fn this.didInsertInput dd)}}
+              {{on "input" (fn this.onInput dd)}}
+              {{on "keydown" (fn this.onInputKeydown dd)}}
+              {{on "focusin" this.enableKeyboardNav}}
+              {{on "focusout" this.disableKeyboardNav}}
+              @type="search"
+              @value={{this.query}}
+              name="related-resources-search"
+              size="25"
+              placeholder={{@inputPlaceholder}}
+              aria-label={{@inputPlaceholder}}
+              aria-controls={{dd.ariaControls}}
+              aria-expanded={{dd.contentIsShown}}
+              aria-haspopup="listbox"
+            />
+            {{#if @searchIsRunning}}
+              <div
+                class="absolute top-1/2 -translate-y-1/2 right-3 bg-white flex"
+              >
+                <FlightIcon @name="loading" />
+              </div>
+            {{/if}}
+          </div>
         </:anchor>
         <:header>
           {{#if this.listHeaderIsShown}}

--- a/web/app/components/document/sidebar/related-resources/add.hbs
+++ b/web/app/components/document/sidebar/related-resources/add.hbs
@@ -45,7 +45,8 @@
             />
             {{#if @searchIsRunning}}
               <div
-                class="absolute top-1/2 -translate-y-1/2 right-3 bg-white flex"
+                data-test-related-resources-search-loading-icon
+                class="absolute top-1/2 -translate-y-1/2 right-3 flex bg-white"
               >
                 <FlightIcon @name="loading" />
               </div>

--- a/web/app/components/document/sidebar/related-resources/add.ts
+++ b/web/app/components/document/sidebar/related-resources/add.ts
@@ -24,11 +24,12 @@ interface DocumentSidebarRelatedResourcesAddComponentSignature {
     objectID?: string;
     relatedDocuments: RelatedHermesDocument[];
     relatedLinks: RelatedExternalLink[];
-    search: (dd: any, query: string) => Promise<void>;
+    search: (dd: any, query: string, shouldIgnoreDelay?: boolean) => Promise<void>;
     allowAddingExternalLinks?: boolean;
     headerTitle: string;
     inputPlaceholder: string;
     searchErrorIsShown?: boolean;
+    searchIsRunning?: boolean;
   };
   Blocks: {
     default: [];
@@ -285,7 +286,7 @@ export default class DocumentSidebarRelatedResourcesAddComponent extends Compone
    * "suggestions." Called when the search input is inserted.
    */
   protected loadInitialData = restartableTask(async (dd: any) => {
-    await this.args.search(dd, "");
+    await this.args.search(dd, "", true);
   });
 }
 

--- a/web/tests/integration/components/document/sidebar/related-resources/add-test.ts
+++ b/web/tests/integration/components/document/sidebar/related-resources/add-test.ts
@@ -1,10 +1,13 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
 import {
+  click,
   fillIn,
   render,
   triggerEvent,
   triggerKeyEvent,
+  waitFor,
+  waitUntil,
 } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
@@ -23,6 +26,7 @@ interface DocumentSidebarRelatedResourcesAddTestContext
   search: (dd: any, query: string) => Promise<void>;
   shownDocuments: Record<string, HermesDocument>;
   allowAddingExternalLinks: boolean;
+  searchIsRunning: boolean;
 }
 
 module(
@@ -82,6 +86,7 @@ module(
         <Document::Sidebar::RelatedResources::Add
           @headerTitle="Test title"
           @inputPlaceholder="Test placeholder"
+          @addResource={{this.noop}}
           @onClose={{this.noop}}
           @shownDocuments={{this.shownDocuments}}
           @objectID="test"
@@ -263,6 +268,34 @@ module(
       assert
         .dom(`${LIST_ITEM_SELECTOR}:nth-child(2) ${DOCUMENT_OPTION_SELECTOR}`)
         .hasAttribute("aria-selected");
+    });
+
+    test("it shows a loading icon while search is running", async function (this: DocumentSidebarRelatedResourcesAddTestContext, assert) {
+      this.set("searchIsRunning", false);
+
+      await render<DocumentSidebarRelatedResourcesAddTestContext>(hbs`
+        <Document::Sidebar::RelatedResources::Add
+          @headerTitle="Test title"
+          @inputPlaceholder="Test placeholder"
+          @onClose={{this.noop}}
+          @addResource={{this.noop}}
+          @shownDocuments={{this.shownDocuments}}
+          @objectID="test"
+          @relatedDocuments={{array}}
+          @relatedLinks={{array}}
+          @search={{this.search}}
+          @searchIsRunning={{this.searchIsRunning}}
+        />
+      `);
+      const iconSelector = "[data-test-related-resources-search-loading-icon]";
+
+      assert.dom(iconSelector).doesNotExist();
+
+      this.set("searchIsRunning", true);
+
+      assert
+        .dom("[data-test-related-resources-search-loading-icon]")
+        .exists("a loading icon is shown when `searchIsRunning` is true");
     });
   }
 );


### PR DESCRIPTION
Adds a loading icon to the RelatedResources search bar to distinguish the "searching" and "search is complete" states.