### PR TITLE
Tweak "request review" design

### DIFF
--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -588,7 +588,7 @@
                 <FlightIcon @size="16" @name="at-sign" />
               </div>
               Approvers and people subscribed to
-              {{@document.product}}
+              “{{@document.product}}”
               will be notified.
             </li>
             <li class="flex items-center">
@@ -596,10 +596,8 @@
                 class="mr-2.5 inline-flex rounded-full text-color-palette-neutral-400"
               >
                 <FlightIcon @size="16" @name="radio" />
-
-                {{! <FlightIcon @size="16" @name="globe" /> }}
               </div>
-              Your doc will appear on Hermes and Google Group emails.
+              Your document will appear in Hermes and Google Workspace search.
             </li>
             <li class="flex items-center">
               <div
@@ -608,15 +606,9 @@
 
                 <FlightIcon @size="16" @name="globe-private" />
               </div>
-              Published docs cannot be deleted.
+              Published documents cannot be deleted but can be archived.
             </li>
           </ul>
-          {{!-- <p class="mb-4 pr-16 text-body-300 text-color-foreground-primary">
-            This will publish your document company-wide.
-            <br />Anyone subscribed to
-            {{@document.product}}
-            will be notified, along with the approvers below.
-          </p> --}}
 
           <Hds::Form::Field @layout="vertical" as |F|>
             <F.Control>

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -425,7 +425,7 @@
           {{#if this.isOwner}}
             <div class="flex items-start px-3 gap-2">
               <Hds::Button
-                @text="Request Review"
+                @text="Publish for review..."
                 @size="medium"
                 @color="primary"
                 class="w-full"
@@ -547,13 +547,12 @@
 
   {{#if this.requestReviewModalIsActive}}
     <Document::Modal
-      @headerText="Request review"
+      @headerText="Publish for review"
       @errorTitle="Error requesting review"
       @close={{this.closeRequestReviewModal}}
       @task={{perform this.requestReview}}
-      @taskButtonText="Request review"
-      @taskButtonLoadingText="Requesting review..."
-      @taskButtonIcon="test"
+      @taskButtonText="Publish doc"
+      @taskButtonLoadingText="Publishing..."
       @hideFooterWhileSaving={{true}}
       @taskButtonIsDisabled={{and
         (not this.docTypeCheckboxValue)
@@ -564,7 +563,7 @@
         {{#if M.taskIsRunning}}
           <div class="grid place-items-center pt-1 pb-12">
             <div class="text-center">
-              <FlightIcon @name="loading" @size={{24}} class="mb-5" />
+              <FlightIcon @name="loading" @size="24" class="mb-5" />
               <h2>Submitting for review...</h2>
               <p class="text-body-300 mb-2">This usually takes about a minute.</p>
               <span
@@ -581,10 +580,44 @@
             </div>
           </div>
         {{else}}
-          <p class="mb-4 pr-16 text-body-300 text-color-foreground-primary">
-            This will publish your document company-wide, and anyone you request
-            below will receive a notification to review.
-          </p>
+          <ul class="mb-6 space-y-1 text-body-300">
+            <li class="flex items-center">
+              <div
+                class="mr-2.5 inline-flex rounded-full text-color-palette-neutral-400"
+              >
+                <FlightIcon @size="16" @name="at-sign" />
+              </div>
+              Approvers and people subscribed to
+              {{@document.product}}
+              will be notified.
+            </li>
+            <li class="flex items-center">
+              <div
+                class="mr-2.5 inline-flex rounded-full text-color-palette-neutral-400"
+              >
+                <FlightIcon @size="16" @name="radio" />
+
+                {{! <FlightIcon @size="16" @name="globe" /> }}
+              </div>
+              Your doc will appear on Hermes and Google Group emails.
+            </li>
+            <li class="flex items-center">
+              <div
+                class="mr-2.5 inline-flex rounded-full text-color-palette-neutral-400"
+              >
+
+                <FlightIcon @size="16" @name="globe-private" />
+              </div>
+              Published docs cannot be deleted.
+            </li>
+          </ul>
+          {{!-- <p class="mb-4 pr-16 text-body-300 text-color-foreground-primary">
+            This will publish your document company-wide.
+            <br />Anyone subscribed to
+            {{@document.product}}
+            will be notified, along with the approvers below.
+          </p> --}}
+
           <Hds::Form::Field @layout="vertical" as |F|>
             <F.Control>
               <Inputs::PeopleSelect
@@ -595,8 +628,9 @@
                 class="mb-0"
               />
             </F.Control>
-            <F.Label>Add approvers</F.Label>
+            <F.Label>Approvers</F.Label>
           </Hds::Form::Field>
+
           {{#if @docType.checks.length}}
             {{! For now, we only support one check }}
             {{#each (take 1 @docType.checks) as |check|}}


### PR DESCRIPTION
Tweaks the "request review" elements to make the process clearer.

Some users mistake "request[ing a] review," which publishes the doc and triggers email notifications, for a lightweight "get eyes on this" type of action. The proposed design moves the idea of "publishing" to the forefront, and calls out, in explicit terms what the action does.

## Current
<img width="282" alt="CleanShot 2023-07-26 at 16 55 34@2x" src="https://github.com/hashicorp-forge/hermes/assets/754957/0c202ea5-3adc-4503-ad84-66e6281e262c">

<img width="640" alt="CleanShot 2023-07-26 at 16 48 31@2x" src="https://github.com/hashicorp-forge/hermes/assets/754957/883b7899-d805-4e2a-8978-6d29b51bf100">


## Proposed

<img width="282" alt="CleanShot 2023-07-26 at 16 55 16@2x" src="https://github.com/hashicorp-forge/hermes/assets/754957/ce4a8af0-f637-4c13-9f37-9159106d6dc5">

<img width="647" alt="CleanShot 2023-07-26 at 16 47 14@2x" src="https://github.com/hashicorp-forge/hermes/assets/754957/7cc18f67-4a63-47e7-b032-f8ed91425238">

