### PR TITLE
Update `editingIsDisabled` conditions

### DIFF
--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -125,7 +125,7 @@
 
       <div class="flex flex-col items-start space-y-2">
         <Document::Sidebar::SectionHeader @title="Product/Area" />
-        {{#if this.isDraft}}
+        {{#if (and this.isDraft this.userHasEditPrivileges)}}
           <div class="w-full relative">
             <Inputs::ProductSelect
               @selected={{this.product}}

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -3,12 +3,16 @@
   @isCollapsed={{@isCollapsed}}
   @toggleCollapsed={{@toggleCollapsed}}
   @userHasScrolled={{this.userHasScrolled}}
+  @shareButtonIsShown={{this.shareButtonIsShown}}
+  @shareButtonTooltipText={{this.temporaryShareButtonTooltipText}}
+  @shareButtonIcon={{this.temporaryShareButtonIcon}}
 />
+
 {{#unless @isCollapsed}}
   <div
     class="sidebar-body"
     {{on "scroll" this.onScroll}}
-    {{did-insert this.registerBody}}
+    {{did-insert this.didInsertBody}}
   >
     {{#let (get-product-id this.product) as |productIcon|}}
       {{#if productIcon}}
@@ -23,66 +27,123 @@
     {{/let}}
 
     <div class="sidebar-body-container">
-      <div class="flex flex-col items-start space-y-2">
-        {{#if (is-empty @document.docNumber)}}
-          <small class="hds-typography-body-100 hds-foreground-faint">{{#unless
-              (is-empty @document.docType)
-            }}{{@document.docType}}{{/unless}}
-          </small>
-        {{else}}
-          <small class="hds-typography-body-100 hds-foreground-faint">{{#unless
-              (is-empty @document.docType)
-            }}{{@document.docType}}{{/unless}}
-            &bullet;
-            <span data-test-sidebar-doc-number>
-              {{@document.docNumber}}
-            </span>
-          </small>
-        {{/if}}
+      <div>
+        {{! div to break the parent's space-y styles }}
+        <div
+          class="flex items-center space-x-1.5
+            {{if this.isDraft 'mb-4 -mt-2' 'mb-2'}}"
+        >
+          <Hds::Badge
+            data-test-sidebar-title-badge
+            @text={{if this.isDraft "Draft" @document.docNumber}}
+            class="uppercase !rounded-[3px]
+              {{if
+                @document.isDraft
+                '!bg-color-palette-neutral-500 !text-white'
+                '!bg-transparent pl-0 !text-color-foreground-faint'
+              }}
+              "
+          />
+          {{#if this.isDraft}}
+            <X::DropdownList
+              data-test-draft-visibility-dropdown
+              @items={{this.draftVisibilityOptions}}
+              @selected={{this.draftVisibility}}
+              @renderOut={{true}}
+              @offset={{hash mainAxis=0 crossAxis=-7}}
+              class="w-[350px]"
+            >
+              <:anchor as |dd|>
+                <dd.ToggleAction
+                  data-test-draft-visibility-toggle
+                  data-test-icon={{this.draftVisibilityIcon}}
+                  data-test-chevron-direction={{if
+                    dd.contentIsShown
+                    "up"
+                    "down"
+                  }}
+                  class="flex items-center text-color-foreground-faint sidebar-header-button draft-visibility-button"
+                  {{tooltip
+                    this.toggleDraftVisibilityTooltipText
+                    placement="bottom"
+                  }}
+                >
+                  <FlightIcon @name={{this.draftVisibilityIcon}} />
+                  <FlightIcon
+                    @name={{if dd.contentIsShown "chevron-up" "chevron-down"}}
+                  />
+                </dd.ToggleAction>
+              </:anchor>
+              <:item as |dd|>
+                <dd.Action
+                  data-test-draft-visibility-option
+                  data-test-is-checked={{dd.isSelected}}
+                  data-test-value={{dd.value}}
+                  class="flex items-start gap-3 py-2.5 pl-4 pr-6"
+                  {{on "click" (perform this.setDraftVisibility dd.value)}}
+                >
+                  <FlightIcon @name={{dd.attrs.icon}} class="shrink-0 mt-0.5" />
+                  <div class="w-full">
+                    <h4>{{dd.attrs.title}}</h4>
+                    <p>{{dd.attrs.description}}</p>
+                  </div>
+                  <FlightIcon
+                    @name="check"
+                    class="check shrink-0 mt-0.5
+                      {{if dd.isSelected 'visible' 'invisible'}}"
+                  />
+                </dd.Action>
+              </:item>
+            </X::DropdownList>
+          {{/if}}
+        </div>
         {{#if this.isOwner}}
-          <EditableField
-            data-test-document-title-editable
-            @value={{this.title}}
-            @onChange={{perform this.save "title"}}
-            @loading={{this.save.isRunning}}
-            @disabled={{this.editingIsDisabled}}
-          >
-            <:default>
-              {{#unless (is-empty this.title)}}
-                <h1
-                  class="hds-typography-display-300 hds-font-weight-semibold hds-foreground-strong"
-                >{{this.title}}</h1>
-              {{else}}
-                <h1
-                  class="hds-typography-display-300 hds-font-weight-semibold hds-foreground-faint"
-                >Enter a title here.</h1>
-              {{/unless}}
-            </:default>
-            <:editing as |F|>
-              <Hds::Form::Textarea::Field
-                {{auto-height-textarea}}
-                @value={{F.value}}
-                class="primary-textarea"
-                name="title"
-                {{on "blur" F.update}}
-                as |F|
-              />
-            </:editing>
-          </EditableField>
+          <div class="mb-8">
+            <EditableField
+              data-test-document-title-editable
+              @value={{this.title}}
+              @onChange={{perform this.save "title"}}
+              @loading={{this.save.isRunning}}
+              @disabled={{this.editingIsDisabled}}
+            >
+              <:default>
+                {{#unless (is-empty this.title)}}
+                  <h1
+                    class="hds-typography-display-300 hds-font-weight-semibold hds-foreground-strong"
+                  >{{this.title}}</h1>
+                {{else}}
+                  <h1
+                    data-test-document-title-read-only
+                    class="hds-typography-display-300 hds-font-weight-semibold hds-foreground-faint"
+                  >
+                    Enter a title here.
+                  </h1>
+                {{/unless}}
+              </:default>
+              <:editing as |F|>
+                <Hds::Form::Textarea::Field
+                  {{auto-height-textarea}}
+                  @value={{F.value}}
+                  class="primary-textarea"
+                  name="title"
+                  {{on "blur" F.update}}
+                  as |F|
+                />
+              </:editing>
+            </EditableField>
+          </div>
         {{else}}
           <h1
-            data-test-document-title-read-only
             class="hds-typography-display-300 hds-font-weight-semibold hds-foreground-strong"
-          >
-            {{this.title}}
-          </h1>
+          >{{this.title}}</h1>
         {{/if}}
       </div>
 
       <hr class="border-0 border-b hds-border-faint" />
 
-      <div class="flex flex-col items-start space-y-2">
-        <Document::Sidebar::SectionHeader @title="Summary" />
+      {{! Summary }}
+      <div class="mb-5">
+        <Document::Sidebar::SectionHeader @title="Summary" class="mb-2" />
         {{#if this.isOwner}}
           <EditableField
             data-test-document-summary-editable
@@ -127,7 +188,10 @@
 
       <div class="flex flex-col items-start space-y-2">
         <Document::Sidebar::SectionHeader @title="Status" />
-        <Doc::State @state={{@document.status}} @hideProgress={{true}} />
+        <div class="flex space-x-1">
+          <Doc::State @state={{@document.status}} @hideProgress={{true}} />
+          <Hds::Badge @text={{@document.docType}} />
+        </div>
       </div>
 
       <div class="flex flex-col items-start space-y-2">
@@ -226,21 +290,23 @@
             @disabled={{this.editingIsDisabled}}
           >
             <:default>
-              {{#if this.approvers.length}}
-                <ol class="person-list">
-                  {{#each this.approvers as |approver|}}
-                    <li>
-                      <Person::Approver
-                        @document={{@document}}
-                        @imgURL={{approver.imgURL}}
-                        @email={{approver.email}}
-                      />
-                    </li>
-                  {{/each}}
-                </ol>
-              {{else}}
-                <em>No approvers</em>
-              {{/if}}
+              <div data-test-document-approvers-read-only>
+                {{#if this.approvers.length}}
+                  <ol class="person-list">
+                    {{#each this.approvers as |approver|}}
+                      <li>
+                        <Person::Approver
+                          @document={{@document}}
+                          @imgURL={{approver.imgURL}}
+                          @email={{approver.email}}
+                        />
+                      </li>
+                    {{/each}}
+                  </ol>
+                {{else}}
+                  <em>No approvers</em>
+                {{/if}}
+              </div>
             </:default>
             <:editing as |F|>
               <Inputs::PeopleSelect
@@ -252,23 +318,21 @@
             </:editing>
           </EditableField>
         {{else}}
-          <div data-test-document-approvers-read-only>
-            {{#if this.approvers.length}}
-              <ol class="person-list">
-                {{#each this.approvers as |approver|}}
-                  <li>
-                    <Person::Approver
-                      @document={{@document}}
-                      @imgURL={{approver.imgURL}}
-                      @email={{approver.email}}
-                    />
-                  </li>
-                {{/each}}
-              </ol>
-            {{else}}
-              <em>No approvers</em>
-            {{/if}}
-          </div>
+          {{#if this.approvers.length}}
+            <ol class="person-list">
+              {{#each this.approvers as |approver|}}
+                <li>
+                  <Person::Approver
+                    @document={{@document}}
+                    @imgURL={{approver.imgURL}}
+                    @email={{approver.email}}
+                  />
+                </li>
+              {{/each}}
+            </ol>
+          {{else}}
+            <em>No approvers</em>
+          {{/if}}
         {{/if}}
       </div>
 
@@ -284,7 +348,7 @@
 
       <div class="flex flex-col items-start">
         <Document::Sidebar::RelatedResources
-          @editingIsDisabled={{not this.isOwner}}
+          @editingIsDisabled={{this.editingIsDisabled}}
           @documentIsDraft={{this.isDraft}}
           @productArea={{@document.product}}
           @objectID={{@document.objectID}}
@@ -380,6 +444,7 @@
         {{else}}
           {{#if this.isOwner}}
             <div class="flex items-start px-3 gap-2">
+
               <Hds::Button
                 @text={{this.moveToStatusButtonText}}
                 @size="medium"
@@ -406,6 +471,7 @@
                 {{on "click" (fn (set this "archiveModalIsActive" true))}}
               />
             </div>
+
           {{else}}
             {{#if this.isApprover}}
               <div class="flex flex-col items-start px-3 gap-2">
@@ -442,6 +508,7 @@
           {{/if}}
         {{/if}}
       {{/if}}
+
     </div>
   {{/if}}
 {{/unless}}

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -134,6 +134,7 @@
           </div>
         {{else}}
           <h1
+            data-test-document-title-read-only
             class="hds-typography-display-300 hds-font-weight-semibold hds-foreground-strong"
           >{{this.title}}</h1>
         {{/if}}
@@ -290,23 +291,21 @@
             @disabled={{this.editingIsDisabled}}
           >
             <:default>
-              <div data-test-document-approvers-read-only>
-                {{#if this.approvers.length}}
-                  <ol class="person-list">
-                    {{#each this.approvers as |approver|}}
-                      <li>
-                        <Person::Approver
-                          @document={{@document}}
-                          @imgURL={{approver.imgURL}}
-                          @email={{approver.email}}
-                        />
-                      </li>
-                    {{/each}}
-                  </ol>
-                {{else}}
-                  <em>No approvers</em>
-                {{/if}}
-              </div>
+              {{#if this.approvers.length}}
+                <ol class="person-list">
+                  {{#each this.approvers as |approver|}}
+                    <li>
+                      <Person::Approver
+                        @document={{@document}}
+                        @imgURL={{approver.imgURL}}
+                        @email={{approver.email}}
+                      />
+                    </li>
+                  {{/each}}
+                </ol>
+              {{else}}
+                <em>No approvers</em>
+              {{/if}}
             </:default>
             <:editing as |F|>
               <Inputs::PeopleSelect
@@ -318,21 +317,23 @@
             </:editing>
           </EditableField>
         {{else}}
-          {{#if this.approvers.length}}
-            <ol class="person-list">
-              {{#each this.approvers as |approver|}}
-                <li>
-                  <Person::Approver
-                    @document={{@document}}
-                    @imgURL={{approver.imgURL}}
-                    @email={{approver.email}}
-                  />
-                </li>
-              {{/each}}
-            </ol>
-          {{else}}
-            <em>No approvers</em>
-          {{/if}}
+          <div data-test-document-approvers-read-only>
+            {{#if this.approvers.length}}
+              <ol class="person-list">
+                {{#each this.approvers as |approver|}}
+                  <li>
+                    <Person::Approver
+                      @document={{@document}}
+                      @imgURL={{approver.imgURL}}
+                      @email={{approver.email}}
+                    />
+                  </li>
+                {{/each}}
+              </ol>
+            {{else}}
+              <em>No approvers</em>
+            {{/if}}
+          </div>
         {{/if}}
       </div>
 

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -298,12 +298,7 @@
       </div>
 
       {{#each-in this.customEditableFields as |field attributes|}}
-        {{#if
-          (or
-            (and (not this.editingIsDisabled) (not this.docIsApproved))
-            attributes.value
-          )
-        }}
+        {{#if (or attributes.value this.isOwner)}}
           <div class="flex flex-col items-start space-y-2">
             <Document::Sidebar::SectionHeader
               @title={{attributes.displayName}}
@@ -314,7 +309,7 @@
               @attributes={{attributes}}
               @onChange={{perform this.save field}}
               @loading={{this.save.isRunning}}
-              @disabled={{or this.editingIsDisabled (not this.isOwner)}}
+              @disabled={{this.editingIsDisabled}}
             />
           </div>
         {{/if}}
@@ -385,7 +380,6 @@
         {{else}}
           {{#if this.isOwner}}
             <div class="flex items-start px-3 gap-2">
-
               <Hds::Button
                 @text={{this.moveToStatusButtonText}}
                 @size="medium"
@@ -412,7 +406,6 @@
                 {{on "click" (fn (set this "archiveModalIsActive" true))}}
               />
             </div>
-
           {{else}}
             {{#if this.isApprover}}
               <div class="flex flex-col items-start px-3 gap-2">
@@ -449,7 +442,6 @@
           {{/if}}
         {{/if}}
       {{/if}}
-
     </div>
   {{/if}}
 {{/unless}}

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -4,7 +4,6 @@
   @toggleCollapsed={{@toggleCollapsed}}
   @userHasScrolled={{this.userHasScrolled}}
 />
-
 {{#unless @isCollapsed}}
   <div
     class="sidebar-body"
@@ -40,12 +39,9 @@
             </span>
           </small>
         {{/if}}
-        {{#if this.editingIsDisabled}}
-          <h1
-            class="hds-typography-display-300 hds-font-weight-semibold hds-foreground-strong"
-          >{{this.title}}</h1>
-        {{else}}
+        {{#if this.isOwner}}
           <EditableField
+            data-test-document-title-editable
             @value={{this.title}}
             @onChange={{perform this.save "title"}}
             @loading={{this.save.isRunning}}
@@ -73,6 +69,13 @@
               />
             </:editing>
           </EditableField>
+        {{else}}
+          <h1
+            data-test-document-title-read-only
+            class="hds-typography-display-300 hds-font-weight-semibold hds-foreground-strong"
+          >
+            {{this.title}}
+          </h1>
         {{/if}}
       </div>
 
@@ -80,12 +83,9 @@
 
       <div class="flex flex-col items-start space-y-2">
         <Document::Sidebar::SectionHeader @title="Summary" />
-        {{#if this.editingIsDisabled}}
-          <p
-            class="hds-typography-body-200 hds-font-weight-medium hds-foreground-primary"
-          >{{this.summary}}</p>
-        {{else}}
+        {{#if this.isOwner}}
           <EditableField
+            data-test-document-summary-editable
             @value={{this.summary}}
             @onChange={{perform this.save "summary"}}
             @loading={{this.save.isRunning}}
@@ -115,6 +115,13 @@
               />
             </:editing>
           </EditableField>
+        {{else}}
+          <p
+            data-test-document-summary-read-only
+            class="hds-typography-body-200 hds-font-weight-medium hds-foreground-primary"
+          >
+            {{this.summary}}
+          </p>
         {{/if}}
       </div>
 
@@ -125,9 +132,10 @@
 
       <div class="flex flex-col items-start space-y-2">
         <Document::Sidebar::SectionHeader @title="Product/Area" />
-        {{#if (and this.isDraft this.userHasEditPrivileges)}}
+        {{#if (and this.isDraft this.isOwner)}}
           <div class="w-full relative">
             <Inputs::ProductSelect
+              data-test-document-product-area-editable
               @selected={{this.product}}
               @onChange={{this.updateProduct.perform}}
               @isSaving={{this.save.isRunning}}
@@ -137,6 +145,7 @@
           </div>
         {{else}}
           <Hds::Badge
+            data-test-document-product-area-read-only
             @text={{@document.product}}
             @icon={{get-product-id @document.product}}
           />
@@ -155,6 +164,7 @@
         <Document::Sidebar::SectionHeader @title="Contributors" />
         {{#if this.isOwner}}
           <EditableField
+            data-test-document-contributors-editable
             @value={{this.contributors}}
             @onChange={{perform this.save "contributors"}}
             @loading={{this.save.isRunning}}
@@ -186,20 +196,22 @@
             </:editing>
           </EditableField>
         {{else}}
-          {{#if this.contributors.length}}
-            <ol class="person-list">
-              {{#each this.contributors as |contributor|}}
-                <li>
-                  <Person
-                    @imgURL={{contributor.imgURL}}
-                    @email={{contributor.email}}
-                  />
-                </li>
-              {{/each}}
-            </ol>
-          {{else}}
-            <em>No contributors</em>
-          {{/if}}
+          <div data-test-document-contributors-read-only>
+            {{#if this.contributors.length}}
+              <ol class="person-list">
+                {{#each this.contributors as |contributor|}}
+                  <li>
+                    <Person
+                      @imgURL={{contributor.imgURL}}
+                      @email={{contributor.email}}
+                    />
+                  </li>
+                {{/each}}
+              </ol>
+            {{else}}
+              <em>No contributors</em>
+            {{/if}}
+          </div>
         {{/if}}
       </div>
 
@@ -207,6 +219,7 @@
         <Document::Sidebar::SectionHeader @title="Approvers" />
         {{#if this.isOwner}}
           <EditableField
+            data-test-document-approvers-editable
             @value={{this.approvers}}
             @onChange={{perform this.save "approvers"}}
             @loading={{this.save.isRunning}}
@@ -239,21 +252,23 @@
             </:editing>
           </EditableField>
         {{else}}
-          {{#if this.approvers.length}}
-            <ol class="person-list">
-              {{#each this.approvers as |approver|}}
-                <li>
-                  <Person::Approver
-                    @document={{@document}}
-                    @imgURL={{approver.imgURL}}
-                    @email={{approver.email}}
-                  />
-                </li>
-              {{/each}}
-            </ol>
-          {{else}}
-            <em>No approvers</em>
-          {{/if}}
+          <div data-test-document-approvers-read-only>
+            {{#if this.approvers.length}}
+              <ol class="person-list">
+                {{#each this.approvers as |approver|}}
+                  <li>
+                    <Person::Approver
+                      @document={{@document}}
+                      @imgURL={{approver.imgURL}}
+                      @email={{approver.email}}
+                    />
+                  </li>
+                {{/each}}
+              </ol>
+            {{else}}
+              <em>No approvers</em>
+            {{/if}}
+          </div>
         {{/if}}
       </div>
 
@@ -269,7 +284,7 @@
 
       <div class="flex flex-col items-start">
         <Document::Sidebar::RelatedResources
-          @editingIsDisabled={{this.editingIsDisabled}}
+          @editingIsDisabled={{not this.isOwner}}
           @documentIsDraft={{this.isDraft}}
           @productArea={{@document.product}}
           @objectID={{@document.objectID}}
@@ -307,7 +322,7 @@
     </div>
   </div>
 
-  {{#if this.userHasEditPrivileges}}
+  {{#if this.isOwner}}
     <div class="sidebar-footer {{if this.editingIsDisabled 'locked'}}">
       {{#if this.editingIsDisabled}}
         <div class="px-3 -mb-1">

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -44,7 +44,7 @@
               }}
               "
           />
-          {{#if this.isDraft}}
+          {{#if (and this.isDraft this.isOwner)}}
             <X::DropdownList
               data-test-draft-visibility-dropdown
               @items={{this.draftVisibilityOptions}}

--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -169,34 +169,56 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
     );
   }
 
-  get docIsApproved() {
+  /**
+   * Whether the doc status is approved. Used to determine editing privileges.
+   * If the doc is approved, editing is exclusive to the doc owner.
+   */
+  private get docIsApproved() {
     return this.args.document.status.toLowerCase() === "approved";
   }
 
-  get docIsInReview() {
+  /**
+   * Whether the doc status is in review. Used to determine editing privileges.
+   * If the doc is in review, editing is exclusive to the doc owner.
+   */
+  private get docIsInReview() {
     return dasherize(this.args.document.status) === "in-review";
   }
 
-  // isOwner returns true if the logged in user is the document owner.
-  get isOwner() {
+  /**
+   * Whether the document viewer is its owner.
+   * True if the logged in user's email matches the documents owner.
+   */
+  protected get isOwner() {
     return this.args.document.owners?.[0] === this.args.profile.email;
   }
 
-  get userHasEditPrivileges() {
-    return this.isOwner || this.isContributor;
-  }
-
-  get editingIsDisabled() {
-    if (!this.args.document.appCreated || this.docIsLocked) {
-      // true is the doc wasn't appCreated or is in a locked state
+  /**
+   * Whether the editing of document metadata allowed, excluding the
+   * product/area field, which is disallowed for published docs.
+   * If the doc is locked, editing is disabled and a message is shown
+   * explaining that suggestions must be removed from the header.
+   *
+   * If the doc was created off-app, editing is disabled and a message
+   * is shown explaining that only app-created docs can be edited.
+   *
+   * If the doc is in a known state, e.g., draft, in review, or approved,
+   * editing is disabled for non-doc-owners.
+   *
+   * If the doc is in an unknown state, editing is disabled.
+   */
+  protected get editingIsDisabled() {
+    if (this.docIsLocked) {
       return true;
-    } else if (this.isDraft) {
-      // true is the doc is a draft/in review/approved and the user is not an owner, contributor, or approver
-      return !this.userHasEditPrivileges;
-    } else if (this.docIsInReview || this.docIsApproved) {
+    }
+
+    if (!this.args.document.appCreated) {
+      return true;
+    }
+
+    if (this.isDraft || this.docIsInReview || this.docIsApproved) {
       return !this.isOwner;
     } else {
-      // doc is obsolete or some unknown status..
       return true;
     }
   }

--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -190,9 +190,11 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
     if (!this.args.document.appCreated || this.docIsLocked) {
       // true is the doc wasn't appCreated or is in a locked state
       return true;
-    } else if (this.isDraft || this.docIsInReview || this.docIsApproved) {
+    } else if (this.isDraft) {
       // true is the doc is a draft/in review/approved and the user is not an owner, contributor, or approver
       return !this.userHasEditPrivileges;
+    } else if (this.docIsInReview || this.docIsApproved) {
+      return !this.isOwner;
     } else {
       // doc is obsolete or some unknown status..
       return true;

--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -183,7 +183,7 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
   }
 
   get userHasEditPrivileges() {
-    return this.isOwner || this.isContributor || this.isApprover;
+    return this.isOwner || this.isContributor;
   }
 
   get editingIsDisabled() {

--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -223,6 +223,14 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
     }
   }
 
+  /**
+   * Whether editing is enabled for basic metadata fields.
+   * Used in the template to make some logic more readable.
+   */
+  protected get editingIsEnabled() {
+    return !this.editingIsDisabled;
+  }
+
   @action refreshRoute() {
     // We force refresh due to a bug with `refreshModel: true`
     // See: https://github.com/emberjs/ember.js/issues/19260

--- a/web/app/components/inputs/product-select/index.hbs
+++ b/web/app/components/inputs/product-select/index.hbs
@@ -1,5 +1,5 @@
 {{! https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/ }}
-<div data-test-product-select>
+<div data-test-product-select ...attributes>
   {{#if this.products}}
     {{#if @formatIsBadge}}
       <Inputs::BadgeDropdownList

--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -214,8 +214,13 @@ export default function (mirageConfig) {
 
       /**
        * Used by the PeopleSelect component to get a list of people.
+       * Used to confirm that an approver has access to a document.
        */
-      this.get("/people", (schema) => {
+      this.get("/people", (schema, request) => {
+        // This allows the test user to view docs they're an approver on.
+        if (request.queryParams.emails === "testuser@example.com") {
+          return new Response(200, {}, []);
+        }
         return schema.people.all();
       });
 
@@ -245,7 +250,6 @@ export default function (mirageConfig) {
        * Used by the RelatedResources component when the doc is a draft.
        */
       this.get("drafts/:document_id/related-resources", (schema, request) => {
-        console.log('drafts related resources');
         let hermesDocuments = schema.relatedHermesDocument
           .all()
           .models.map((doc) => {

--- a/web/tests/acceptance/authenticated/document-test.ts
+++ b/web/tests/acceptance/authenticated/document-test.ts
@@ -53,6 +53,7 @@ const assertEditingIsDisabled = (assert: Assert) => {
   assert.dom(EDITABLE_CONTRIBUTORS_SELECTOR).doesNotExist();
   assert.dom(EDITABLE_APPROVERS_SELECTOR).doesNotExist();
 
+  assert.dom(DRAFT_VISIBILITY_TOGGLE_SELECTOR).doesNotExist();
   assert.dom(ADD_RELATED_RESOURCE_BUTTON_SELECTOR).doesNotExist();
 
   assert.dom(READ_ONLY_TITLE_SELECTOR).exists();
@@ -333,6 +334,7 @@ module("Acceptance | authenticated/document", function (hooks) {
     assert.dom(EDITABLE_CONTRIBUTORS_SELECTOR).exists();
     assert.dom(EDITABLE_APPROVERS_SELECTOR).exists();
 
+    assert.dom(DRAFT_VISIBILITY_TOGGLE_SELECTOR).exists();
     assert.dom(ADD_RELATED_RESOURCE_BUTTON_SELECTOR).exists();
 
     assert.dom(READ_ONLY_TITLE_SELECTOR).doesNotExist();
@@ -357,6 +359,7 @@ module("Acceptance | authenticated/document", function (hooks) {
     assert.dom(EDITABLE_CONTRIBUTORS_SELECTOR).exists();
     assert.dom(EDITABLE_APPROVERS_SELECTOR).exists();
 
+    assert.dom(DRAFT_VISIBILITY_TOGGLE_SELECTOR).doesNotExist();
     assert.dom(ADD_RELATED_RESOURCE_BUTTON_SELECTOR).exists();
 
     assert.dom(READ_ONLY_TITLE_SELECTOR).doesNotExist();


### PR DESCRIPTION
Updates the front-end editing conditions to match the back end. Here's where things currently stand:

<img width="662" alt="CleanShot 2023-07-19 at 18 12 23@2x" src="https://github.com/hashicorp-forge/hermes/assets/754957/3f9625c5-c8df-41e1-b1c5-b73f3c9d7832">

We'll likely tweak these permissions further (e.g., to include "view" access for approvers and stakeholders), but that will be handled separately.

---
TODO: Write permissions-based tests.