### PR TITLE
Fix footer visibility conditions

### DIFF
--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -382,7 +382,7 @@
     </div>
   </div>
 
-  {{#if this.isOwner}}
+  {{#if this.footerIsShown}}
     <div class="sidebar-footer {{if this.editingIsDisabled 'locked'}}">
       {{#if this.editingIsDisabled}}
         <div class="px-3 -mb-1">

--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -382,6 +382,15 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
   }
 
   /**
+   * Whether the footer is shown.
+   * True for editors who may need to see the "doc is locked" message,
+   * as well as approvers and owners who need doc-management controls.
+   */
+  protected get footerIsShown() {
+    return this.isApprover || this.isOwner || this.isContributor;
+  }
+
+  /**
    * Whether editing is enabled for basic metadata fields.
    * Used in the template to make some logic more readable.
    */


### PR DESCRIPTION
Reverts an unintended bug from #265 causing the footer to be hidden from approvers and contributors.