### PR TITLE
Add API for shareable drafts

### DIFF
--- a/configs/config.hcl
+++ b/configs/config.hcl
@@ -85,6 +85,9 @@ google_workspace {
   // docs_folder contains all published documents in a flat structure.
   docs_folder = "my-docs-folder-id"
 
+  // domain is the Google Workspace domain (e.g., "hashicorp.com").
+  domain = "your-domain-dot-com"
+
   // drafts_folder contains all draft documents.
   drafts_folder = "my-drafts-folder-id"
 

--- a/internal/api/documents.go
+++ b/internal/api/documents.go
@@ -40,6 +40,15 @@ type DocumentPatchRequest struct {
 	TargetVersion  string   `json:"targetVersion,omitempty"`
 }
 
+type documentSubcollectionRequestType int
+
+const (
+	unspecifiedDocumentSubcollectionRequestType documentSubcollectionRequestType = iota
+	noSubcollectionRequestType
+	relatedResourcesDocumentSubcollectionRequestType
+	shareableDocumentSubcollectionRequestType
+)
+
 func DocumentHandler(
 	cfg *config.Config,
 	l hclog.Logger,
@@ -49,8 +58,8 @@ func DocumentHandler(
 	db *gorm.DB) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Parse document ID from the URL path.
-		docID, isRelatedResourcesRequest, err := parseDocumentsURLPath(
+		// Parse document ID and request type from the URL path.
+		docID, reqType, err := parseDocumentsURLPath(
 			r.URL.Path, "documents")
 		if err != nil {
 			l.Error("error parsing documents URL path",
@@ -116,10 +125,18 @@ func DocumentHandler(
 			return
 		}
 
-		// Pass request off to the documents related resources handler if
-		// appropriate.
-		if isRelatedResourcesRequest {
+		// Pass request off to associated subcollection handler, if appropriate.
+		switch reqType {
+		case relatedResourcesDocumentSubcollectionRequestType:
 			documentsResourceRelatedResourcesHandler(w, r, docID, docObj, l, ar, db)
+			return
+		case shareableDocumentSubcollectionRequestType:
+			l.Warn("invalid shareable request for documents collection",
+				"error", err,
+				"path", r.URL.Path,
+				"method", r.Method,
+			)
+			http.Error(w, "Bad request", http.StatusBadRequest)
 			return
 		}
 
@@ -483,44 +500,61 @@ func updateRecentlyViewedDocs(
 	return nil
 }
 
-// parseDocumentsURLPath parses the document ID from a documents API URL path
-// and determines if it is a related resources request.
-// resourceType should be "documents" or "drafts", as appropriate.
-func parseDocumentsURLPath(path, resourceType string) (
+// parseDocumentsURLPath parses the document ID and subcollection request type
+// from a documents/drafts API URL path.
+func parseDocumentsURLPath(path, collection string) (
 	docID string,
-	isRelatedResourcesRequest bool,
+	reqType documentSubcollectionRequestType,
 	err error,
 ) {
-	resourceURLPathRE := regexp.MustCompile(
+	noSubcollectionRE := regexp.MustCompile(
 		fmt.Sprintf(
 			`^\/api\/v1\/%s\/([0-9A-Za-z_\-]+)$`,
-			resourceType))
-	resourceRelatedResourcesURLPathRE := regexp.MustCompile(
+			collection))
+	relatedResourcesSubcollectionRE := regexp.MustCompile(
 		fmt.Sprintf(
 			`^\/api\/v1\/%s\/([0-9A-Za-z_\-]+)\/related-resources$`,
-			resourceType))
+			collection))
+	// shareable isn't really a subcollection, but we'll go with it.
+	shareableRE := regexp.MustCompile(
+		fmt.Sprintf(
+			`^\/api\/v1\/%s\/([0-9A-Za-z_\-]+)\/shareable$`,
+			collection))
 
 	switch {
-	case resourceURLPathRE.MatchString(path):
-		matches := resourceURLPathRE.FindStringSubmatch(path)
+	case noSubcollectionRE.MatchString(path):
+		matches := noSubcollectionRE.FindStringSubmatch(path)
 		if len(matches) != 2 {
-			return "", false, fmt.Errorf(
+			return "", unspecifiedDocumentSubcollectionRequestType, fmt.Errorf(
 				"wrong number of string submatches for resource URL path")
 		}
-		return matches[1], false, nil
+		return matches[1], noSubcollectionRequestType, nil
 
-	case resourceRelatedResourcesURLPathRE.MatchString(path):
-		matches := resourceRelatedResourcesURLPathRE.
+	case relatedResourcesSubcollectionRE.MatchString(path):
+		matches := relatedResourcesSubcollectionRE.
 			FindStringSubmatch(path)
 		if len(matches) != 2 {
 			return "",
-				true,
+				relatedResourcesDocumentSubcollectionRequestType,
 				fmt.Errorf(
-					"wrong number of string submatches for resource related resources URL path")
+					"wrong number of string submatches for related resources subcollection URL path")
 		}
-		return matches[1], true, nil
+		return matches[1], relatedResourcesDocumentSubcollectionRequestType, nil
+
+	case shareableRE.MatchString(path):
+		matches := shareableRE.
+			FindStringSubmatch(path)
+		if len(matches) != 2 {
+			return "",
+				shareableDocumentSubcollectionRequestType,
+				fmt.Errorf(
+					"wrong number of string submatches for shareable subcollection URL path")
+		}
+		return matches[1], shareableDocumentSubcollectionRequestType, nil
 
 	default:
-		return "", false, fmt.Errorf("path did not match any URL strings")
+		return "",
+			unspecifiedDocumentSubcollectionRequestType,
+			fmt.Errorf("path did not match any URL strings")
 	}
 }

--- a/internal/api/documents.go
+++ b/internal/api/documents.go
@@ -125,7 +125,8 @@ func DocumentHandler(
 			return
 		}
 
-		// Pass request off to associated subcollection handler, if appropriate.
+		// Pass request off to associated subcollection (part of the URL after the
+		// document ID) handler, if appropriate.
 		switch reqType {
 		case relatedResourcesDocumentSubcollectionRequestType:
 			documentsResourceRelatedResourcesHandler(w, r, docID, docObj, l, ar, db)

--- a/internal/api/documents_test.go
+++ b/internal/api/documents_test.go
@@ -6,59 +6,56 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseDocumentsURLPath(t *testing.T) {
+func TestParseDocumentIDFromURLPath(t *testing.T) {
 	cases := map[string]struct {
-		url                        string
-		resourceType               string
-		wantDocID                  string
-		wantRelatedResourceRequest bool
-		shouldErr                  bool
+		path        string
+		collection  string
+		wantReqType documentSubcollectionRequestType
+		wantDocID   string
+		shouldErr   bool
 	}{
-		"good document resource URL": {
-			url:          "/api/v1/documents/doc123",
-			resourceType: "documents",
-			wantDocID:    "doc123",
+		"good documents collection URL with related resources": {
+			path:        "/api/v1/documents/doc123/related-resources",
+			collection:  "documents",
+			wantReqType: relatedResourcesDocumentSubcollectionRequestType,
+			wantDocID:   "doc123",
 		},
-		"good document resource URL with related resources": {
-			url:                        "/api/v1/documents/doc123/related-resources",
-			resourceType:               "documents",
-			wantDocID:                  "doc123",
-			wantRelatedResourceRequest: true,
+		"good drafts collection URL with related resources": {
+			path:        "/api/v1/drafts/doc123/related-resources",
+			collection:  "drafts",
+			wantReqType: relatedResourcesDocumentSubcollectionRequestType,
+			wantDocID:   "doc123",
 		},
-		"good draft resource URL": {
-			url:          "/api/v1/drafts/doc123",
-			resourceType: "drafts",
-			wantDocID:    "doc123",
-		},
-		"good draft resource URL with related resources": {
-			url:                        "/api/v1/drafts/doc123/related-resources",
-			resourceType:               "drafts",
-			wantDocID:                  "doc123",
-			wantRelatedResourceRequest: true,
+		"good drafts collection URL with shareable": {
+			path:        "/api/v1/drafts/doc123/shareable",
+			collection:  "drafts",
+			wantReqType: shareableDocumentSubcollectionRequestType,
+			wantDocID:   "doc123",
 		},
 		"extra frontslash after related-resources": {
-			url:          "/api/v1/documents/doc123/related-resources/",
-			resourceType: "documents",
-			shouldErr:    true,
+			path:        "/api/v1/documents/doc123/related-resources/",
+			collection:  "documents",
+			wantReqType: relatedResourcesDocumentSubcollectionRequestType,
+			shouldErr:   true,
 		},
 		"no document resource ID": {
-			url:          "/api/v1/documents/",
-			resourceType: "documents",
-			shouldErr:    true,
+			path:       "/api/v1/documents/",
+			collection: "documents",
+			shouldErr:  true,
 		},
 	}
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
-			docID, rrReq, err := parseDocumentsURLPath(c.url, c.resourceType)
+			docID, reqType, err := parseDocumentsURLPath(c.path, c.collection)
 
 			if c.shouldErr {
 				assert.Error(err)
 			} else {
 				assert.NoError(err)
 				assert.Equal(c.wantDocID, docID)
-				assert.Equal(c.wantRelatedResourceRequest, rrReq)
+				assert.Equal(c.wantReqType, reqType)
 			}
 		})
 	}

--- a/internal/api/drafts.go
+++ b/internal/api/drafts.go
@@ -537,7 +537,8 @@ func DraftsDocumentHandler(
 			return
 		}
 
-		// Pass request off to associated subcollection handler, if appropriate.
+		// Pass request off to associated subcollection (part of the URL after the
+		// draft document ID) handler, if appropriate.
 		switch reqType {
 		case relatedResourcesDocumentSubcollectionRequestType:
 			documentsResourceRelatedResourcesHandler(w, r, docId, docObj, l, ar, db)

--- a/internal/api/drafts.go
+++ b/internal/api/drafts.go
@@ -439,8 +439,8 @@ func DraftsDocumentHandler(
 	db *gorm.DB) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Parse document ID from the URL path.
-		docId, isRelatedResourcesRequest, err := parseDocumentsURLPath(
+		// Parse document ID and request type from the URL path.
+		docId, reqType, err := parseDocumentsURLPath(
 			r.URL.Path, "drafts")
 		if err != nil {
 			l.Error("error parsing drafts URL path",
@@ -503,6 +503,22 @@ func DraftsDocumentHandler(
 			return
 		}
 
+		// Get document from database.
+		doc := models.Document{
+			GoogleFileID: docId,
+		}
+		if err := doc.Get(db); err != nil {
+			l.Error("error getting document draft from database",
+				"error", err,
+				"path", r.URL.Path,
+				"method", r.Method,
+				"doc_id", docId,
+			)
+			http.Error(w, "Error requesting document draft",
+				http.StatusInternalServerError)
+			return
+		}
+
 		// Authorize request (only allow owners or contributors to get past this
 		// point in the handler). We further authorize some methods later that
 		// require owner access only.
@@ -514,17 +530,20 @@ func DraftsDocumentHandler(
 		if contains(docObj.GetContributors(), userEmail) {
 			isContributor = true
 		}
-		if !isOwner && !isContributor {
+		if !isOwner && !isContributor && !doc.ShareableAsDraft {
 			http.Error(w,
-				"Only owners or contributors can access a draft document",
+				"Only owners or contributors can access a non-shared draft document",
 				http.StatusUnauthorized)
 			return
 		}
 
-		// Pass request off to the documents related resources handler if
-		// appropriate.
-		if isRelatedResourcesRequest {
+		// Pass request off to associated subcollection handler, if appropriate.
+		switch reqType {
+		case relatedResourcesDocumentSubcollectionRequestType:
 			documentsResourceRelatedResourcesHandler(w, r, docId, docObj, l, ar, db)
+			return
+		case shareableDocumentSubcollectionRequestType:
+			draftsShareableHandler(w, r, docId, docObj, *cfg, l, ar, s, db)
 			return
 		}
 
@@ -561,22 +580,6 @@ func DraftsDocumentHandler(
 
 			// Set custom editable fields.
 			docObj.SetCustomEditableFields()
-
-			// Get document from database.
-			doc := models.Document{
-				GoogleFileID: docId,
-			}
-			if err := doc.Get(db); err != nil {
-				l.Error("error getting document draft from database",
-					"error", err,
-					"path", r.URL.Path,
-					"method", r.Method,
-					"doc_id", docId,
-				)
-				http.Error(w, "Error requesting document draft",
-					http.StatusInternalServerError)
-				return
-			}
 
 			// Set locked value for response to value from the database (this value
 			// isn't stored in Algolia).

--- a/internal/api/drafts_shareable.go
+++ b/internal/api/drafts_shareable.go
@@ -1,0 +1,192 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/hashicorp-forge/hermes/internal/config"
+	"github.com/hashicorp-forge/hermes/pkg/algolia"
+	gw "github.com/hashicorp-forge/hermes/pkg/googleworkspace"
+	hcd "github.com/hashicorp-forge/hermes/pkg/hashicorpdocs"
+	"github.com/hashicorp-forge/hermes/pkg/models"
+	"github.com/hashicorp/go-hclog"
+	"gorm.io/gorm"
+)
+
+type draftsShareablePutRequest struct {
+	IsShareable *bool `json:"isShareable"`
+}
+
+type draftsShareableGetResponse struct {
+	IsShareable bool `json:"isShareable"`
+}
+
+func draftsShareableHandler(
+	w http.ResponseWriter,
+	r *http.Request,
+	docID string,
+	docObj hcd.Doc,
+	cfg config.Config,
+	l hclog.Logger,
+	algoRead *algolia.Client,
+	goog *gw.Service,
+	db *gorm.DB,
+) {
+	switch r.Method {
+	case "GET":
+		// Get document from database.
+		d := models.Document{
+			GoogleFileID: docID,
+		}
+		if err := d.Get(db); err != nil {
+			l.Error("error getting document from database",
+				"error", err,
+				"path", r.URL.Path,
+				"method", r.Method,
+				"doc_id", docID,
+			)
+			http.Error(w, "Error accessing document",
+				http.StatusInternalServerError)
+			return
+		}
+
+		resp := draftsShareableGetResponse{
+			IsShareable: d.ShareableAsDraft,
+		}
+
+		// Write response.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		enc := json.NewEncoder(w)
+		if err := enc.Encode(resp); err != nil {
+			l.Error("error encoding response",
+				"error", err,
+				"doc_id", docID,
+			)
+			http.Error(w, "Error building response", http.StatusInternalServerError)
+			return
+		}
+
+	case "PUT":
+		// Authorize request (only the document owner is authorized).
+		userEmail := r.Context().Value("userEmail").(string)
+		if docObj.GetOwners()[0] != userEmail {
+			http.Error(w, "Only the document owner can change shareable settings",
+				http.StatusForbidden)
+			return
+		}
+
+		// Decode request.
+		var req draftsShareablePutRequest
+		if err := decodeRequest(r, &req); err != nil {
+			l.Error("error decoding request",
+				"error", err,
+				"path", r.URL.Path,
+				"method", r.Method,
+				"doc_id", docID,
+			)
+			http.Error(w, "Bad request", http.StatusBadRequest)
+			return
+		}
+
+		// Validate request.
+		if req.IsShareable == nil {
+			l.Warn("bad request: missing required 'isShareable' field",
+				"path", r.URL.Path,
+				"method", r.Method,
+				"doc_id", docID,
+			)
+			http.Error(w,
+				"Bad request: missing required 'isShareable' field",
+				http.StatusBadRequest)
+			return
+		}
+
+		// Get document from database.
+		doc := models.Document{
+			GoogleFileID: docID,
+		}
+		if err := doc.Get(db); err != nil {
+			l.Error("error getting document from database",
+				"error", err,
+				"path", r.URL.Path,
+				"method", r.Method,
+				"doc_id", docID,
+			)
+			http.Error(w, "Error accessing document",
+				http.StatusInternalServerError)
+			return
+		}
+
+		// Find out if the draft is already shared with the domain.
+		perms, err := goog.ListPermissions(docID)
+		if err != nil {
+			l.Error("error listing Google Drive permissions",
+				"error", err,
+				"path", r.URL.Path,
+				"method", r.Method,
+				"doc_id", docID,
+			)
+			http.Error(w,
+				"Error updating document permissions",
+				http.StatusInternalServerError)
+			return
+		}
+		alreadySharedPermIDs := []string{}
+		for _, p := range perms {
+			isInherited := false
+			for _, pd := range p.PermissionDetails {
+				if pd.Inherited {
+					isInherited = true
+				}
+			}
+			if p.Domain == cfg.GoogleWorkspace.Domain &&
+				p.Role == "commenter" &&
+				!isInherited {
+				alreadySharedPermIDs = append(alreadySharedPermIDs, p.Id)
+			}
+		}
+
+		// Update file permissions, if necessary.
+		if *req.IsShareable {
+			if len(alreadySharedPermIDs) == 0 {
+				// File is not already shared with domain, so share it.
+				goog.ShareFileWithDomain(docID, cfg.GoogleWorkspace.Domain, "commenter")
+			}
+		} else {
+			for _, id := range alreadySharedPermIDs {
+				// File is already shared with domain, so remove the permission.
+				goog.DeletePermission(docID, id)
+			}
+		}
+
+		// Update ShareableAsDraft for document in the database.
+		if err := db.Model(&doc).
+			// We need to update using Select because ShareableAsDraft is a
+			// boolean.
+			Select("ShareableAsDraft").
+			Updates(models.Document{ShareableAsDraft: *req.IsShareable}).
+			Error; err != nil {
+			l.Error("error updating ShareableAsDraft in the database",
+				"error", err,
+				"path", r.URL.Path,
+				"method", r.Method,
+				"doc_id", docID,
+			)
+			http.Error(w, "Error updating document draft",
+				http.StatusInternalServerError)
+			return
+		}
+
+		l.Info("updated ShareableAsDraft for document",
+			"path", r.URL.Path,
+			"method", r.Method,
+			"doc_id", docID,
+			"shareable_as_draft", doc.ShareableAsDraft,
+		)
+
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+}

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -157,14 +157,6 @@ func (c *Command) Run(args []string) int {
 			return 1
 		}
 	}
-	if cfg.GoogleWorkspace == nil {
-		c.UI.Error("error validating config: google_workspace block is required")
-		return 1
-	}
-	if cfg.GoogleWorkspace.Domain == "" {
-		c.UI.Error("error validating config: google_workspace domain is required")
-		return 1
-	}
 
 	// Build configuration for Okta authentication.
 	if !cfg.Okta.Disabled {
@@ -198,6 +190,7 @@ func (c *Command) Run(args []string) int {
 		cfg.Algolia.SearchAPIKey:            "Algolia Search API Key is required",
 		cfg.BaseURL:                         "Base URL is required",
 		cfg.GoogleWorkspace.DocsFolder:      "Google Workspace Docs Folder is required",
+		cfg.GoogleWorkspace.Domain:          "Google Workspace Domain is required",
 		cfg.GoogleWorkspace.DraftsFolder:    "Google Workspace Drafts Folder is required",
 		cfg.GoogleWorkspace.ShortcutsFolder: "Google Workspace Shortcuts Folder is required",
 	}

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -157,6 +157,14 @@ func (c *Command) Run(args []string) int {
 			return 1
 		}
 	}
+	if cfg.GoogleWorkspace == nil {
+		c.UI.Error("error validating config: google_workspace block is required")
+		return 1
+	}
+	if cfg.GoogleWorkspace.Domain == "" {
+		c.UI.Error("error validating config: google_workspace domain is required")
+		return 1
+	}
 
 	// Build configuration for Okta authentication.
 	if !cfg.Okta.Disabled {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -177,6 +177,9 @@ type GoogleWorkspace struct {
 	// DocsFolder is the folder that contains all published documents.
 	DocsFolder string `hcl:"docs_folder"`
 
+	// Domain is the Google Workspace domain (e.g., "hashicorp.com").
+	Domain string `hcl:"domain"`
+
 	// DraftsFolder is the folder that contains all document drafts.
 	DraftsFolder string `hcl:"drafts_folder"`
 

--- a/pkg/googleworkspace/drive_helpers.go
+++ b/pkg/googleworkspace/drive_helpers.go
@@ -349,6 +349,24 @@ func (s *Service) ShareFile(
 	return nil
 }
 
+// ShareFileWithDomain shares a Google Drive file with a domain.
+func (s *Service) ShareFileWithDomain(
+	fileID, domain, role string) error {
+
+	_, err := s.Drive.Permissions.Create(fileID,
+		&drive.Permission{
+			Domain: domain,
+			Role:   role,
+			Type:   "domain",
+		}).
+		SupportsAllDrives(true).
+		Do()
+	if err != nil {
+		return fmt.Errorf("error updating file permissions: %w", err)
+	}
+	return nil
+}
+
 // ListPermissions lists permissions for a Google Drive file.
 func (s *Service) ListPermissions(fileID string) ([]*drive.Permission, error) {
 	var permissions []*drive.Permission

--- a/pkg/models/document.go
+++ b/pkg/models/document.go
@@ -62,6 +62,10 @@ type Document struct {
 	// Status is the status of the document.
 	Status DocumentStatus
 
+	// ShareableAsDraft is true if the document can be shared in the WIP (draft)
+	// status.
+	ShareableAsDraft bool
+
 	// Summary is a summary of the document.
 	Summary string
 


### PR DESCRIPTION
This PR adds an API for sharing drafts documents with the Google Workspace organization.

### Breaking changes

- New required `google_workspace.domain` config attribute:
```hcl
google_workspace {
  // domain is the Google Workspace domain (e.g., "hashicorp.com").
  domain = "your-domain-dot-com"
}
```

### New API endpoints

- `/api/v1/drafts/{document_id}/shareable`
  - Methods: GET, PUT
