### PR TITLE
(WIP) Add support screen

### DIFF
--- a/web/app/components/dashboard/new-features-banner.ts
+++ b/web/app/components/dashboard/new-features-banner.ts
@@ -2,9 +2,11 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import window from "ember-window-mock";
 import { action } from "@ember/object";
+import Ember from "ember";
 
-export const NEW_FEATURES_BANNER_LOCAL_STORAGE_ITEM =
-  "july-20-2023-newFeatureBannerIsShown";
+export const NEW_FEATURES_BANNER_LOCAL_STORAGE_ITEM = Ember.testing
+  ? "test-newFeatureBannerIsShown"
+  : "july-20-2023-newFeatureBannerIsShown";
 
 interface DashboardNewFeaturesBannerSignature {
   Args: {};

--- a/web/app/components/footer.ts
+++ b/web/app/components/footer.ts
@@ -13,3 +13,9 @@ export default class FooterComponent extends Component {
     return new Date().getFullYear();
   }
 }
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry {
+    Footer: typeof FooterComponent;
+  }
+}

--- a/web/app/components/header/nav.hbs
+++ b/web/app/components/header/nav.hbs
@@ -76,15 +76,15 @@
           />
           <dd.Separator class="mt-2" />
           <dd.Interactive
-            data-test-user-menu-item="email-notifications"
-            @route="authenticated.settings"
-            @text="Email notifications"
-          />
-          <dd.Interactive
-            data-test-user-menu-item="email-notifications"
+            data-test-user-menu-item="support"
             @route="support"
             @text="Support"
             class={{if this.userMenuHighlightIsShown "highlighted-new"}}
