### PR TITLE
Make ProductArea badges interactive

### DIFF
--- a/web/app/components/doc/row.hbs
+++ b/web/app/components/doc/row.hbs
@@ -24,11 +24,9 @@
   </Hds::Table::Td>
   <Hds::Table::Td class="status">
     <Doc::State @state={{@status}} @hideProgress={{true}} /></Hds::Table::Td>
-  <Hds::Table::Td class="product"><Hds::Badge
-      @text={{this.productAreaName}}
-      @icon={{or (get-product-id @productArea) "folder"}}
-      title={{this.productAreaName}}
-    /></Hds::Table::Td>
+  <Hds::Table::Td class="product">
+    <ProductBadgeLink @productArea={{@productArea}} />
+  </Hds::Table::Td>
   <Hds::Table::Td class="owner">
     <Person @ignoreUnknown={{true}} @imgURL={{@avatar}} @email={{@owner}} />
   </Hds::Table::Td>

--- a/web/app/components/doc/row.ts
+++ b/web/app/components/doc/row.ts
@@ -17,15 +17,7 @@ interface DocRowComponentSignature {
   };
 }
 
-export default class DocRowComponent extends Component<DocRowComponentSignature> {
-  get productAreaName() {
-    if (this.args.productArea === "Cloud Platform") {
-      return "HCP";
-    } else {
-      return this.args.productArea;
-    }
-  }
-}
+export default class DocRowComponent extends Component<DocRowComponentSignature> {}
 
 declare module "@glint/environment-ember-loose/registry" {
   export default interface Registry {

--- a/web/app/components/doc/snippet.ts
+++ b/web/app/components/doc/snippet.ts
@@ -3,7 +3,7 @@ import Component from "@glimmer/component";
 interface DocSnippetComponentSignature {
   Element: HTMLParagraphElement;
   Args: {
-    snippet: string;
+    snippet?: string;
   };
 }
 

--- a/web/app/components/doc/tile.hbs
+++ b/web/app/components/doc/tile.hbs
@@ -5,6 +5,11 @@
     @query={{hash draft=@isDraft}}
     class="pb-2 block"
   >
+    {{!
+      We create a click area that extends beyond the edges of its relative container.
+      This makes the parent div clickable without having to wrap itself in a link,
+      and lets us nest interactive elements (e.g., ProductBadgeLink) in a way that improves the mouse experience without sacrificing accessibility.
+    }}
     <div
       aria-hidden="true"
       class="absolute rounded-md group-hover:bg-color-surface-faint -top-4 -left-4 -right-4 -bottom-6"
@@ -47,7 +52,5 @@
     </div>
   </LinkTo>
 
-  <div class="relative">
-    <ProductBadgeLink @productArea={{@productArea}} />
-  </div>
+  <ProductBadgeLink @productArea={{@productArea}} class="relative" />
 </div>

--- a/web/app/components/doc/tile.hbs
+++ b/web/app/components/doc/tile.hbs
@@ -1,44 +1,53 @@
-<LinkTo
-  @route="authenticated.document"
-  @model={{@docID}}
-  @query={{hash draft=@isDraft}}
-  class="flex flex-col items-start space-y-2 p-4 -m-4 rounded-md hover:bg-color-palette-neutral-50 active:bg-color-palette-neutral-100 overflow-hidden"
->
-  <div class="space-y-2">
-    <Doc::Thumbnail
-      @status={{@status}}
-      @product={{@productArea}}
-      @isLarge={{true}}
-    />
-    <Doc::State @state={{@status}} />
+<div class="relative group">
+  <LinkTo
+    @route="authenticated.document"
+    @model={{@docID}}
+    @query={{hash draft=@isDraft}}
+    class="pb-2 block"
+  >
+    <div
+      aria-hidden="true"
+      class="absolute rounded-md group-hover:bg-color-surface-faint -top-4 -left-4 -right-4 -bottom-6"
+    ></div>
+
+    <div class="relative">
+      <div class="space-y-2.5 inline-block">
+        <Doc::Thumbnail
+          @status={{@status}}
+          @product={{@productArea}}
+          @isLarge={{true}}
+        />
+        <Doc::State @state={{@status}} />
+      </div>
+      <div class="mt-2 space-y-1">
+        <h4 class="doc-tile-title">
+          {{@title}}
+        </h4>
+        {{#if @docNumber}}
+          <small class="text-body-100 text-color-foreground-faint">
+            {{@docNumber}}
+          </small>
+        {{/if}}
+      </div>
+      <div class="space-y-1 mt-2 max-w-full">
+        <Person
+          @ignoreUnknown={{true}}
+          @imgURL={{@avatar}}
+          @email="{{@owner}}"
+        />
+        {{#if @modifiedAgo}}
+          <p class="text-body-100 text-color-foreground-faint">
+            {{@modifiedAgo}}
+          </p>
+        {{/if}}
+      </div>
+      {{#if (and @isResult @snippet)}}
+        <Doc::Snippet @snippet={{@snippet}} class="mt-2" />
+      {{/if}}
+    </div>
+  </LinkTo>
+
+  <div class="relative">
+    <ProductBadgeLink @productArea={{@productArea}} />
   </div>
-
-  <div class="flex flex-col items-start space-y-1">
-    <h4 class="doc-tile-title">
-      {{@title}}
-    </h4>
-    {{#if (not (is-empty @docNumber))}}
-      <small class="text-body-100 text-color-foreground-faint">
-        {{@docNumber}}
-      </small>
-    {{/if}}
-  </div>
-
-  <div class="flex flex-col items-start space-y-1 pb-1 max-w-full">
-    <Person @ignoreUnknown={{true}} @imgURL={{@avatar}} @email={{@owner}} />
-    {{#if (not (is-empty @modifiedAgo))}}
-      <p class="text-body-100 text-color-foreground-faint">
-        {{@modifiedAgo}}
-      </p>
-    {{/if}}
-  </div>
-
-  <Hds::Badge
-    @text={{this.productAreaName}}
-    @icon={{or (get-product-id this.this.args.productArea) "folder"}}
-  />
-
-  {{#if (and @isResult @snippet)}}
-    <Doc::Snippet @snippet={{@snippet}} class="pt-2" />
-  {{/if}}
-</LinkTo>
+</div>

--- a/web/app/components/doc/tile.ts
+++ b/web/app/components/doc/tile.ts
@@ -7,7 +7,8 @@ interface DocTileComponentSignature {
     docNumber?: string;
     isOwner?: boolean;
     isResult?: boolean;
-    modifiedAge?: string;
+    isDraft?: boolean;
+    modifiedAgo?: string;
     owner?: string;
     productArea?: string;
     snippet?: string;
@@ -17,16 +18,7 @@ interface DocTileComponentSignature {
   };
 }
 
-export default class DocTileComponent extends Component<DocTileComponentSignature> {
-  protected get productAreaName(): string | undefined {
-    switch (this.args.productArea) {
-      case "Cloud Platform":
-        return "HCP";
-      default:
-        return this.args.productArea;
-    }
-  }
-}
+export default class DocTileComponent extends Component<DocTileComponentSignature> {}
 
 declare module "@glint/environment-ember-loose/registry" {
   export default interface Registry {

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -209,10 +209,9 @@
             />
           </div>
         {{else}}
-          <Hds::Badge
+          <ProductBadgeLink
             data-test-document-product-area-read-only
-            @text={{@document.product}}
-            @icon={{get-product-id @document.product}}
+            @productArea={{@document.product}}
           />
         {{/if}}
       </div>

--- a/web/app/components/product-badge-link.hbs
+++ b/web/app/components/product-badge-link.hbs
@@ -1,0 +1,12 @@
+<LinkTo
+  @route="authenticated.all"
+  @query={{this.query}}
+  class="product-badge-link"
+  ...attributes
+>
+  <Hds::Badge
+    @icon={{or (get-product-id this.this.args.productArea) "folder"}}
+    @text={{this.productAreaName}}
+    title={{this.productAreaName}}
+  />
+</LinkTo>

--- a/web/app/components/product-badge-link.hbs
+++ b/web/app/components/product-badge-link.hbs
@@ -1,5 +1,5 @@
 <LinkTo
-  @route="authenticated.all"
+  @route={{this.route}}
   @query={{this.query}}
   class="product-badge-link"
   ...attributes

--- a/web/app/components/product-badge-link.ts
+++ b/web/app/components/product-badge-link.ts
@@ -34,22 +34,21 @@ export default class ProductBadgeLinkComponent extends Component<ProductBadgeLin
     }
   }
 
+  /**
+   * The route the badge should link to.
+   * If on the /drafts or /my screen, keep the filters scoped there.
+   * In all other cases, link to the /all screen.
+   */
   protected get route() {
     const { currentRouteName } = this.router;
 
-    if (!currentRouteName) {
-      return "authenticated.all";
+    switch (currentRouteName) {
+      case "authenticated.drafts":
+      case "authenticated.my":
+        return currentRouteName;
+      default:
+        return "authenticated.all";
     }
-
-    if (currentRouteName.includes("drafts")) {
-      return "authenticated.drafts";
-    }
-
-    if (currentRouteName.includes("my")) {
-      return "authenticated.my";
-    }
-
-    return "authenticated.all";
   }
 }
 

--- a/web/app/components/product-badge-link.ts
+++ b/web/app/components/product-badge-link.ts
@@ -1,0 +1,38 @@
+import Component from "@glimmer/component";
+
+interface ProductBadgeLinkComponentSignature {
+  Element: HTMLAnchorElement;
+  Args: {
+    productArea?: string;
+  };
+  Blocks: {
+    default: [];
+  };
+}
+
+export default class ProductBadgeLinkComponent extends Component<ProductBadgeLinkComponentSignature> {
+  protected get productAreaName(): string {
+    switch (this.args.productArea) {
+      case "Cloud Platform":
+        return "HCP";
+      default:
+        return this.args.productArea || "Unknown";
+    }
+  }
+
+  protected get query() {
+    if (this.args.productArea) {
+      return {
+        product: [this.args.productArea],
+      };
+    } else {
+      return {};
+    }
+  }
+}
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry {
+    ProductBadgeLink: typeof ProductBadgeLinkComponent;
+  }
+}

--- a/web/app/components/product-badge-link.ts
+++ b/web/app/components/product-badge-link.ts
@@ -36,7 +36,7 @@ export default class ProductBadgeLinkComponent extends Component<ProductBadgeLin
 
   /**
    * The route the badge should link to.
-   * If on the /drafts or /my screen, keep the filters scoped there.
+   * If on the /drafts or /my screen, stay there.
    * In all other cases, link to the /all screen.
    */
   protected get route() {

--- a/web/app/components/product-badge-link.ts
+++ b/web/app/components/product-badge-link.ts
@@ -1,3 +1,5 @@
+import RouterService from "@ember/routing/router-service";
+import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
 
 interface ProductBadgeLinkComponentSignature {
@@ -11,6 +13,8 @@ interface ProductBadgeLinkComponentSignature {
 }
 
 export default class ProductBadgeLinkComponent extends Component<ProductBadgeLinkComponentSignature> {
+  @service declare router: RouterService;
+
   protected get productAreaName(): string {
     switch (this.args.productArea) {
       case "Cloud Platform":
@@ -28,6 +32,24 @@ export default class ProductBadgeLinkComponent extends Component<ProductBadgeLin
     } else {
       return {};
     }
+  }
+
+  protected get route() {
+    const { currentRouteName } = this.router;
+
+    if (!currentRouteName) {
+      return "authenticated.all";
+    }
+
+    if (currentRouteName.includes("drafts")) {
+      return "authenticated.drafts";
+    }
+
+    if (currentRouteName.includes("my")) {
+      return "authenticated.my";
+    }
+
+    return "authenticated.all";
   }
 }
 

--- a/web/app/styles/app.scss
+++ b/web/app/styles/app.scss
@@ -34,6 +34,7 @@
 @use "components/sidebar";
 @use "components/document/related-resources";
 @use "components/hds-badge";
+@use "components/product-badge-link";
 @use "components/header/facet-dropdown";
 @use "components/floating-u-i/content";
 @use "components/settings/subscription-list-item";

--- a/web/app/styles/components/product-badge-link.scss
+++ b/web/app/styles/components/product-badge-link.scss
@@ -1,0 +1,5 @@
+.product-badge-link {
+  &:hover .hds-badge--color-neutral {
+    @apply bg-color-palette-neutral-200;
+  }
+}

--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -297,12 +297,17 @@ export default function (mirageConfig) {
        * a list of facets and draft results.
        */
       this.get("/drafts", () => {
+        const allDocs = this.schema.document.all().models;
+        const drafts = allDocs.filter((doc) => {
+          return doc.attrs.isDraft;
+        });
+
         return new Response(
           200,
           {},
           {
             facets: [],
-            Hits: [],
+            Hits: drafts,
             params: "",
             page: 0,
           }

--- a/web/mirage/factories/document.ts
+++ b/web/mirage/factories/document.ts
@@ -29,6 +29,7 @@ export default Factory.extend({
   modifiedAgo: 1000000000,
   modifiedTime: 1,
   appCreated: true,
+  isDraft: true,
   docNumber() {
     // @ts-ignore - Mirage types are wrong
     // See discussion at https://github.com/miragejs/miragejs/pull/525

--- a/web/tests/acceptance/authenticated/all-test.ts
+++ b/web/tests/acceptance/authenticated/all-test.ts
@@ -1,9 +1,11 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { setupApplicationTest } from "ember-qunit";
 import { module, test } from "qunit";
 import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
+
+const PRODUCT_BADGE_LINK_SELECTOR = ".product-badge-link";
 
 interface AuthenticatedAllRouteTestContext extends MirageTestContext {}
 
@@ -18,5 +20,20 @@ module("Acceptance | authenticated/all", function (hooks) {
   test("the page title is correct", async function (this: AuthenticatedAllRouteTestContext, assert) {
     await visit("/all");
     assert.equal(getPageTitle(), "All Docs | Hermes");
+  });
+
+  test("product area badges are clickable filters", async function (this: AuthenticatedAllRouteTestContext, assert) {
+    // Note: "Vault" is the default product area in the Mirage factory.
+
+    this.server.createList("document", 5);
+    this.server.create("document", { product: "Labs" });
+
+    await visit("/all");
+
+    assert
+      .dom(PRODUCT_BADGE_LINK_SELECTOR)
+      .hasAttribute("href", "/all?product=%5B%22Vault%22%5D");
+
+    // TODO: Set up a handler in Mirage to return filtered results.
   });
 });

--- a/web/tests/acceptance/authenticated/all-test.ts
+++ b/web/tests/acceptance/authenticated/all-test.ts
@@ -1,6 +1,6 @@
-import { click, visit } from "@ember/test-helpers";
+import { visit } from "@ember/test-helpers";
 import { setupApplicationTest } from "ember-qunit";
-import { module, test } from "qunit";
+import { module, test, todo } from "qunit";
 import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
@@ -22,18 +22,24 @@ module("Acceptance | authenticated/all", function (hooks) {
     assert.equal(getPageTitle(), "All Docs | Hermes");
   });
 
-  test("product area badges are clickable filters", async function (this: AuthenticatedAllRouteTestContext, assert) {
+  test("product badges have the correct hrefs", async function (this: AuthenticatedAllRouteTestContext, assert) {
     // Note: "Vault" is the default product area in the Mirage factory.
 
-    this.server.createList("document", 5);
-    this.server.create("document", { product: "Labs" });
+    this.server.create("document", {
+      product: "Labs",
+    });
 
     await visit("/all");
 
     assert
       .dom(PRODUCT_BADGE_LINK_SELECTOR)
-      .hasAttribute("href", "/all?product=%5B%22Vault%22%5D");
-
-    // TODO: Set up a handler in Mirage to return filtered results.
+      .hasAttribute("href", "/all?product=%5B%22Labs%22%5D");
   });
+
+  todo(
+    "product badges are clickable",
+    async function (this: AuthenticatedAllRouteTestContext, assert) {
+      assert.true(false);
+    }
+  );
 });

--- a/web/tests/acceptance/authenticated/all-test.ts
+++ b/web/tests/acceptance/authenticated/all-test.ts
@@ -35,11 +35,4 @@ module("Acceptance | authenticated/all", function (hooks) {
       .dom(PRODUCT_BADGE_LINK_SELECTOR)
       .hasAttribute("href", "/all?product=%5B%22Labs%22%5D");
   });
-
-  todo(
-    "product badges are clickable",
-    async function (this: AuthenticatedAllRouteTestContext, assert) {
-      assert.true(false);
-    }
-  );
 });

--- a/web/tests/acceptance/authenticated/drafts-test.ts
+++ b/web/tests/acceptance/authenticated/drafts-test.ts
@@ -1,6 +1,6 @@
 import { visit } from "@ember/test-helpers";
 import { setupApplicationTest } from "ember-qunit";
-import { module, test } from "qunit";
+import { module, test, todo } from "qunit";
 import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
@@ -19,4 +19,23 @@ module("Acceptance | authenticated/drafts", function (hooks) {
     await visit("/drafts");
     assert.equal(getPageTitle(), "My Drafts | Hermes");
   });
+
+  test("product badges have the correct hrefs", async function (this: AuthenticatedDraftRouteTestContext, assert) {
+    this.server.create("document", {
+      product: "Security",
+    });
+
+    await visit("/drafts");
+
+    assert
+      .dom(".product-badge-link")
+      .hasAttribute("href", "/drafts?product=%5B%22Security%22%5D");
+  });
+
+  todo(
+    "product badges are clickable",
+    async function (this: AuthenticatedDraftRouteTestContext, assert) {
+      assert.true(false);
+    }
+  );
 });

--- a/web/tests/acceptance/authenticated/drafts-test.ts
+++ b/web/tests/acceptance/authenticated/drafts-test.ts
@@ -31,11 +31,4 @@ module("Acceptance | authenticated/drafts", function (hooks) {
       .dom(".product-badge-link")
       .hasAttribute("href", "/drafts?product=%5B%22Security%22%5D");
   });
-
-  todo(
-    "product badges are clickable",
-    async function (this: AuthenticatedDraftRouteTestContext, assert) {
-      assert.true(false);
-    }
-  );
 });

--- a/web/tests/acceptance/authenticated/my-test.ts
+++ b/web/tests/acceptance/authenticated/my-test.ts
@@ -1,6 +1,6 @@
 import { visit } from "@ember/test-helpers";
 import { setupApplicationTest } from "ember-qunit";
-import { module, test, todo } from "qunit";
+import { module, test } from "qunit";
 import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
@@ -33,11 +33,4 @@ module("Acceptance | authenticated/my", function (hooks) {
       .dom(PRODUCT_BADGE_LINK_SELECTOR)
       .hasAttribute("href", "/my?product=%5B%22Terraform%22%5D");
   });
-
-  todo(
-    "product badges are clickable",
-    async function (this: AuthenticatedMyRouteTestContext, assert) {
-      assert.true(false);
-    }
-  );
 });

--- a/web/tests/acceptance/authenticated/my-test.ts
+++ b/web/tests/acceptance/authenticated/my-test.ts
@@ -1,9 +1,11 @@
 import { visit } from "@ember/test-helpers";
 import { setupApplicationTest } from "ember-qunit";
-import { module, test } from "qunit";
+import { module, test, todo } from "qunit";
 import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
+
+const PRODUCT_BADGE_LINK_SELECTOR = ".product-badge-link";
 
 interface AuthenticatedMyRouteTestContext extends MirageTestContext {}
 
@@ -19,4 +21,23 @@ module("Acceptance | authenticated/my", function (hooks) {
     await visit("/my");
     assert.equal(getPageTitle(), "My Docs | Hermes");
   });
+
+  test("product badges have the correct hrefs", async function (this: AuthenticatedMyRouteTestContext, assert) {
+    this.server.create("document", {
+      product: "Terraform",
+    });
+
+    await visit("/my");
+
+    assert
+      .dom(PRODUCT_BADGE_LINK_SELECTOR)
+      .hasAttribute("href", "/my?product=%5B%22Terraform%22%5D");
+  });
+
+  todo(
+    "product badges are clickable",
+    async function (this: AuthenticatedMyRouteTestContext, assert) {
+      assert.true(false);
+    }
+  );
 });

--- a/web/tests/acceptance/authenticated/results-test.ts
+++ b/web/tests/acceptance/authenticated/results-test.ts
@@ -19,4 +19,14 @@ module("Acceptance | authenticated/results", function (hooks) {
     await visit("/results");
     assert.equal(getPageTitle(), "Search Results | Hermes");
   });
+
+  test("product badges have the correct hrefs", async function (this: AuthenticatedResultsRouteTestContext, assert) {
+    this.server.createList("document", 10);
+
+    await visit("/results");
+
+    assert
+      .dom(".product-badge-link")
+      .hasAttribute("href", "/all?product=%5B%22Vault%22%5D");
+  });
 });

--- a/web/tests/integration/components/document/sidebar/header-test.ts
+++ b/web/tests/integration/components/document/sidebar/header-test.ts
@@ -32,6 +32,7 @@ module("Integration | Component | document/sidebar/header", function (hooks) {
       objectID: "400",
       status: "in-review",
       docNumber: "001",
+      isDraft: false,
     });
     this.set("document", this.server.schema.document.first().attrs);
 
@@ -131,7 +132,11 @@ module("Integration | Component | document/sidebar/header", function (hooks) {
   });
 
   test("it populates the correct share link (with ShortLinkBaseURL)", async function (this: DocumentSidebarHeaderTestContext, assert) {
-    this.server.create("document", { docType: "PRD", docNumber: "TST-001" });
+    this.server.create("document", {
+      docType: "PRD",
+      docNumber: "TST-001",
+      isDraft: false,
+    });
     this.set("document", this.server.schema.document.first().attrs);
 
     let configService = this.owner.lookup("service:config") as ConfigService;

--- a/web/tests/integration/components/product-badge-link-test.ts
+++ b/web/tests/integration/components/product-badge-link-test.ts
@@ -1,0 +1,30 @@
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+import { TestContext, render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+
+interface ProductBadgeLinkComponentTestContext extends TestContext {}
+
+module("Integration | Component | product-badge-link", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("it renders with the correct attributes", async function (this: ProductBadgeLinkComponentTestContext, assert) {
+    await render<ProductBadgeLinkComponentTestContext>(hbs`
+      <ProductBadgeLink class="foo" @productArea="Cloud Platform" />
+      <ProductBadgeLink class="bar" @productArea="Terraform" />
+      <ProductBadgeLink class="baz" />
+    `);
+
+    assert
+      .dom(".foo")
+      .hasAttribute("href", "/all?product=%5B%22Cloud%20Platform%22%5D")
+      .hasText("HCP");
+
+    assert
+      .dom(".bar")
+      .hasAttribute("href", "/all?product=%5B%22Terraform%22%5D")
+      .hasText("Terraform");
+
+    assert.dom(".baz").hasAttribute("href", "/all").hasText("Unknown");
+  });
+});


### PR DESCRIPTION
Makes ProductArea badges clickable to initiate a product filter. Badges on the `/my` and `/drafts` are scoped to keep you on that route. All other users point to `/all`.