+          />
+          <dd.Interactive
+            data-test-user-menu-item="email-notifications"
+            @route="authenticated.settings"
+            @text="Email notifications"
           />
           {{#if this.showSignOut}}
             <dd.Interactive

--- a/web/app/components/header/nav.hbs
+++ b/web/app/components/header/nav.hbs
@@ -79,10 +79,12 @@
             data-test-user-menu-item="email-notifications"
             @route="authenticated.settings"
             @text="Email notifications"
-            class={{if
-              this.emailNotificationsHighlightIsShown
-              "highlighted-new"
-            }}
+          />
+          <dd.Interactive
+            data-test-user-menu-item="email-notifications"
+            @route="support"
+            @text="Support"
+            class={{if this.userMenuHighlightIsShown "highlighted-new"}}
           />
           {{#if this.showSignOut}}
             <dd.Interactive

--- a/web/app/components/header/nav.ts
+++ b/web/app/components/header/nav.ts
@@ -14,6 +14,8 @@ interface HeaderNavComponentSignature {
   Args: {};
 }
 
+const LOCAL_STORAGE_KEY = "july-26-2023-supportHighlightIsShown";
+
 export default class HeaderNavComponent extends Component<HeaderNavComponentSignature> {
   @service("config") declare configSvc: ConfigService;
   @service declare session: SessionService;
@@ -49,9 +51,8 @@ export default class HeaderNavComponent extends Component<HeaderNavComponentSign
    * Whether to the "new" badge should appear on the email notifications menuitem.
    * Will be false if the user has previously closed the dropdown.
    */
-  @tracked protected emailNotificationsHighlightIsShown =
-    window.localStorage.getItem("emailNotificationsHighlightIsShown") !==
-    "false";
+  @tracked protected localStorageItemIsFalse =
+    window.localStorage.getItem(LOCAL_STORAGE_KEY) === "false";
 
   /**
    * Whether a highlight icon should appear over the user avatar.
@@ -59,8 +60,7 @@ export default class HeaderNavComponent extends Component<HeaderNavComponentSign
    * (i.e., when we've just announced a feature), as determined by localStorage.
    * Set false when the user menu is opened.
    */
-  @tracked protected userMenuHighlightIsShown =
-    this.emailNotificationsHighlightIsShown;
+  @tracked protected userMenuHighlightIsShown = !this.localStorageItemIsFalse;
 
   /**
    * The actions to take when the dropdown menu is opened.
@@ -68,8 +68,7 @@ export default class HeaderNavComponent extends Component<HeaderNavComponentSign
    * (We assume the user to have seen the highlight when they open the menu.)
    */
   @action protected onDropdownOpen(): void {
-    this.userMenuHighlightIsShown = false;
-    window.localStorage.setItem("emailNotificationsHighlightIsShown", "false");
+    // window.localStorage.setItem(LOCAL_STORAGE_KEY, "false");
   }
 
   /**
@@ -77,7 +76,7 @@ export default class HeaderNavComponent extends Component<HeaderNavComponentSign
    * Force-hides the emailNotificationsHighlight if it's visible.
    */
   @action protected onDropdownClose(): void {
-    this.emailNotificationsHighlightIsShown = false;
+    this.userMenuHighlightIsShown = false;
   }
 
   @action protected invalidateSession(): void {
@@ -87,7 +86,6 @@ export default class HeaderNavComponent extends Component<HeaderNavComponentSign
 
 declare module "@glint/environment-ember-loose/registry" {
   export default interface Registry {
-    'Header::Nav': typeof HeaderNavComponent;
+    "Header::Nav": typeof HeaderNavComponent;
   }
 }
-

--- a/web/app/components/header/nav.ts
+++ b/web/app/components/header/nav.ts
@@ -9,12 +9,15 @@ import AuthenticatedUserService, {
 } from "hermes/services/authenticated-user";
 import window from "ember-window-mock";
 import { tracked } from "@glimmer/tracking";
+import Ember from "ember";
 
 interface HeaderNavComponentSignature {
   Args: {};
 }
 
-const LOCAL_STORAGE_KEY = "july-26-2023-supportHighlightIsShown";
+export const NEW_NAV_ITEM_LOCAL_STORAGE_KEY = Ember.testing
+  ? "test-supportHighlightIsShown"
+  : "july-26-2023-supportHighlightIsShown";
 
 export default class HeaderNavComponent extends Component<HeaderNavComponentSignature> {
   @service("config") declare configSvc: ConfigService;
@@ -52,7 +55,7 @@ export default class HeaderNavComponent extends Component<HeaderNavComponentSign
    * Will be false if the user has previously closed the dropdown.
    */
   @tracked protected localStorageItemIsFalse =
-    window.localStorage.getItem(LOCAL_STORAGE_KEY) === "false";
+    window.localStorage.getItem(NEW_NAV_ITEM_LOCAL_STORAGE_KEY) === "false";
 
   /**
    * Whether a highlight icon should appear over the user avatar.
@@ -68,7 +71,7 @@ export default class HeaderNavComponent extends Component<HeaderNavComponentSign
    * (We assume the user to have seen the highlight when they open the menu.)
    */
   @action protected onDropdownOpen(): void {
-    // window.localStorage.setItem(LOCAL_STORAGE_KEY, "false");
+    window.localStorage.setItem(NEW_NAV_ITEM_LOCAL_STORAGE_KEY, "false");
   }
 
   /**

--- a/web/app/components/hermes-logo.ts
+++ b/web/app/components/hermes-logo.ts
@@ -6,3 +6,9 @@ interface HermesLogoComponentSignature {
 }
 
 export default class HermesLogoComponent extends Component<HermesLogoComponentSignature> {}
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry {
+    HermesLogo: typeof HermesLogoComponent;
+  }
+}

--- a/web/app/components/support/index.hbs
+++ b/web/app/components/support/index.hbs
@@ -1,10 +1,6 @@
 <div class="w-full max-w-3xl mx-auto">
-  <div class="relative flex items-center justify-center w-full h-16">
-    {{! TODO: replace with component }}
-    <LinkTo
-      @route="authenticated.dashboard"
-      class="flex text-color-foreground-faint hover:text-color-foreground-strong items-center space-x-2"
-    >
+  <div class="grid place-items-center h-16">
+    <LinkTo @route="authenticated.dashboard" class="header-link">
       <FlightIcon @name="arrow-left" />
       <span>Back to the Dashboard</span>
     </LinkTo>
@@ -14,19 +10,19 @@
     @level="high"
     @hasBorder={{true}}
     @overflow="visible"
-    class="relative w-full card px-24 pt-14 pb-20"
+    class="page-card"
   >
-    <div class="flex space-x-3 items-center">
+    <div class="hermes-support-header">
       <LinkTo @route="authenticated.dashboard">
         <HermesLogo />
       </LinkTo>
       <Hds::Badge @text="Support" @color="success" @type="inverted" />
     </div>
 
-    <ul class="space-y-12 mt-12">
+    <ul class="content-sections">
       {{#each @docs.sections as |section|}}
-        <li>
-          <h2 class="mb-4 hermes-h4">
+        <li class="content-section">
+          <h2 class="hermes-h4">
             {{#if section.titleIcon}}
               <FlightIcon @name={{section.titleIcon}} />
             {{/if}}
@@ -34,20 +30,18 @@
               {{section.title}}
             </span>
           </h2>
-          <ul class="space-y-6">
+          <ul class="content-section-items">
             {{#each section.items as |item|}}
               <li>
                 <h4>{{item.title}}</h4>
-                <p>{{item.content}}</p>
+                <div>
+                  {{markdown-to-html item.content}}
+                </div>
                 {{#if item.links}}
-                  <ul class="support-links">
-
+                  <ul class="links">
                     {{#each item.links as |link|}}
                       <li>
-                        <ExternalLink
-                          href={{link.href}}
-                          class="flex space-x-2 text-color-foreground-faint items-center"
-                        >
+                        <ExternalLink href={{link.url}}>
                           {{#if link.icon}}
                             <FlightIcon @name={{link.icon}} />
                           {{/if}}

--- a/web/app/components/support/index.hbs
+++ b/web/app/components/support/index.hbs
@@ -3,207 +3,66 @@
     {{! TODO: replace with component }}
     <LinkTo
       @route="authenticated.dashboard"
-      class="flex text-color-foreground-faint items-center space-x-2"
+      class="flex text-color-foreground-faint hover:text-color-foreground-strong items-center space-x-2"
     >
       <FlightIcon @name="arrow-left" />
       <span>Back to the Dashboard</span>
     </LinkTo>
-
-    {{! <LinkTo
-      @route="authenticated.dashboard"
-      class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
-    >
-      <HermesLogo />
-    </LinkTo> }}
-
   </div>
+
   <Hds::Card::Container
     @level="high"
     @hasBorder={{true}}
     @overflow="visible"
-    class="relative w-full px-24 pt-14 pb-16"
+    class="relative w-full card px-24 pt-14 pb-20"
   >
     <div class="flex space-x-3 items-center">
       <LinkTo @route="authenticated.dashboard">
         <HermesLogo />
       </LinkTo>
-
       <Hds::Badge @text="Support" @color="success" @type="inverted" />
     </div>
-    {{!-- <div class="mt-0 mb-10 flex w-full text-cenXter justify-ceXnter">
-      {{! <HermesLogo /> }}
-      <div>
-        <h1 class="mb-1.5 text-[2.8rem] leading-none">
-          We can explain.
-        </h1>
 
-        <p class="text-color-foreground-faint">
-          (Our temporary support docs)
-        </p>
-      </div>
-    </div> --}}
-    <div class="mt-12 mb-14">
-      <h2 class="mb-4 hermes-h4">
-        <FlightIcon @name="alert-diamond" />
-        <span>
-          Known limitations
-        </span>
-      </h2>
-      <ul class="space-y-6">
+    <ul class="space-y-12 mt-12">
+      {{#each @docs.sections as |section|}}
         <li>
-          {{! <h4>How do I accept document suggestions?</h4> }}
-          <h4>Doc suggestions must be accepted off-site.</h4>
-          <p>
-            Unfortunately, Google disables this function for embedded documents
-            like you see in Hermes. To accept suggestions, you'll need to open
-            your document directly in Google. Look for the
-            <div
-              class="bg-color-palette-neutral-100 border border-color-border-primary inline-flex py-1 px-2 rounded-sm relative translate-y-0.5 mx-0.5 -my-1"
-            >
-              <FlightIcon @name="external-link" />
-            </div>
-            button in the Hermes document sidebar.
-          </p>
-        </li>
-        <li>
-          <h4>Suggestions in the header will lock your document.</h4>
-          <p>
-            If this happens, remove the suggestions from your document header,
-            wait a few minutes (for Hermes to notice the change), then refresh.
-            If your document is still locked after 10 minutes, please get in
-            touch.
-          </p>
-        </li>
-        <li>
-          {{! <h4>Why aren't I receiving comment notifications?</h4> }}
-          <h4>You must manually enable "all notifications."</h4>
-          <p>
-            By default, you'll get emailed about @-mentions and threads
-            involving you. To receive to all comments, you'll need use the
-            Google Docs interface. Open your doc in Google (
-            <div
-              class="bg-color-palette-neutral-100 border border-color-border-primary inline-flex py-1 px-2 rounded-sm relative translate-y-0.5 -mx-0.5 -my-1"
-            >
-              <FlightIcon @name="external-link" />
-            </div>
-            ), then
-            <a href="https://support.google.com/docs/answer/91588">follow these
-              instructions</a>.
-          </p>
-        </li>
-      </ul>
-    </div>
+          <h2 class="mb-4 hermes-h4">
+            {{#if section.titleIcon}}
+              <FlightIcon @name={{section.titleIcon}} />
+            {{/if}}
+            <span>
+              {{section.title}}
+            </span>
+          </h2>
+          <ul class="space-y-6">
+            {{#each section.items as |item|}}
+              <li>
+                <h4>{{item.title}}</h4>
+                <p>{{item.content}}</p>
+                {{#if item.links}}
+                  <ul class="support-links">
 
-    <div class="mb-14">
-      <h2 class="mb-4 hermes-h4">
-        <FlightIcon @name="discussion-square" />
-        <span>
-          Frequently asked questions
-        </span>
-      </h2>
-      <ul class="space-y-6">
-        <li>
-          <h4>How do I stop getting 400 errors from Google?</h4>
-          <p>
-            This is most often caused by content blockers or browser security
-            settings. Safe-listing the Hermes domain will typically resolve the
-            issue.
-          </p>
-        </li>
-        <li>
-          <h4>Why did Hermes assign the wrong document number?</h4>
-          <p>
-            Generally this is traced to a document that was created outside of
-            Hermes being moved into the Hermes folder. TODO: Add more info and
-            instructions on how to fix.
-          </p>
-        </li>
-        <li>
-          <h4>How do I add teams as contributors/approvers?</h4>
-          <p>
-            We don't yet support team and group email addresses, so you'll need
-            to invite them off-site. If you're looking to share a draft, be sure
-            to switch it shareable via the document sidebar.
-          </p>
-        </li>
-        <li>
-          <h4>How do I delete a document?</h4>
-          <p>
-            Published documents cannot be fully deleted, but they can be
-            archived. Drafts, on the other hand, can be deleted by clicking the
-            trash icon in the document sidebar.
-          </p>
-        </li>
-        <li>
-          <h4>Can I re-publish a document?</h4>
-          <p>
-            Once a document is published it cannot be re-published. If a
-            document has undergone significant changes, it's best to create a
-            new document and archive the old one or manually socialize the
-            existing document with your team.
-          </p>
-        </li>
-
-        <li>
-          <h4>Can I transfer or share document ownership?</h4>
-          <p>
-            Our current implementation doesn't yet support this.
-          </p>
-        </li>
-        <li>
-          <h4>Why aren't my drafts in the shared Drive folder?</h4>
-          <p>
-            Drafts are kept out of the shared drive until they're published. If
-            you need to find the file on Drive, you can generally find it by
-            name.
-          </p>
-        </li>
-
-      </ul>
-    </div>
-    <div>
-      <h2 class="hermes-h4 mb-4">
-        <FlightIcon @name="support" />
-        <span>
-          Additional help
-        </span>
-      </h2>
-      <ul class="space-y-6">
-        <li>
-          <h4>Still have a question, bug, or feature request?</h4>
-          <p>
-            HashiCorp employees are encouraged to contact us on Slack.
-            Open-source users can submit an issue on GitHub and we'll reply as
-            soon as we can.
-          </p>
-          <ul class="text-body-300 mt-5 space-y-1.5 support-links">
-            <li>
-              <LinkTo
-                @route="authenticated.dashboard"
-                class="flex text-color-foreground-faint items-center"
-              >
-                <FlightIcon class="mr-2" @name="slack" />
-                proj-hermes-feedback
-              </LinkTo>
-            </li>
-            <li>
-
-              <a class="flex text-color-foreground-faint items-center">
-                <FlightIcon class="mr-2" @name="mail" />
-                labs@hashicorp.com
-              </a>
-            </li>
-            <li>
-
-              <a class="flex text-color-foreground-faint items-center">
-                <FlightIcon class="mr-2" @name="github" />
-                Github Issues
-              </a>
-            </li>
+                    {{#each item.links as |link|}}
+                      <li>
+                        <ExternalLink
+                          href={{link.href}}
+                          class="flex space-x-2 text-color-foreground-faint items-center"
+                        >
+                          {{#if link.icon}}
+                            <FlightIcon @name={{link.icon}} />
+                          {{/if}}
+                          <span>{{link.title}}</span>
+                        </ExternalLink>
+                      </li>
+                    {{/each}}
+                  </ul>
+                {{/if}}
+              </li>
+            {{/each}}
           </ul>
         </li>
-      </ul>
-    </div>
+      {{/each}}
+    </ul>
   </Hds::Card::Container>
   <Footer />
 </div>

--- a/web/app/components/support/index.hbs
+++ b/web/app/components/support/index.hbs
@@ -1,0 +1,171 @@
+<div class="w-full max-w-2xl mx-auto">
+  <div class="relative flex items-center justify-between w-full h-16">
+    {{! TODO: replace with component }}
+    <LinkTo @route="authenticated.dashboard" class="flex items-center">
+      <FlightIcon class="mr-2" @name="arrow-left" />
+      Dashboard
+    </LinkTo>
+    <LinkTo
+      @route="authenticated.dashboard"
+      class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
+    >
+      <HermesLogo />
+    </LinkTo>
+  </div>
+  <Hds::Card::Container
+    @level="high"
+    @hasBorder={{true}}
+    @overflow="visible"
+    class="relative w-full px-16 pt-12 pb-14"
+  >
+    <div class="mb-6 flex w-full justify-between">
+      <h1>Support</h1>
+      {{#if true}}
+        <Hds::Button
+          @text="Chat us on Slack"
+          @icon="slack"
+          {{!-- @color="secondary" --}}
+          {{! @size="small" }}
+          {{!-- @href={{this.slackURL}} --}}
+        />
+      {{/if}}
+    </div>
+    <div class="mb-12">
+      <h2 class="mb-4 hermes-h4">
+        <FlightIcon @name="alert-diamond" />
+        <span>
+          Known limitations
+        </span>
+      </h2>
+      <ul class="space-y-6">
+        <li>
+          {{! <h4>How do I accept document suggestions?</h4> }}
+          <h4>Suggestions must be accepted off-site.</h4>
+          <p>
+            Unfortunately this can't be done yet in Hermes, but you can open
+            your document in Google Docs and accept suggestions there. Look for
+            the
+            <FlightIcon
+              @name="external-link"
+              class="inline-flex mx-2 leading-none"
+            />
+            icon in your document sidebar.
+          </p>
+        </li>
+        <li>
+          <h4>Suggestions in the header will lock your doc.</h4>
+          <p>
+            Remove all comments and suggestions from the header of your doc,
+            then wait 5 minutes and refresh. Get in touch if this fails to
+            resolve the issue.
+          </p>
+        </li>
+        <li>
+          {{! <h4>Why aren't I receiving comment notifications?</h4> }}
+          <h4>Receiving "all notifications" isn't the default.</h4>
+          <p>
+            By default, you should receive notifications for mentions and
+            threads involving you. To subscribe to all comments, open your
+            document in Google Docs and click the bell icon in the top right.
+            From there, look for the "Subscribe to new comments" option. TODO:
+            Make this more precise.
+          </p>
+        </li>
+      </ul>
+    </div>
+
+    <div class="mb-12">
+      <h2 class="mb-4 hermes-h4">
+        <FlightIcon @name="discussion-square" />
+        <span>
+          Frequently asked questions
+        </span>
+      </h2>
+      <ul class="space-y-6">
+
+        <li>
+          <h4>How do I unlock a document?</h4>
+          <p>
+            Remove all comments and suggestions from the header of your doc,
+            then wait 5 minutes and refresh. Get in touch if this fails to
+            resolve the issue.
+          </p>
+        </li>
+        <li>
+          <h4>Why did Hermes assign the wrong document number?</h4>
+          <p>
+            Generally this is traced to a document that was created outside of
+            Hermes being moved into the Hermes folder. TODO: Add more info and
+            instructions on how to fix.
+          </p>
+        </li>
+        <li>
+          <h4>Can I re-publish a document?</h4>
+          <p>
+            Once a document is published it cannot be re-published. If a
+            document has undergone significant changes, it's best to create a
+            new document and archive the old one or manually socialize the
+            existing document with your team.
+          </p>
+        </li>
+        <li>
+          <h4>How do I add teams as contributors/approvers?</h4>
+          <p>
+            We don't yet support team and group email addresses, so you'll need
+            to invite them off-site. If you're looking to share a draft, be sure
+            to switch it shareable via the document sidebar.
+          </p>
+        </li>
+        <li>
+          <h4>How do I stop getting 400 errors from Google?</h4>
+          <p>
+            This is most often caused by content blockers or browser security
+            settings. Safe-listing the Hermes domain will typically resolve the
+            issue.
+          </p>
+        </li>
+        <li>
+          <h4>Can I transfer or share document ownership?</h4>
+          <p>
+            Our current implementation doesn't yet support this.
+          </p>
+        </li>
+        <li>
+          <h4>Why don't drafts appearing in the shared Drive folder?</h4>
+          <p>
+            Drafts are kept out of the shared drive until they're published. If
+            you need to find the file on Drive, you can generally find it by
+            name.
+          </p>
+        </li>
+        <li>
+          <h4>How do I delete a published document?</h4>
+          <p>
+            Published documents cannot be fully deleted, but they can be
+            archived. Drafts, on the other hand, can be deleted by clicking the
+            trash icon in the document sidebar.
+          </p>
+        </li>
+      </ul>
+    </div>
+    <div>
+      <h2 class="hermes-h4 mb-4">
+        <FlightIcon @name="support" />
+        <span>
+          Additional support
+        </span>
+      </h2>
+      <ul>
+        <li>
+          <h4>How do I submit a bug or feature request?</h4>
+          <p>
+            HashiCorp employees are encouraged to contact us on Slack.
+            Open-source users can submit an issue on GitHub and we'll reply as
+            soon as we can.
+          </p>
+        </li>
+      </ul>
+    </div>
+  </Hds::Card::Container>
+  <Footer />
+</div>

--- a/web/app/components/support/index.hbs
+++ b/web/app/components/support/index.hbs
@@ -1,36 +1,48 @@
-<div class="w-full max-w-2xl mx-auto">
-  <div class="relative flex items-center justify-between w-full h-16">
+<div class="w-full max-w-3xl mx-auto">
+  <div class="relative flex items-center justify-center w-full h-16">
     {{! TODO: replace with component }}
-    <LinkTo @route="authenticated.dashboard" class="flex items-center">
-      <FlightIcon class="mr-2" @name="arrow-left" />
-      Dashboard
-    </LinkTo>
     <LinkTo
+      @route="authenticated.dashboard"
+      class="flex text-color-foreground-faint items-center space-x-2"
+    >
+      <FlightIcon @name="arrow-left" />
+      <span>Back to the Dashboard</span>
+    </LinkTo>
+
+    {{! <LinkTo
       @route="authenticated.dashboard"
       class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
     >
       <HermesLogo />
-    </LinkTo>
+    </LinkTo> }}
+
   </div>
   <Hds::Card::Container
     @level="high"
     @hasBorder={{true}}
     @overflow="visible"
-    class="relative w-full px-16 pt-12 pb-14"
+    class="relative w-full px-24 pt-14 pb-16"
   >
-    <div class="mb-6 flex w-full justify-between">
-      <h1>Support</h1>
-      {{#if true}}
-        <Hds::Button
-          @text="Chat us on Slack"
-          @icon="slack"
-          {{!-- @color="secondary" --}}
-          {{! @size="small" }}
-          {{!-- @href={{this.slackURL}} --}}
-        />
-      {{/if}}
+    <div class="flex space-x-3 items-center">
+      <LinkTo @route="authenticated.dashboard">
+        <HermesLogo />
+      </LinkTo>
+
+      <Hds::Badge @text="Support" @color="success" @type="inverted" />
     </div>
-    <div class="mb-12">
+    {{!-- <div class="mt-0 mb-10 flex w-full text-cenXter justify-ceXnter">
+      {{! <HermesLogo /> }}
+      <div>
+        <h1 class="mb-1.5 text-[2.8rem] leading-none">
+          We can explain.
+        </h1>
+
+        <p class="text-color-foreground-faint">
+          (Our temporary support docs)
+        </p>
+      </div>
+    </div> --}}
+    <div class="mt-12 mb-14">
       <h2 class="mb-4 hermes-h4">
         <FlightIcon @name="alert-diamond" />
         <span>
@@ -40,41 +52,41 @@
       <ul class="space-y-6">
         <li>
           {{! <h4>How do I accept document suggestions?</h4> }}
-          <h4>Suggestions must be accepted off-site.</h4>
+          <h4>Doc suggestions must be accepted off-site.</h4>
           <p>
-            Unfortunately this can't be done yet in Hermes, but you can open
-            your document in Google Docs and accept suggestions there. Look for
-            the
-            <FlightIcon
-              @name="external-link"
-              class="inline-flex mx-2 leading-none"
-            />
-            icon in your document sidebar.
+            Unfortunately, Google disables this function for embedded documents
+            like you see in Hermes. To accept suggestions, you'll need to open
+            your document directly in Google. Look for the
+            <div
+              class="bg-color-palette-neutral-100 border border-color-border-primary inline-flex py-0.5 px-1 rounded-sm relative translate-y-0.5 mx-0.5 -my-1"
+            >
+              <FlightIcon @name="external-link" />
+            </div>
+            button in the Hermes document sidebar.
           </p>
         </li>
         <li>
-          <h4>Suggestions in the header will lock your doc.</h4>
+          <h4>Suggestions in the header will lock your document.</h4>
           <p>
-            Remove all comments and suggestions from the header of your doc,
-            then wait 5 minutes and refresh. Get in touch if this fails to
-            resolve the issue.
+            If this happens, remove all suggestions from the header of your doc,
+            and refresh Hermes. Please be patient, as it may take a few minutes
+            for your changes to be noticed by Hermes. If your document remains
+            locked after 10 minutes, please get in touch.
           </p>
         </li>
         <li>
           {{! <h4>Why aren't I receiving comment notifications?</h4> }}
-          <h4>Receiving "all notifications" isn't the default.</h4>
+          <h4>Subscribing to all notifications must be done manually.</h4>
           <p>
-            By default, you should receive notifications for mentions and
-            threads involving you. To subscribe to all comments, open your
-            document in Google Docs and click the bell icon in the top right.
-            From there, look for the "Subscribe to new comments" option. TODO:
-            Make this more precise.
+            By default, you will receive email notifications for @-mentions and
+            threads involving you. To get to all comments, you'll need use the
+            Google Docs interface. Open your doc in Google, then click the
           </p>
         </li>
       </ul>
     </div>
 
-    <div class="mb-12">
+    <div class="mb-14">
       <h2 class="mb-4 hermes-h4">
         <FlightIcon @name="discussion-square" />
         <span>
@@ -155,14 +167,39 @@
           Additional support
         </span>
       </h2>
-      <ul>
+      <ul class="space-y-6">
         <li>
-          <h4>How do I submit a bug or feature request?</h4>
+          <h4>Still have a question, bug, or feature request?</h4>
           <p>
             HashiCorp employees are encouraged to contact us on Slack.
             Open-source users can submit an issue on GitHub and we'll reply as
             soon as we can.
           </p>
+          <ul class="text-body-300 mt-5 space-y-1.5 support-links">
+            <li>
+              <LinkTo
+                @route="authenticated.dashboard"
+                class="flex text-color-foreground-faint items-center"
+              >
+                <FlightIcon class="mr-2" @name="slack" />
+                proj-hermes-feedback
+              </LinkTo>
+            </li>
+            <li>
+
+              <a class="flex text-color-foreground-faint items-center">
+                <FlightIcon class="mr-2" @name="mail" />
+                labs@hashicorp.com
+              </a>
+            </li>
+            <li>
+
+              <a class="flex text-color-foreground-faint items-center">
+                <FlightIcon class="mr-2" @name="github" />
+                Github Issues
+              </a>
+            </li>
+          </ul>
         </li>
       </ul>
     </div>

--- a/web/app/components/support/index.hbs
+++ b/web/app/components/support/index.hbs
@@ -58,7 +58,7 @@
             like you see in Hermes. To accept suggestions, you'll need to open
             your document directly in Google. Look for the
             <div
-              class="bg-color-palette-neutral-100 border border-color-border-primary inline-flex py-0.5 px-1 rounded-sm relative translate-y-0.5 mx-0.5 -my-1"
+              class="bg-color-palette-neutral-100 border border-color-border-primary inline-flex py-1 px-2 rounded-sm relative translate-y-0.5 mx-0.5 -my-1"
             >
               <FlightIcon @name="external-link" />
             </div>
@@ -68,19 +68,27 @@
         <li>
           <h4>Suggestions in the header will lock your document.</h4>
           <p>
-            If this happens, remove all suggestions from the header of your doc,
-            and refresh Hermes. Please be patient, as it may take a few minutes
-            for your changes to be noticed by Hermes. If your document remains
-            locked after 10 minutes, please get in touch.
+            If this happens, remove the suggestions from your document header,
+            wait a few minutes (for Hermes to notice the change), then refresh.
+            If your document is still locked after 10 minutes, please get in
+            touch.
           </p>
         </li>
         <li>
           {{! <h4>Why aren't I receiving comment notifications?</h4> }}
-          <h4>Subscribing to all notifications must be done manually.</h4>
+          <h4>You must manually enable "all notifications."</h4>
           <p>
-            By default, you will receive email notifications for @-mentions and
-            threads involving you. To get to all comments, you'll need use the
-            Google Docs interface. Open your doc in Google, then click the
+            By default, you'll get emailed about @-mentions and threads
+            involving you. To receive to all comments, you'll need use the
+            Google Docs interface. Open your doc in Google (
+            <div
+              class="bg-color-palette-neutral-100 border border-color-border-primary inline-flex py-1 px-2 rounded-sm relative translate-y-0.5 -mx-0.5 -my-1"
+            >
+              <FlightIcon @name="external-link" />
+            </div>
+            ), then
+            <a href="https://support.google.com/docs/answer/91588">follow these
+              instructions</a>.
           </p>
         </li>
       </ul>
@@ -94,13 +102,12 @@
         </span>
       </h2>
       <ul class="space-y-6">
-
         <li>
-          <h4>How do I unlock a document?</h4>
+          <h4>How do I stop getting 400 errors from Google?</h4>
           <p>
-            Remove all comments and suggestions from the header of your doc,
-            then wait 5 minutes and refresh. Get in touch if this fails to
-            resolve the issue.
+            This is most often caused by content blockers or browser security
+            settings. Safe-listing the Hermes domain will typically resolve the
+            issue.
           </p>
         </li>
         <li>
@@ -112,15 +119,6 @@
           </p>
         </li>
         <li>
-          <h4>Can I re-publish a document?</h4>
-          <p>
-            Once a document is published it cannot be re-published. If a
-            document has undergone significant changes, it's best to create a
-            new document and archive the old one or manually socialize the
-            existing document with your team.
-          </p>
-        </li>
-        <li>
           <h4>How do I add teams as contributors/approvers?</h4>
           <p>
             We don't yet support team and group email addresses, so you'll need
@@ -129,13 +127,23 @@
           </p>
         </li>
         <li>
-          <h4>How do I stop getting 400 errors from Google?</h4>
+          <h4>How do I delete a document?</h4>
           <p>
-            This is most often caused by content blockers or browser security
-            settings. Safe-listing the Hermes domain will typically resolve the
-            issue.
+            Published documents cannot be fully deleted, but they can be
+            archived. Drafts, on the other hand, can be deleted by clicking the
+            trash icon in the document sidebar.
           </p>
         </li>
+        <li>
+          <h4>Can I re-publish a document?</h4>
+          <p>
+            Once a document is published it cannot be re-published. If a
+            document has undergone significant changes, it's best to create a
+            new document and archive the old one or manually socialize the
+            existing document with your team.
+          </p>
+        </li>
+
         <li>
           <h4>Can I transfer or share document ownership?</h4>
           <p>
@@ -143,28 +151,21 @@
           </p>
         </li>
         <li>
-          <h4>Why don't drafts appearing in the shared Drive folder?</h4>
+          <h4>Why aren't my drafts in the shared Drive folder?</h4>
           <p>
             Drafts are kept out of the shared drive until they're published. If
             you need to find the file on Drive, you can generally find it by
             name.
           </p>
         </li>
-        <li>
-          <h4>How do I delete a published document?</h4>
-          <p>
-            Published documents cannot be fully deleted, but they can be
-            archived. Drafts, on the other hand, can be deleted by clicking the
-            trash icon in the document sidebar.
-          </p>
-        </li>
+
       </ul>
     </div>
     <div>
       <h2 class="hermes-h4 mb-4">
         <FlightIcon @name="support" />
         <span>
-          Additional support
+          Additional help
         </span>
       </h2>
       <ul class="space-y-6">

--- a/web/app/components/support/index.ts
+++ b/web/app/components/support/index.ts
@@ -1,7 +1,9 @@
 import Component from "@glimmer/component";
 
 interface SupportComponentSignature {
-  Args: {};
+  Args: {
+    docs: any;
+  };
 }
 
 export default class SupportComponent extends Component<SupportComponentSignature> {}

--- a/web/app/components/support/index.ts
+++ b/web/app/components/support/index.ts
@@ -1,0 +1,13 @@
+import Component from "@glimmer/component";
+
+interface SupportComponentSignature {
+  Args: {};
+}
+
+export default class SupportComponent extends Component<SupportComponentSignature> {}
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry {
+    Support: typeof SupportComponent;
+  }
+}

--- a/web/app/router.js
+++ b/web/app/router.js
@@ -20,5 +20,6 @@ Router.map(function () {
     });
   });
   this.route("authenticate");
-  this.route('404', { path: '/*path' })
+  this.route("404", { path: "/*path" });
+  this.route("support");
 });

--- a/web/app/routes/support.ts
+++ b/web/app/routes/support.ts
@@ -1,0 +1,3 @@
+import Route from "@ember/routing/route";
+
+export default class SupportRoute extends Route {}

--- a/web/app/routes/support.ts
+++ b/web/app/routes/support.ts
@@ -1,5 +1,23 @@
 import Route from "@ember/routing/route";
 
+const insertIcon = (icon: string, optionalClassName?: string) => {
+  return `
+    <span class="inline-icon ${optionalClassName}">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="flight-icon icon-${icon}"
+        aria-label="${icon}"
+        fill="currentColor"
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+      >
+        <use href="#flight-${icon}-16"></use>
+      </svg>
+    </span>
+  `;
+};
+
 export default class SupportRoute extends Route {
   model() {
     return {
@@ -10,8 +28,9 @@ export default class SupportRoute extends Route {
           items: [
             {
               title: "Doc suggestions must be accepted off-site",
-              content:
-                "Unfortunately, Google disables this function for embedded documents like you see in Hermes. To accept suggestions, you'll need to open your document directly in Google. Look for the {{icon='external-link'}} button in the Hermes document sidebar.",
+              content: `Unfortunately, Google disables this function for embedded documents like you see in Hermes. To accept suggestions, you'll need to open your document directly in Google. Look for the ${insertIcon(
+                "external-link"
+              )} button in the Hermes document sidebar.\nnd ain't that the truth pal.`,
             },
             {
               title: "Suggestions in the header will lock your document.",
@@ -20,8 +39,10 @@ export default class SupportRoute extends Route {
             },
             {
               title: 'You must manually enable "all notifications."',
-              content:
-                "By default, you'll get emailed about @-mentions and threads involving you. To receive all comments, you'll need to open your doc outside of Hermes ({{icon='external-link'}}), then [follow these instructions](https://support.google.com/docs/answer/91588).",
+              content: `By default, you'll get emailed about @-mentions and threads involving you. To receive all comments, you'll need to open your doc in Google (${insertIcon(
+                "external-link",
+                "with-parentheses"
+              )}), then [follow these instructions](https://support.google.com/docs/answer/91588).`,
             },
           ],
         },
@@ -30,7 +51,7 @@ export default class SupportRoute extends Route {
           titleIcon: "discussion-square",
           items: [
             {
-              title: "How do I stop getting 400 errors from Google?",
+              title: "Why am I getting 400 errors from Google?",
               content:
                 "This is usually caused by content blockers or browser security settings. Safe-listing the Hermes domain will typically resolve the issue.",
             },
@@ -46,8 +67,13 @@ export default class SupportRoute extends Route {
             },
             {
               title: "How do I delete a document?",
-              content:
-                "Published docs can't be deleted, only archived. Drafts, on the other hand, can be deleted using the {{icon='trash'}} button the document sidebar.",
+              content: `Published docs can't be deleted, only archived (${insertIcon(
+                "archive",
+                "with-parentheses"
+              )}). Drafts, on the other hand, can be deleted using the ${insertIcon(
+                "trash",
+                "critical"
+              )} button the document sidebar.`,
             },
             {
               title: "Can I transfer or share document ownership?",
@@ -72,7 +98,7 @@ export default class SupportRoute extends Route {
                 {
                   title: "proj-hermes-feedback",
                   icon: "slack",
-                  url: "",
+                  url: "https://hashicorp.slack.com/archives/C03F4PTHZ1U",
                 },
                 {
                   title: "labs@hashicorp.com",
@@ -82,7 +108,7 @@ export default class SupportRoute extends Route {
                 {
                   title: "GitHub Issues",
                   icon: "github",
-                  url: "",
+                  url: "https://github.com/hashicorp-forge/hermes/issues",
                 },
               ],
             },

--- a/web/app/routes/support.ts
+++ b/web/app/routes/support.ts
@@ -1,3 +1,9 @@
 import Route from "@ember/routing/route";
 
-export default class SupportRoute extends Route {}
+export default class SupportRoute extends Route {
+  model() {
+    return;
+    // TODO: format the FAQs so that they can be displayed on the support page
+    // ... markdown?
+  }
+}

--- a/web/app/routes/support.ts
+++ b/web/app/routes/support.ts
@@ -2,8 +2,93 @@ import Route from "@ember/routing/route";
 
 export default class SupportRoute extends Route {
   model() {
-    return;
-    // TODO: format the FAQs so that they can be displayed on the support page
-    // ... markdown?
+    return {
+      sections: [
+        {
+          title: "Known limitations",
+          titleIcon: "alert-diamond",
+          items: [
+            {
+              title: "Doc suggestions must be accepted off-site",
+              content:
+                "Unfortunately, Google disables this function for embedded documents like you see in Hermes. To accept suggestions, you'll need to open your document directly in Google. Look for the {{icon='external-link'}} button in the Hermes document sidebar.",
+            },
+            {
+              title: "Suggestions in the header will lock your document.",
+              content:
+                "If this happens, remove the suggestions from your document header, wait a few minutes (for Hermes to notice the change), then refresh. If your document is still locked after 10 minutes, please get in touch.",
+            },
+            {
+              title: 'You must manually enable "all notifications."',
+              content:
+                "By default, you'll get emailed about @-mentions and threads involving you. To receive all comments, you'll need to open your doc outside of Hermes ({{icon='external-link'}}), then [follow these instructions](https://support.google.com/docs/answer/91588).",
+            },
+          ],
+        },
+        {
+          title: "Frequency asked questions",
+          titleIcon: "discussion-square",
+          items: [
+            {
+              title: "How do I stop getting 400 errors from Google?",
+              content:
+                "This is usually caused by content blockers or browser security settings. Safe-listing the Hermes domain will typically resolve the issue.",
+            },
+            {
+              title: "Why did Hermes assign the wrong document number?",
+              content:
+                "Generally this happens when a document created outside of Hermes is moved into the Hermes folder. We don't have an automated fix for this yet.",
+            },
+            {
+              title: "How do I add teams as contributors/approvers?",
+              content:
+                "We don't yet support team and group email addresses, so you'll need to invite them off-site. If you want to share a draft, be sure to make it \"Shareable\" first.",
+            },
+            {
+              title: "How do I delete a document?",
+              content:
+                "Published docs can't be deleted, only archived. Drafts, on the other hand, can be deleted using the {{icon='trash'}} button the document sidebar.",
+            },
+            {
+              title: "Can I transfer or share document ownership?",
+              content: "Our current implementation doesn't yet support this.",
+            },
+            {
+              title: "Why aren't drafts showing up in the shared Drive folder?",
+              content:
+                "Drafts are kept out of the shared folder until they're published. If you need to find the file on Drive, you'll have to search it by name.",
+            },
+          ],
+        },
+        {
+          title: "Additional help",
+          titleIcon: "support",
+          items: [
+            {
+              title: "Still have a question, bug, or request?",
+              content:
+                "HashiCorp employees are encouraged to contact us on Slack. Open-source users should reach out on GitHub Issues.",
+              links: [
+                {
+                  title: "proj-hermes-feedback",
+                  icon: "slack",
+                  url: "",
+                },
+                {
+                  title: "labs@hashicorp.com",
+                  icon: "mail",
+                  url: "mailto:labs@hashicorp.com",
+                },
+                {
+                  title: "GitHub Issues",
+                  icon: "github",
+                  url: "",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
   }
 }

--- a/web/app/styles/app.scss
+++ b/web/app/styles/app.scss
@@ -3,7 +3,7 @@
 @use "./animations";
 @use "./typography";
 
-
+@use "routes/support";
 @use "components/action";
 @use "components/toolbar";
 @use "components/tooltip";

--- a/web/app/styles/routes/support.scss
+++ b/web/app/styles/routes/support.scss
@@ -1,0 +1,70 @@
+.hermes-support {
+  .header-link {
+    @apply flex items-center space-x-2 text-color-foreground-faint;
+
+    &:hover {
+      @apply text-color-foreground-primary;
+    }
+  }
+
+  .page-card {
+    @apply w-full px-24 pt-14 pb-20 text-body-300;
+  }
+
+  .hermes-support-header {
+    @apply flex items-center space-x-3 mb-12;
+  }
+
+  .content-sections {
+    @apply space-y-14;
+
+    a {
+      @apply underline text-color-foreground-faint;
+
+      &:hover {
+        @apply text-color-foreground-primary;
+      }
+    }
+  }
+
+  .content-section > h2 {
+    @apply flex items-center space-x-2.5 mb-4;
+
+    svg {
+      @apply text-color-foreground-action;
+    }
+  }
+
+  .content-section-items {
+    @apply space-y-6;
+
+    .links {
+      @apply mt-5 space-y-1.5;
+
+      svg {
+        @apply text-color-foreground-primary;
+      }
+
+      a {
+        @apply flex space-x-2 items-center;
+      }
+    }
+  }
+
+  .inline-icon {
+    @apply border border-color-border-primary bg-color-palette-neutral-100 rounded;
+    @apply inline-flex py-1 px-[7px];
+
+    // Some tweaks to make the icon align with the text
+    @apply relative translate-y-0.5 mx-px -my-1;
+
+    &.with-parentheses {
+      // Bring the icon closer to the parentheses
+      @apply -mx-0.5;
+    }
+
+    &.critical {
+      @apply bg-color-surface-critical border-color-border-critical text-color-foreground-critical-on-surface;
+    }
+  }
+}

--- a/web/app/styles/typography.scss
+++ b/web/app/styles/typography.scss
@@ -20,9 +20,25 @@
 
 .static-text-screen {
   h2 {
-    @apply text-body-200 flex items-center space-x-2;
+    @apply text-body-200 flex items-center space-x-2.5;
+
+    svg {
+      @apply text-color-foreground-action;
+    }
   }
-  p, h4 {
-    @apply text-body-300
+
+  p a {
+    @apply text-color-foreground-action underline;
+  }
+
+  p,
+  h4 {
+    @apply text-body-300;
+  }
+
+  .support-links {
+    svg {
+      @apply text-color-foreground-primary;
+    }
   }
 }

--- a/web/app/styles/typography.scss
+++ b/web/app/styles/typography.scss
@@ -17,3 +17,12 @@
 .truncated-text-container {
   @apply truncate block font-regular text-body-100 text-color-foreground-faint;
 }
+
+.static-text-screen {
+  h2 {
+    @apply text-body-200 flex items-center space-x-2;
+  }
+  p, h4 {
+    @apply text-body-300
+  }
+}

--- a/web/app/styles/typography.scss
+++ b/web/app/styles/typography.scss
@@ -19,6 +19,10 @@
 }
 
 .static-text-screen {
+  .card {
+    @apply text-body-300;
+  }
+
   h2 {
     @apply text-body-200 flex items-center space-x-2.5;
 
@@ -31,12 +35,9 @@
     @apply underline text-color-foreground-faint;
   }
 
-  p,
-  h4 {
-    @apply text-body-300;
-  }
-
   .support-links {
+    @apply mt-5 space-y-1.5;
+
     svg {
       @apply text-color-foreground-primary;
     }

--- a/web/app/styles/typography.scss
+++ b/web/app/styles/typography.scss
@@ -28,7 +28,7 @@
   }
 
   p a {
-    @apply text-color-foreground-action underline;
+    @apply underline text-color-foreground-faint;
   }
 
   p,

--- a/web/app/styles/typography.scss
+++ b/web/app/styles/typography.scss
@@ -17,29 +17,3 @@
 .truncated-text-container {
   @apply truncate block font-regular text-body-100 text-color-foreground-faint;
 }
-
-.static-text-screen {
-  .card {
-    @apply text-body-300;
-  }
-
-  h2 {
-    @apply text-body-200 flex items-center space-x-2.5;
-
-    svg {
-      @apply text-color-foreground-action;
-    }
-  }
-
-  p a {
-    @apply underline text-color-foreground-faint;
-  }
-
-  .support-links {
-    @apply mt-5 space-y-1.5;
-
-    svg {
-      @apply text-color-foreground-primary;
-    }
-  }
-}

--- a/web/app/templates/support.hbs
+++ b/web/app/templates/support.hbs
@@ -1,4 +1,4 @@
 {{page-title "Support"}}
 {{set-body-class "bg-color-page-faint static-text-screen"}}
 
-<Support />
+<Support @docs={{@model}} />

--- a/web/app/templates/support.hbs
+++ b/web/app/templates/support.hbs
@@ -1,4 +1,4 @@
 {{page-title "Support"}}
-{{set-body-class "bg-color-page-faint static-text-screen"}}
+{{set-body-class "bg-color-page-faint hermes-support"}}
 
 <Support @docs={{@model}} />

--- a/web/app/templates/support.hbs
+++ b/web/app/templates/support.hbs
@@ -1,0 +1,4 @@
+{{page-title "Support"}}
+{{set-body-class "bg-color-page-faint static-text-screen"}}
+
+<Support />

--- a/web/package.json
+++ b/web/package.json
@@ -76,6 +76,7 @@
     "ember-cli-htmlbars": "^5.7.2",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-mirage": "^2.4.0",
+    "ember-cli-showdown": "^7.0.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-string-helpers": "^6.1.0",
     "ember-cli-terser": "^4.0.2",

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -65,6 +65,7 @@ module.exports = {
           "var(--token-color-surface-interactive-hover)",
         "color-surface-primary": "var(--token-color-surface-primary)",
         "color-surface-strong": "var(--token-color-surface-strong)",
+        "color-surface-success": "var(--token-color-surface-success)",
         "color-surface-warning": "var(--token-color-surface-warning)",
 
         // Border
@@ -74,6 +75,7 @@ module.exports = {
         "color-border-faint": "var(--token-color-border-faint)",
         "color-border-primary": "var(--token-color-border-primary)",
         "color-border-strong": "var(--token-color-border-strong)",
+        "color-border-success": "var(--token-color-border-success)",
         "color-border-warning": "var(--token-color-border-warning)",
 
         // Page
@@ -94,6 +96,11 @@ module.exports = {
         "color-foreground-high-contrast":
           "var(--token-color-foreground-high-contrast)",
         "color-foreground-highlight": "var(--token-color-foreground-highlight)",
+        "color-foreground-highlight-on-surface":
+          "var(--token-color-foreground-highlight-on-surface)",
+        "color-foreground-success": "var(--token-color-foreground-success)",
+        "color-foreground-success-on-surface":
+          "var(--token-color-foreground-success-on-surface)",
         "color-foreground-primary": "var(--token-color-foreground-primary)",
         "color-foreground-strong": "var(--token-color-foreground-strong)",
         "color-foreground-warning": "var(--token-color-foreground-warning)",

--- a/web/tests/acceptance/support-test.ts
+++ b/web/tests/acceptance/support-test.ts
@@ -1,0 +1,17 @@
+import { visit } from "@ember/test-helpers";
+import { setupApplicationTest } from "ember-qunit";
+import { module, test } from "qunit";
+import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
+import { getPageTitle } from "ember-page-title/test-support";
+
+interface AuthenticateRouteTestContext extends MirageTestContext {}
+
+module("Acceptance | support", function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test("the page title is correct", async function (this: AuthenticateRouteTestContext, assert) {
+    await visit("/support");
+    assert.equal(getPageTitle(), "Support | Hermes");
+  });
+});

--- a/web/tests/integration/components/header/nav-test.ts
+++ b/web/tests/integration/components/header/nav-test.ts
@@ -6,6 +6,10 @@ import { setupWindowMock } from "ember-window-mock/test-support";
 import AuthenticatedUserService from "hermes/services/authenticated-user";
 import { setupMirage } from "ember-cli-mirage/test-support";
 import window from "ember-window-mock";
+import { NEW_NAV_ITEM_LOCAL_STORAGE_KEY } from "hermes/components/header/nav";
+
+const HIGHLIGHTED_NEW_TEXT_SELECTOR =
+  ".highlighted-new .hds-dropdown-list-item__interactive-text";
 
 module("Integration | Component | header/nav", function (hooks) {
   setupRenderingTest(hooks);
@@ -27,10 +31,7 @@ module("Integration | Component | header/nav", function (hooks) {
   });
 
   test("it renders correctly", async function (assert) {
-    await render(hbs`
-      {{! @glint-nocheck: not typesafe yet }}
-      <Header::Nav />
-    `);
+    await render(hbs`<Header::Nav />`);
 
     assert.dom(".header-nav").exists();
     assert.dom('[data-test-nav-link="all"]').hasAttribute("href", "/all");
@@ -44,25 +45,21 @@ module("Integration | Component | header/nav", function (hooks) {
     assert.dom("[data-test-user-menu-title]").hasText("Foo Bar");
     assert.dom("[data-test-user-menu-email]").hasText("foo@example.com");
 
+    assert.dom('[data-test-user-menu-item="support"]').hasText("Support");
     assert
       .dom('[data-test-user-menu-item="email-notifications"]')
       .hasText("Email notifications");
-
     assert.dom('[data-test-user-menu-item="sign-out"]').hasText("Sign out");
   });
 
   test("it shows an icon when the user menu has something to highlight", async function (assert) {
-    await render(hbs`
-      {{! @glint-nocheck: not typesafe yet }}
-      <Header::Nav />
-    `);
+    window.localStorage.removeItem(NEW_NAV_ITEM_LOCAL_STORAGE_KEY);
 
-    assert.equal(
-      window.localStorage.getItem("emailNotificationsHighlightIsShown"),
-      null
-    );
+    await render(hbs`<Header::Nav />`);
 
-    assert.dom("[data-test-user-menu-highlight]").exists("highlight is shown");
+    assert
+      .dom("[data-test-user-menu-highlight]")
+      .exists("the highlight dot is shown");
 
     await click("[data-test-user-menu-toggle]");
 
@@ -71,7 +68,7 @@ module("Integration | Component | header/nav", function (hooks) {
       .doesNotExist("highlight is hidden when the menu is open");
 
     assert
-      .dom(".highlighted-new .hds-dropdown-list-item__interactive-text")
+      .dom(HIGHLIGHTED_NEW_TEXT_SELECTOR)
       .hasPseudoElementStyle(
         "after",
         { content: '"New"' },
@@ -83,7 +80,7 @@ module("Integration | Component | header/nav", function (hooks) {
     await click("[data-test-user-menu-toggle]");
 
     assert
-      .dom(".highlighted-new")
-      .doesNotExist("highlight is hidden after the menu is closed");
+      .dom(HIGHLIGHTED_NEW_TEXT_SELECTOR)
+      .doesNotExist('the "highlighted-new" class is removed');
   });
 });

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -25,6 +25,7 @@
     "tests/**/*",
     "types/**/*",
     "node_modules/@gavant/glint-template-types/types/ember-animated/*",
+    "node_modules/@gavant/glint-template-types/types/ember-cli-showdown/markdown-to-html.d.ts",
     "node_modules/@gavant/glint-template-types/types/ember-click-outside/modifier.d.ts",
     "node_modules/@gavant/glint-template-types/types/ember-concurrency/perform.d.ts",
     "node_modules/@gavant/glint-template-types/types/ember-on-helper/on-document.d.ts",

--- a/web/types/glint/index.d.ts
+++ b/web/types/glint/index.d.ts
@@ -38,6 +38,7 @@ import { AnimatedIfCurly } from "ember-animated/components/animated-if";
 import { FlashMessageComponent } from "ember-cli-flash/flash-message";
 import OnClickOutsideModifier from "ember-click-outside/modifiers/on-click-outside";
 import { HdsFormErrorComponent } from "hds/form/error";
+import { MarkdownToHtmlCurly } from "ember-cli-showdown/components/markdown-to-html";
 
 declare module "@glint/environment-ember-loose/registry" {
   export default interface Registry {
@@ -45,6 +46,7 @@ declare module "@glint/environment-ember-loose/registry" {
     "will-destroy": typeof WillDestroyModifier;
     "on-document": typeof OnDocumentHelper;
     "click-outside": typeof OnClickOutsideModifier;
+    "markdown-to-html": typeof MarkdownToHtmlCurly
     AnimatedContainer: typeof AnimatedContainer;
     AnimatedValue: typeof AnimatedValue;
     AnimatedOrphans: typeof AnimatedOrphans;

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3986,7 +3986,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^3.0.0, ansi-styles@npm:^3.2.1":
+"ansi-styles@npm:^3.0.0, ansi-styles@npm:^3.2.0, ansi-styles@npm:^3.2.1":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
   dependencies:
@@ -6412,6 +6412,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"camelcase@npm:^5.0.0":
+  version: 5.3.1
+  resolution: "camelcase@npm:5.3.1"
+  checksum: e6effce26b9404e3c0f301498184f243811c30dfe6d0b9051863bd8e4034d09c8c2923794f280d6827e5aa055f6c434115ff97864a16a963366fb35fd673024b
+  languageName: node
+  linkType: hard
+
 "can-symlink@npm:^1.0.0":
   version: 1.0.0
   resolution: "can-symlink@npm:1.0.0"
@@ -6701,6 +6708,17 @@ __metadata:
   version: 3.0.0
   resolution: "cli-width@npm:3.0.0"
   checksum: 4c94af3769367a70e11ed69aa6095f1c600c0ff510f3921ab4045af961820d57c0233acfa8b6396037391f31b4c397e1f614d234294f979ff61430a6c166c3f6
+  languageName: node
+  linkType: hard
+
+"cliui@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "cliui@npm:5.0.0"
+  dependencies:
+    string-width: ^3.1.0
+    strip-ansi: ^5.2.0
+    wrap-ansi: ^5.1.0
+  checksum: 0bb8779efe299b8f3002a73619eaa8add4081eb8d1c17bc4fedc6240557fb4eacdc08fe87c39b002eacb6cfc117ce736b362dbfd8bf28d90da800e010ee97df4
   languageName: node
   linkType: hard
 
@@ -7282,6 +7300,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decamelize@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "decamelize@npm:1.2.0"
+  checksum: ad8c51a7e7e0720c70ec2eeb1163b66da03e7616d7b98c9ef43cce2416395e84c1e9548dd94f5f6ffecfee9f8b94251fc57121a8b021f2ff2469b2bae247b8aa
+  languageName: node
+  linkType: hard
+
 "decode-uri-component@npm:^0.2.0":
   version: 0.2.2
   resolution: "decode-uri-component@npm:0.2.2"
@@ -7699,7 +7724,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ember-auto-import@npm:^2.6.0":
+"ember-auto-import@npm:^2.6.0, ember-auto-import@npm:^2.6.3":
   version: 2.6.3
   resolution: "ember-auto-import@npm:2.6.3"
   dependencies:
@@ -8123,6 +8148,20 @@ __metadata:
     broccoli-sass-source-maps: ^4.0.0
     ember-cli-version-checker: ^2.1.0
   checksum: 99eb9045b19c82851a90435df14b4ab4108ee0fd57a9e78d085c225a9d3dfb72bae8118707cf2f1a2d4d37abc2c40ad0dd95c0079f43d051ec90526448189ac3
+  languageName: node
+  linkType: hard
+
+"ember-cli-showdown@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "ember-cli-showdown@npm:7.0.0"
+  dependencies:
+    ember-auto-import: ^2.6.3
+    ember-cli-babel: ^7.26.11
+    ember-cli-htmlbars: ^6.2.0
+    showdown: ^1.8.6
+  peerDependencies:
+    ember-source: ^3.12.0 || >4.0.0
+  checksum: 3fe9aa3ad7aa0660792155d2a3ab3ae47573685bc4cd781f1855d81c774714cf6f52c4975525140060d44f76878c2556e143191b86fd3a15c7dd721246342f16
   languageName: node
   linkType: hard
 
@@ -9098,6 +9137,13 @@ __metadata:
     ember-cli-babel: ^7.26.11
     ember-cli-htmlbars: ^6.0.1
   checksum: e06d077fe72e6dacd070cb7c41e9646bc2357996ab4ca0d0ae0c869fe23159a29de297894f45561a8bfe8b630dbb875b52513032872f5ed74adfbe161c606843
+  languageName: node
+  linkType: hard
+
+"emoji-regex@npm:^7.0.1":
+  version: 7.0.3
+  resolution: "emoji-regex@npm:7.0.3"
+  checksum: 9159b2228b1511f2870ac5920f394c7e041715429a68459ebe531601555f11ea782a8e1718f969df2711d38c66268174407cbca57ce36485544f695c2dfdc96e
   languageName: node
   linkType: hard
 
@@ -10615,7 +10661,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-caller-file@npm:^2.0.5":
+"get-caller-file@npm:^2.0.1, get-caller-file@npm:^2.0.5":
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"
   checksum: b9769a836d2a98c3ee734a88ba712e62703f1df31b94b784762c433c27a386dd6029ff55c2a920c392e33657d80191edbf18c61487e198844844516f843496b9
@@ -11174,6 +11220,7 @@ __metadata:
     ember-cli-inject-live-reload: ^2.1.0
     ember-cli-mirage: ^2.4.0
     ember-cli-postcss: ^8.0.0
+    ember-cli-showdown: ^7.0.0
     ember-cli-sri: ^2.1.1
     ember-cli-string-helpers: ^6.1.0
     ember-cli-terser: ^4.0.2
@@ -15456,6 +15503,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"require-main-filename@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "require-main-filename@npm:2.0.0"
+  checksum: e9e294695fea08b076457e9ddff854e81bffbe248ed34c1eec348b7abbd22a0d02e8d75506559e2265e96978f3c4720bd77a6dad84755de8162b357eb6c778c7
+  languageName: node
+  linkType: hard
+
 "require-relative@npm:^0.8.7":
   version: 0.8.7
   resolution: "require-relative@npm:0.8.7"
@@ -16103,6 +16157,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"showdown@npm:^1.8.6":
+  version: 1.9.1
+  resolution: "showdown@npm:1.9.1"
+  dependencies:
+    yargs: ^14.2
+  bin:
+    showdown: bin/showdown.js
+  checksum: d6aac199cb28c2b89bce804eddda928c816e5a2b0e0e6dfe66db8ced6968e237995bf1d547046c9970b804e5c3181b1a55740883e1332c837024668f9c031a01
+  languageName: node
+  linkType: hard
+
 "side-channel@npm:^1.0.4":
   version: 1.0.4
   resolution: "side-channel@npm:1.0.4"
@@ -16612,6 +16677,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-width@npm:^3.0.0, string-width@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "string-width@npm:3.1.0"
+  dependencies:
+    emoji-regex: ^7.0.1
+    is-fullwidth-code-point: ^2.0.0
+    strip-ansi: ^5.1.0
+  checksum: 57f7ca73d201682816d573dc68bd4bb8e1dff8dc9fcf10470fdfc3474135c97175fec12ea6a159e67339b41e86963112355b64529489af6e7e70f94a7caf08b2
+  languageName: node
+  linkType: hard
+
 "string.prototype.matchall@npm:^4.0.5":
   version: 4.0.8
   resolution: "string.prototype.matchall@npm:4.0.8"
@@ -16704,7 +16780,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^5.1.0, strip-ansi@npm:^5.2.0":
+"strip-ansi@npm:^5.0.0, strip-ansi@npm:^5.1.0, strip-ansi@npm:^5.2.0":
   version: 5.2.0
   resolution: "strip-ansi@npm:5.2.0"
   dependencies:
@@ -18066,6 +18142,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"which-module@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "which-module@npm:2.0.1"
+  checksum: 1967b7ce17a2485544a4fdd9063599f0f773959cca24176dbe8f405e55472d748b7c549cd7920ff6abb8f1ab7db0b0f1b36de1a21c57a8ff741f4f1e792c52be
+  languageName: node
+  linkType: hard
+
 "which@npm:^1.2.14, which@npm:^1.2.9":
   version: 1.3.1
   resolution: "which@npm:1.3.1"
@@ -18151,6 +18234,17 @@ __metadata:
   version: 6.3.1
   resolution: "workerpool@npm:6.3.1"
   checksum: 0974e3af33e0702933d3f1f0bb2768a8540f700adb46798ac64f3053c2beea82851a30d07c8b2804870651cddcc8f0574acaab1aa4cc2ef5ed9182746d6abd25
+  languageName: node
+  linkType: hard
+
+"wrap-ansi@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "wrap-ansi@npm:5.1.0"
+  dependencies:
+    ansi-styles: ^3.2.0
+    string-width: ^3.0.0
+    strip-ansi: ^5.0.0
+  checksum: 9b48c862220e541eb0daa22661b38b947973fc57054e91be5b0f2dcc77741a6875ccab4ebe970a394b4682c8dfc17e888266a105fb8b0a9b23c19245e781ceae
   languageName: node
   linkType: hard
 
@@ -18258,6 +18352,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yargs-parser@npm:^15.0.1":
+  version: 15.0.3
+  resolution: "yargs-parser@npm:15.0.3"
+  dependencies:
+    camelcase: ^5.0.0
+    decamelize: ^1.2.0
+  checksum: 06611c1893fa9f1c25ae79df3c6e2edbac7c8d75257a4b55b8432cbc87ee03eda86bea0537f65b4b8a0d9684c83fa6e9ef61ef720a1e5cc8a9aa6893b54ee4c3
+  languageName: node
+  linkType: hard
+
 "yargs-parser@npm:^20.2.2":
   version: 20.2.9
   resolution: "yargs-parser@npm:20.2.9"
@@ -18269,6 +18373,25 @@ __metadata:
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
   checksum: ed2d96a616a9e3e1cc7d204c62ecc61f7aaab633dcbfab2c6df50f7f87b393993fe6640d017759fe112d0cb1e0119f2b4150a87305cc873fd90831c6a58ccf1c
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^14.2":
+  version: 14.2.3
+  resolution: "yargs@npm:14.2.3"
+  dependencies:
+    cliui: ^5.0.0
+    decamelize: ^1.2.0
+    find-up: ^3.0.0
+    get-caller-file: ^2.0.1
+    require-directory: ^2.1.1
+    require-main-filename: ^2.0.0
+    set-blocking: ^2.0.0
+    string-width: ^3.0.0
+    which-module: ^2.0.0
+    y18n: ^4.0.0
+    yargs-parser: ^15.0.1
+  checksum: 684fcb1896e6c873c31c09c5c16445d6253dfe505aa879cff56d49425f5bca44f2ab8d7a1c949f3b932ae8654128425e89770e5e2f2c3d816e5816b9eb6efb6f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds a support screen that's accessible from the user menu. It reads JSON/Markdown from [somewhere] and formats it in the template.