### PR TITLE
Footer/UserNav: Add support docs link

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,9 @@ type Config struct {
 
 	// ShortenerBaseURL is the base URL for building short links.
 	ShortenerBaseURL string `hcl:"shortener_base_url,optional"`
+
+	// SupportLinkURL is the URL for the support documentation.
+	SupportLinkURL string `hcl:"support_link_url,optional"`
 }
 
 // DocumentTypes contain available document types.

--- a/web/app/components/external-link.hbs
+++ b/web/app/components/external-link.hbs
@@ -10,6 +10,6 @@
     {{yield}}
   </span>
   {{#if @iconIsShown}}
-    <FlightIcon @name={{"external-link"}} class="opacity-75" />
+    <FlightIcon @name="external-link" class="opacity-75" />
   {{/if}}
 </a>

--- a/web/app/components/external-link.hbs
+++ b/web/app/components/external-link.hbs
@@ -3,7 +3,13 @@
   href="#"
   target="_blank"
   rel="noopener noreferrer"
+  class={{if @iconIsShown "flex items-center space-x-1.5"}}
   ...attributes
 >
-  {{yield}}
+  <span>
+    {{yield}}
+  </span>
+  {{#if @iconIsShown}}
+    <FlightIcon @name={{"external-link"}} class="opacity-75" />
+  {{/if}}
 </a>

--- a/web/app/components/external-link.ts
+++ b/web/app/components/external-link.ts
@@ -4,7 +4,6 @@ interface ExternalLinkComponentSignature {
   Element: HTMLAnchorElement;
   Args: {
     iconIsShown?: boolean;
-    iconIsSmall?: boolean;
   };
   Blocks: {
     default: [];

--- a/web/app/components/external-link.ts
+++ b/web/app/components/external-link.ts
@@ -2,6 +2,10 @@ import Component from "@glimmer/component";
 
 interface ExternalLinkComponentSignature {
   Element: HTMLAnchorElement;
+  Args: {
+    iconIsShown?: boolean;
+    iconIsSmall?: boolean;
+  };
   Blocks: {
     default: [];
   };

--- a/web/app/components/footer.hbs
+++ b/web/app/components/footer.hbs
@@ -21,11 +21,8 @@
           <ExternalLink @iconIsShown={{true}} href={{this.gitHubRepoURL}}>
             GitHub repo
           </ExternalLink>
-          {{#if this.supportLinkIsShown}}
-            <ExternalLink
-              @iconIsShown={{true}}
-              href="https://github.com/hashicorp-forge/hermes"
-            >
+          {{#if this.supportDocsURL}}
+            <ExternalLink @iconIsShown={{true}} href={{this.supportDocsURL}}>
               Support docs
             </ExternalLink>
           {{/if}}

--- a/web/app/components/footer.hbs
+++ b/web/app/components/footer.hbs
@@ -8,13 +8,6 @@
             {{this.currentYear}}
             HashiCorp
           </div>
-          {{#if this.hermesVersion}}
-            <div class="mx-2">·</div>
-            <div class="flex items-center">
-              Version
-              {{this.hermesVersion}}
-            </div>
-          {{/if}}
         </div>
 
         <div class="flex items-center space-x-4">

--- a/web/app/components/footer.hbs
+++ b/web/app/components/footer.hbs
@@ -3,7 +3,7 @@
     <div class="x-container">
       <div class="footer-inner">
         <div class="flex items-center">
-          <div>
+          <div data-test-footer-copyright>
             ©
             {{this.currentYear}}
             HashiCorp
@@ -11,11 +11,19 @@
         </div>
 
         <div class="flex items-center space-x-4">
-          <ExternalLink @iconIsShown={{true}} href={{this.gitHubRepoURL}}>
+          <ExternalLink
+            data-test-footer-github-link
+            @iconIsShown={{true}}
+            href={{this.gitHubRepoURL}}
+          >
             GitHub
           </ExternalLink>
-          {{#if this.supportDocsURL}}
-            <ExternalLink @iconIsShown={{true}} href={{this.supportDocsURL}}>
+          {{#if this.supportURL}}
+            <ExternalLink
+              data-test-footer-support-link
+              @iconIsShown={{true}}
+              href={{this.supportURL}}
+            >
               Support
             </ExternalLink>
           {{/if}}

--- a/web/app/components/footer.hbs
+++ b/web/app/components/footer.hbs
@@ -1,20 +1,35 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{#unless (eq this.currentRouteName "authenticated.document")}}
-  <div class="footer">
+  <div class="footer" ...attributes>
     <div class="x-container">
-      <div
-        class="text-body-200 text-color-foreground-faint flex items-center justify-center"
-      >
-        ©
-        {{this.currentYear}}
-        HashiCorp
-        <div class="mx-2">•</div>
-        <ExternalLink
-          href="https://github.com/hashicorp-forge/hermes"
-          class="flex"
-        >
-          View Hermes on GitHub
-        </ExternalLink>
+      <div class="footer-inner">
+        <div class="flex items-center">
+          <div>
+            ©
+            {{this.currentYear}}
+            HashiCorp
+          </div>
+          {{#if this.hermesVersion}}
+            <div class="mx-2">·</div>
+            <div class="flex items-center">
+              Version
+              {{this.hermesVersion}}
+            </div>
+          {{/if}}
+        </div>
+
+        <div class="flex items-center space-x-4">
+          <ExternalLink @iconIsShown={{true}} href={{this.gitHubRepoURL}}>
+            GitHub repo
+          </ExternalLink>
+          {{#if this.supportLinkIsShown}}
+            <ExternalLink
+              @iconIsShown={{true}}
+              href="https://github.com/hashicorp-forge/hermes"
+            >
+              Support docs
+            </ExternalLink>
+          {{/if}}
+        </div>
       </div>
     </div>
   </div>

--- a/web/app/components/footer.ts
+++ b/web/app/components/footer.ts
@@ -29,7 +29,7 @@ export default class FooterComponent extends Component<FooterComponentSignature>
 
   protected get supportDocsURL() {
     // TODO: Get this from the config
-    return "";
+    return "#";
   }
 }
 

--- a/web/app/components/footer.ts
+++ b/web/app/components/footer.ts
@@ -24,7 +24,7 @@ export default class FooterComponent extends Component<FooterComponentSignature>
     return HERMES_GITHUB_REPO_URL;
   }
 
-  protected get supportDocsURL() {
+  protected get supportURL() {
     return this.config.config.support_link_url;
   }
 }

--- a/web/app/components/footer.ts
+++ b/web/app/components/footer.ts
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 import RouterService from "@ember/routing/router-service";
 import { HERMES_GITHUB_REPO_URL } from "hermes/utils/hermes-urls";
+import ConfigService from "hermes/services/config";
 
 interface FooterComponentSignature {
   Element: HTMLDivElement;
@@ -9,6 +10,7 @@ interface FooterComponentSignature {
 
 export default class FooterComponent extends Component<FooterComponentSignature> {
   @service declare router: RouterService;
+  @service declare config: ConfigService;
 
   protected get currentRouteName(): string {
     return this.router.currentRouteName;
@@ -18,18 +20,12 @@ export default class FooterComponent extends Component<FooterComponentSignature>
     return new Date().getFullYear();
   }
 
-  protected get hermesVersion() {
-    // TODO: Get this from the config
-    return "0.3.0";
-  }
-
   protected get gitHubRepoURL() {
     return HERMES_GITHUB_REPO_URL;
   }
 
   protected get supportDocsURL() {
-    // TODO: Get this from the config
-    return "#";
+    return this.config.config.support_link_url;
   }
 }
 

--- a/web/app/components/footer.ts
+++ b/web/app/components/footer.ts
@@ -18,18 +18,18 @@ export default class FooterComponent extends Component<FooterComponentSignature>
     return new Date().getFullYear();
   }
 
-  protected get supportLinkIsShown() {
-    // TODO: Get this from the config
-    return true;
-  }
-
   protected get hermesVersion() {
-    // return "0.3.0";
-    return null;
+    // TODO: Get this from the config
+    return "0.3.0";
   }
 
   protected get gitHubRepoURL() {
     return HERMES_GITHUB_REPO_URL;
+  }
+
+  protected get supportDocsURL() {
+    // TODO: Get this from the config
+    return "";
   }
 }
 

--- a/web/app/components/footer.ts
+++ b/web/app/components/footer.ts
@@ -1,8 +1,13 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 import RouterService from "@ember/routing/router-service";
+import { HERMES_GITHUB_REPO_URL } from "hermes/utils/hermes-urls";
 
-export default class FooterComponent extends Component {
+interface FooterComponentSignature {
+  Element: HTMLDivElement;
+}
+
+export default class FooterComponent extends Component<FooterComponentSignature> {
   @service declare router: RouterService;
 
   protected get currentRouteName(): string {
@@ -11,5 +16,25 @@ export default class FooterComponent extends Component {
 
   protected get currentYear(): number {
     return new Date().getFullYear();
+  }
+
+  protected get supportLinkIsShown() {
+    // TODO: Get this from the config
+    return true;
+  }
+
+  protected get hermesVersion() {
+    // return "0.3.0";
+    return null;
+  }
+
+  protected get gitHubRepoURL() {
+    return HERMES_GITHUB_REPO_URL;
+  }
+}
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry {
+    Footer: typeof FooterComponent;
   }
 }

--- a/web/app/components/header/nav.hbs
+++ b/web/app/components/header/nav.hbs
@@ -76,6 +76,22 @@
           />
           <dd.Separator class="mt-2" />
           <dd.Interactive
+            @href={{this.gitHubRepoURL}}
+            @isHrefExternal={{true}}
+            @text="GitHub repo"
+            @icon="external-link"
+            class="user-menu-external-link"
+          />
+          {{#if this.supportDocsLinkIsShown}}
+            <dd.Interactive
+              @href={{this.supportDocsURL}}
+              @isHrefExternal={{true}}
+              @text="Support docs"
+              @icon="external-link"
+              class="user-menu-external-link"
+            />
+          {{/if}}
+          <dd.Interactive
             data-test-user-menu-item="email-notifications"
             @route="authenticated.settings"
             @text="Email notifications"

--- a/web/app/components/header/nav.hbs
+++ b/web/app/components/header/nav.hbs
@@ -82,7 +82,7 @@
             @icon="external-link"
             class="user-menu-external-link"
           />
-          {{#if this.supportDocsLinkIsShown}}
+          {{#if this.supportDocsURL}}
             <dd.Interactive
               @href={{this.supportDocsURL}}
               @isHrefExternal={{true}}

--- a/web/app/components/header/nav.hbs
+++ b/web/app/components/header/nav.hbs
@@ -76,6 +76,7 @@
           />
           <dd.Separator class="mt-2" />
           <dd.Interactive
+            data-test-user-menu-github
             @href={{this.gitHubRepoURL}}
             @isHrefExternal={{true}}
             @text="GitHub"
@@ -84,6 +85,7 @@
           />
           {{#if this.supportDocsURL}}
             <dd.Interactive
+              data-test-user-menu-support
               @href={{this.supportDocsURL}}
               @isHrefExternal={{true}}
               @text="Support"

--- a/web/app/components/header/nav.ts
+++ b/web/app/components/header/nav.ts
@@ -9,6 +9,7 @@ import AuthenticatedUserService, {
 } from "hermes/services/authenticated-user";
 import window from "ember-window-mock";
 import { tracked } from "@glimmer/tracking";
+import { HERMES_GITHUB_REPO_URL } from "hermes/utils/hermes-urls";
 
 interface HeaderNavComponentSignature {
   Args: {};
@@ -30,6 +31,19 @@ export default class HeaderNavComponent extends Component<HeaderNavComponentSign
 
   protected get showSignOut(): boolean {
     return !this.configSvc.config.skip_google_auth;
+  }
+
+  protected get supportDocsLinkIsShown() {
+    // this should depend on the config
+    return true;
+  }
+
+  protected get gitHubRepoURL() {
+    return HERMES_GITHUB_REPO_URL;
+  }
+
+  protected get supportDocsURL() {
+    return "";
   }
 
   /**
@@ -87,7 +101,6 @@ export default class HeaderNavComponent extends Component<HeaderNavComponentSign
 
 declare module "@glint/environment-ember-loose/registry" {
   export default interface Registry {
-    'Header::Nav': typeof HeaderNavComponent;
+    "Header::Nav": typeof HeaderNavComponent;
   }
 }
-

--- a/web/app/components/header/nav.ts
+++ b/web/app/components/header/nav.ts
@@ -33,17 +33,12 @@ export default class HeaderNavComponent extends Component<HeaderNavComponentSign
     return !this.configSvc.config.skip_google_auth;
   }
 
-  protected get supportDocsLinkIsShown() {
-    // this should depend on the config
-    return true;
-  }
-
   protected get gitHubRepoURL() {
     return HERMES_GITHUB_REPO_URL;
   }
 
   protected get supportDocsURL() {
-    return "";
+    return this.configSvc.config.support_link_url;
   }
 
   /**

--- a/web/app/config/environment.d.ts
+++ b/web/app/config/environment.d.ts
@@ -23,6 +23,7 @@ declare const config: {
   shortLinkBaseURL: string;
   skipGoogleAuth: boolean;
   showEmberAnimatedTools: boolean;
+  supportLinkURL: string;
 };
 
 export default config;

--- a/web/app/routes/application.ts
+++ b/web/app/routes/application.ts
@@ -70,18 +70,17 @@ export default class ApplicationRoute extends Route {
 
     this.flags.initialize();
 
-    // Set config from the backend in production
-    if (config.environment === "production") {
-      await this.fetchSvc
-        .fetch("/api/v1/web/config")
-        .then((response) => response?.json())
-        .then((json) => {
-          this.config.setConfig(json);
-        })
-        .catch((err) => {
-          console.log("Error fetching and setting web config: " + err);
-        });
-    }
+    console.log('did it work');
+
+    await this.fetchSvc
+      .fetch("/api/v1/web/config")
+      .then((response) => response?.json())
+      .then((json) => {
+        this.config.setConfig(json);
+      })
+      .catch((err) => {
+        console.log("Error fetching and setting web config: " + err);
+      });
 
     // Initialize the metrics service
     this.metrics;

--- a/web/app/routes/application.ts
+++ b/web/app/routes/application.ts
@@ -1,7 +1,6 @@
 import Route from "@ember/routing/route";
 import { UnauthorizedError } from "@ember-data/adapter/error";
 import { action } from "@ember/object";
-import config from "hermes/config/environment";
 import { inject as service } from "@ember/service";
 import ConfigService from "hermes/services/config";
 import FetchService from "hermes/services/fetch";
@@ -12,7 +11,6 @@ import window from "ember-window-mock";
 import { REDIRECT_STORAGE_KEY } from "hermes/services/session";
 import Transition from "@ember/routing/transition";
 import MetricsService from "hermes/services/metrics";
-import GoogleAnalyticsFourAdapter from "hermes/metrics-adapters/google-analytics-four";
 
 export default class ApplicationRoute extends Route {
   @service declare config: ConfigService;
@@ -69,8 +67,6 @@ export default class ApplicationRoute extends Route {
     await this.session.setup();
 
     this.flags.initialize();
-
-    console.log('did it work');
 
     await this.fetchSvc
       .fetch("/api/v1/web/config")

--- a/web/app/services/config.ts
+++ b/web/app/services/config.ts
@@ -14,6 +14,7 @@ export default class ConfigService extends Service {
     short_link_base_url: config.shortLinkBaseURL,
     skip_google_auth: config.skipGoogleAuth,
     google_analytics_tag_id: undefined,
+    support_link_url: config.supportLinkURL,
   };
 
   setConfig(param) {

--- a/web/app/styles/components/footer.scss
+++ b/web/app/styles/components/footer.scss
@@ -1,7 +1,19 @@
 .footer {
-  @apply text-center mt-12 mb-16;
+  @apply mt-12 mb-16 w-full text-body-200 text-color-foreground-faint;
 
-  a {
-    @apply text-inherit no-underline border-b border-b-color-border-primary hover:border-b-color-foreground-action hover:text-color-foreground-action;
+  .footer-inner {
+    @apply border-t border-t-color-border-primary pt-6 flex w-full items-center justify-between;
+  }
+
+  &.compact {
+    @apply mt-6;
+
+    .x-container {
+      @apply px-0;
+    }
+
+    .footer-inner {
+      @apply border-t-0;
+    }
   }
 }

--- a/web/app/styles/components/footer.scss
+++ b/web/app/styles/components/footer.scss
@@ -6,7 +6,7 @@
   }
 
   &.compact {
-    @apply mt-6;
+    @apply mt-0;
 
     .x-container {
       @apply px-0;

--- a/web/app/styles/components/nav.scss
+++ b/web/app/styles/components/nav.scss
@@ -39,6 +39,18 @@
     @apply w-[30px] h-[30px] rounded-[3px] absolute z-10 top-1/2 -translate-y-1/2 left-[3px] pointer-events-none;
   }
 
+  .user-menu-external-link {
+    @apply flex-row-reverse justify-end;
+
+    .hds-dropdown-list-item__interactive-icon {
+      @apply mr-0 ml-1.5 opacity-50;
+    }
+
+    .hds-dropdown-list-item__interactive-text {
+      @apply flex-initial;
+    }
+  }
+
   .search-dropdown {
     @apply w-full max-w-none min-w-[320px];
   }

--- a/web/app/styles/components/nav.scss
+++ b/web/app/styles/components/nav.scss
@@ -42,8 +42,14 @@
   .user-menu-external-link {
     @apply flex-row-reverse justify-end;
 
+    &:not(:hover) {
+      .hds-dropdown-list-item__interactive-icon {
+        @apply text-color-foreground-faint opacity-75;
+      }
+    }
+
     .hds-dropdown-list-item__interactive-icon {
-      @apply mr-0 ml-1.5 opacity-50;
+      @apply mr-0 ml-1.5;
     }
 
     .hds-dropdown-list-item__interactive-text {

--- a/web/app/templates/authenticate.hbs
+++ b/web/app/templates/authenticate.hbs
@@ -5,28 +5,30 @@
 <div
   class="flex flex-col items-center justify-center flex-1 min-h-full py-12 relative"
 >
-  <Hds::Card::Container
-    @level="high"
-    @hasBorder="true"
-    @overflow="visible"
-    class="flex flex-col items-center px-24 pt-24 pb-32 text-center relative"
-  >
-    <HermesLogo class="mb-8" />
-    <h1 class="">
-      Welcome to Hermes.
-    </h1>
-    <p class="mb-8 text-display-300">
-      Log in to browse, search, and manage documents
-    </p>
-    <Hds::Button
-      @text="Authenticate with Google"
-      @size="large"
-      @icon="google"
-      {{on "click" (perform this.authenticate)}}
-    />
+  <div class="w-full max-w-xl mx-auto">
+    <Hds::Card::Container
+      @level="high"
+      @hasBorder="true"
+      @overflow="visible"
+      class="w-full flex flex-col items-center px-20 pt-24 pb-32 text-center relative"
+    >
+      <HermesLogo class="mb-8" />
+      <h1 class="">
+        Welcome to Hermes.
+      </h1>
+      <p class="mb-8 text-display-300">
+        Log in to browse, search, and manage documents
+      </p>
+      <Hds::Button
+        @text="Authenticate with Google"
+        @size="large"
+        @icon="google"
+        {{on "click" (perform this.authenticate)}}
+      />
 
-  </Hds::Card::Container>
-  <Footer/>
+    </Hds::Card::Container>
+    <Footer class="compact" />
+  </div>
 </div>
 
 {{outlet}}

--- a/web/app/utils/hermes-urls.d.ts
+++ b/web/app/utils/hermes-urls.d.ts
@@ -1,0 +1,5 @@
+declare module "hermes/utils/hermes-urls" {
+  export const HERMES_GITHUB_REPO_URL: string;
+  export const TEST_SUPPORT_URL: string;
+  export const TEST_SHORT_LINK_BASE_URL: string;
+}

--- a/web/app/utils/hermes-urls.ts
+++ b/web/app/utils/hermes-urls.ts
@@ -1,0 +1,2 @@
+export const HERMES_GITHUB_REPO_URL =
+  "https://github.com/hashicorp-forge/hermes";

--- a/web/app/utils/hermes-urls.ts
+++ b/web/app/utils/hermes-urls.ts
@@ -1,4 +1,12 @@
 export const HERMES_GITHUB_REPO_URL =
   "https://github.com/hashicorp-forge/hermes";
 
-export const TEST_SUPPORT_URL = "https://example.com/support";
+/**
+ * These values are loaded by the Mirage in acceptance tests.
+ *
+ * To mock them in rendering tests, set them directly on the service, e.g.,
+ * let mockConfigSvc = this.owner.lookup("service:config") as ConfigService;
+ * mockConfigSvc.config.support_link_url = SUPPORT_URL;
+ */
+export const TEST_SUPPORT_URL = "https://config-loaded-support-link.com";
+export const TEST_SHORT_LINK_URL = "https://config-loaded-short-link.com";

--- a/web/app/utils/hermes-urls.ts
+++ b/web/app/utils/hermes-urls.ts
@@ -1,2 +1,4 @@
 export const HERMES_GITHUB_REPO_URL =
   "https://github.com/hashicorp-forge/hermes";
+
+export const TEST_SUPPORT_URL = "https://example.com/support";

--- a/web/app/utils/hermes-urls.ts
+++ b/web/app/utils/hermes-urls.ts
@@ -9,4 +9,4 @@ export const HERMES_GITHUB_REPO_URL =
  * mockConfigSvc.config.support_link_url = SUPPORT_URL;
  */
 export const TEST_SUPPORT_URL = "https://config-loaded-support-link.com";
-export const TEST_SHORT_LINK_URL = "https://config-loaded-short-link.com";
+export const TEST_SHORT_LINK_BASE_URL = "https://config-loaded-short-link-base-url.com";

--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -1,10 +1,13 @@
 // https://www.ember-cli-mirage.com/docs/advanced/server-configuration
 
 import { Collection, Response, createServer } from "miragejs";
-import config from "../config/environment";
-import { SearchResponse } from "@algolia/client-search";
 import { getTestDocNumber } from "./factories/document";
-import { SearchForFacetValuesResponse } from "@algolia/client-search";
+
+// @ts-ignore - Mirage is not finding import
+import config from "../config/environment";
+
+// @ts-ignore - Mirage is not finding import
+import { TEST_SUPPORT_URL } from "hermes/utils/hermes-urls";
 
 export default function (mirageConfig) {
   let finalConfig = {
@@ -141,6 +144,27 @@ export default function (mirageConfig) {
        * GET requests
        *
        *************************************************************************/
+
+      /**
+       * Used by the config service for environment variables.
+       */
+      this.get("/web/config", () => {
+        return new Response(
+          200,
+          {},
+          {
+            algolia_docs_index_name: config.algolia.docsIndexName,
+            algolia_drafts_index_name: config.algolia.draftsIndexName,
+            algolia_internal_index_name: config.algolia.internalIndexName,
+            feature_flags: null,
+            google_doc_folders: "",
+            short_link_base_url: config.shortLinkBaseURL,
+            skip_google_auth: config.skipGoogleAuth,
+            google_analytics_tag_id: undefined,
+            support_link_url: TEST_SUPPORT_URL,
+          }
+        );
+      });
 
       /**
        * Used in the /new routes when creating a document.

--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -8,8 +8,7 @@ import config from "../config/environment";
 
 import {
   TEST_SUPPORT_URL,
-  TEST_SHORT_LINK_URL,
-  // @ts-ignore - Mirage not detecting file
+  TEST_SHORT_LINK_BASE_URL,
 } from "hermes/utils/hermes-urls";
 
 export default function (mirageConfig) {
@@ -161,7 +160,7 @@ export default function (mirageConfig) {
             algolia_internal_index_name: config.algolia.internalIndexName,
             feature_flags: null,
             google_doc_folders: "",
-            short_link_base_url: TEST_SHORT_LINK_URL,
+            short_link_base_url: TEST_SHORT_LINK_BASE_URL,
             skip_google_auth: false,
             google_analytics_tag_id: undefined,
             support_link_url: TEST_SUPPORT_URL,

--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -3,11 +3,14 @@
 import { Collection, Response, createServer } from "miragejs";
 import { getTestDocNumber } from "./factories/document";
 
-// @ts-ignore - Mirage is not finding import
+// @ts-ignore - Mirage not detecting file
 import config from "../config/environment";
 
-// @ts-ignore - Mirage is not finding import
-import { TEST_SUPPORT_URL } from "hermes/utils/hermes-urls";
+import {
+  TEST_SUPPORT_URL,
+  TEST_SHORT_LINK_URL,
+  // @ts-ignore - Mirage not detecting file
+} from "hermes/utils/hermes-urls";
 
 export default function (mirageConfig) {
   let finalConfig = {
@@ -158,8 +161,8 @@ export default function (mirageConfig) {
             algolia_internal_index_name: config.algolia.internalIndexName,
             feature_flags: null,
             google_doc_folders: "",
-            short_link_base_url: config.shortLinkBaseURL,
-            skip_google_auth: config.skipGoogleAuth,
+            short_link_base_url: TEST_SHORT_LINK_URL,
+            skip_google_auth: false,
             google_analytics_tag_id: undefined,
             support_link_url: TEST_SUPPORT_URL,
           }

--- a/web/tests/acceptance/application-test.ts
+++ b/web/tests/acceptance/application-test.ts
@@ -7,6 +7,7 @@ import {
 } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import SessionService from "hermes/services/session";
+import { TEST_SUPPORT_URL } from "hermes/utils/hermes-urls";
 
 module("Acceptance | application", function (hooks) {
   setupApplicationTest(hooks);
@@ -108,7 +109,6 @@ module("Acceptance | application", function (hooks) {
     await click("[data-test-flash-notification-button]");
     await waitFor(successSelector);
 
-
     assert
       .dom(warningSelector)
       .doesNotExist("flash notification is dismissed on reauth buttonClick");
@@ -174,5 +174,21 @@ module("Acceptance | application", function (hooks) {
      *
      */
     teardownContext(this);
+  });
+
+  test("the config is grabbed from the backend when the app loads", async function (this: ApplicationTestContext, assert) {
+    await authenticateSession({});
+
+    await visit("/");
+
+    assert
+      .dom(".footer [data-test-footer-support-link]")
+      .hasAttribute("href", TEST_SUPPORT_URL);
+
+    await click("[data-test-user-menu-toggle]");
+
+    assert
+      .dom("[data-test-user-menu-support")
+      .hasAttribute("href", TEST_SUPPORT_URL);
   });
 });

--- a/web/tests/acceptance/authenticate-test.ts
+++ b/web/tests/acceptance/authenticate-test.ts
@@ -14,4 +14,9 @@ module("Acceptance | authenticate", function (hooks) {
     await visit("/authenticate");
     assert.equal(getPageTitle(), "Authenticate | Hermes");
   });
+
+  test('the footer has the compact class', async function (this: AuthenticateRouteTestContext, assert) {
+    await visit("/authenticate");
+    assert.dom(".footer").hasClass("compact");
+  });
 });

--- a/web/tests/acceptance/authenticated/document-test.ts
+++ b/web/tests/acceptance/authenticated/document-test.ts
@@ -1,5 +1,6 @@
 import {
   click,
+  find,
   findAll,
   triggerEvent,
   visit,
@@ -17,6 +18,8 @@ import {
 } from "hermes/components/document/sidebar";
 import { capitalize } from "@ember/string";
 import window from "ember-window-mock";
+import sinon from "sinon";
+import { TEST_SHORT_LINK_URL } from "hermes/utils/hermes-urls";
 
 const ADD_RELATED_RESOURCE_BUTTON_SELECTOR =
   "[data-test-section-header-button-for='Related resources']";
@@ -162,6 +165,17 @@ module("Acceptance | authenticated/document", function (hooks) {
     assert
       .dom("[data-test-product-select]")
       .doesNotExist("published docs don't show a product select element");
+  });
+
+  test("the shortLinkURL is loaded by the config service", async function (this: AuthenticatedDocumentRouteTestContext, assert) {
+    this.server.create("document", { objectID: 500, title: "Test Document" });
+
+    await visit("/document/500");
+    const shortLinkURL = find(COPY_URL_BUTTON_SELECTOR)?.getAttribute(
+      "data-test-url"
+    );
+
+    assert.true(shortLinkURL?.startsWith(TEST_SHORT_LINK_URL));
   });
 
   test("a flash message displays when a related resource fails to save", async function (this: AuthenticatedDocumentRouteTestContext, assert) {

--- a/web/tests/acceptance/authenticated/document-test.ts
+++ b/web/tests/acceptance/authenticated/document-test.ts
@@ -19,7 +19,7 @@ import {
 import { capitalize } from "@ember/string";
 import window from "ember-window-mock";
 import sinon from "sinon";
-import { TEST_SHORT_LINK_URL } from "hermes/utils/hermes-urls";
+import { TEST_SHORT_LINK_BASE_URL } from "hermes/utils/hermes-urls";
 
 const ADD_RELATED_RESOURCE_BUTTON_SELECTOR =
   "[data-test-section-header-button-for='Related resources']";
@@ -175,7 +175,7 @@ module("Acceptance | authenticated/document", function (hooks) {
       "data-test-url"
     );
 
-    assert.true(shortLinkURL?.startsWith(TEST_SHORT_LINK_URL));
+    assert.true(shortLinkURL?.startsWith(TEST_SHORT_LINK_BASE_URL));
   });
 
   test("a flash message displays when a related resource fails to save", async function (this: AuthenticatedDocumentRouteTestContext, assert) {

--- a/web/tests/acceptance/authenticated/document-test.ts
+++ b/web/tests/acceptance/authenticated/document-test.ts
@@ -79,6 +79,12 @@ module("Acceptance | authenticated/document", function (hooks) {
     assert.equal(getPageTitle(), "Test Document | Hermes");
   });
 
+  test("the footer is not shown", async function (this: AuthenticatedDocumentRouteTestContext, assert) {
+    this.server.create("document", { objectID: 1, title: "Test Document" });
+    await visit("/document/1");
+    assert.dom(".footer").doesNotExist();
+  });
+
   test("the page title is correct (draft)", async function (this: AuthenticatedDocumentRouteTestContext, assert) {
     this.server.create("document", {
       objectID: 1,

--- a/web/tests/integration/components/external-link-test.ts
+++ b/web/tests/integration/components/external-link-test.ts
@@ -8,7 +8,6 @@ module("Integration | Component | external-link", function (hooks) {
 
   test("it renders an external link", async function (assert) {
     await render(hbs`
-      {{! @glint-nocheck: not typesafe yet }}
       <ExternalLink href="https://hashicorp.com" class="font-bold">
         HashiCorp
       </ExternalLink>
@@ -21,5 +20,20 @@ module("Integration | Component | external-link", function (hooks) {
       .hasAttribute("href", "https://hashicorp.com")
       .hasAttribute("target", "_blank")
       .hasAttribute("rel", "noopener noreferrer");
+  });
+
+  test("it can render with an icon", async function (assert) {
+    await render(hbs`
+      <ExternalLink class="foo" href="" @iconIsShown={{true}} />
+      <ExternalLink class="bar" href="" />
+  `);
+
+    const fooClasslist = document.querySelector(".foo")?.classList;
+    assert.true(fooClasslist?.contains("flex"));
+    assert.dom(".foo svg").exists();
+
+    const barClasslist = document.querySelector(".bar")?.classList;
+    assert.false(barClasslist?.contains("flex"));
+    assert.dom(".bar svg").doesNotExist();
   });
 });

--- a/web/tests/integration/components/footer-test.ts
+++ b/web/tests/integration/components/footer-test.ts
@@ -1,0 +1,43 @@
+import { render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import { setupMirage } from "ember-cli-mirage/test-support";
+import { setupRenderingTest } from "ember-qunit";
+import { module, test } from "qunit";
+import MockDate from "mockdate";
+import { HERMES_GITHUB_REPO_URL } from "hermes/utils/hermes-urls";
+import ConfigService from "hermes/services/config";
+import RouterService from "@ember/routing/router-service";
+
+const SUPPORT_URL = "https://example.com/support";
+
+module("Integration | Component | footer", function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test("it renders as expected (default setup)", async function (assert) {
+    MockDate.set("2000-01-01T06:00:00.000-07:00");
+
+    await render(hbs`<Footer />`);
+
+    assert
+      .dom("[data-test-footer-copyright]")
+      .containsText("2000", "The current year is shown");
+
+    assert
+      .dom("[data-test-footer-github-link]")
+      .hasAttribute("href", HERMES_GITHUB_REPO_URL);
+
+    MockDate.reset();
+  });
+
+  test("it renders as expected (with optional links)", async function (assert) {
+    let mockConfigSvc = this.owner.lookup("service:config") as ConfigService;
+    mockConfigSvc.config.support_link_url = SUPPORT_URL;
+
+    await render(hbs`<Footer />`);
+
+    assert
+      .dom("[data-test-footer-support-link]")
+      .hasAttribute("href", SUPPORT_URL);
+  });
+});

--- a/web/tests/integration/components/footer-test.ts
+++ b/web/tests/integration/components/footer-test.ts
@@ -6,9 +6,8 @@ import { module, test } from "qunit";
 import MockDate from "mockdate";
 import { HERMES_GITHUB_REPO_URL } from "hermes/utils/hermes-urls";
 import ConfigService from "hermes/services/config";
-import RouterService from "@ember/routing/router-service";
 
-const SUPPORT_URL = "https://example.com/support";
+const SUPPORT_URL = "https://footer-component-support.com";
 
 module("Integration | Component | footer", function (hooks) {
   setupRenderingTest(hooks);
@@ -31,6 +30,9 @@ module("Integration | Component | footer", function (hooks) {
   });
 
   test("it renders as expected (with optional links)", async function (assert) {
+    // In assertion tests, Mirage automatically loads our mock config.
+    // Rendering tests skip this step, so we need to do it manually.
+
     let mockConfigSvc = this.owner.lookup("service:config") as ConfigService;
     mockConfigSvc.config.support_link_url = SUPPORT_URL;
 

--- a/web/tests/integration/components/header/nav-test.ts
+++ b/web/tests/integration/components/header/nav-test.ts
@@ -6,6 +6,11 @@ import { setupWindowMock } from "ember-window-mock/test-support";
 import AuthenticatedUserService from "hermes/services/authenticated-user";
 import { setupMirage } from "ember-cli-mirage/test-support";
 import window from "ember-window-mock";
+import { HERMES_GITHUB_REPO_URL } from "hermes/utils/hermes-urls";
+import ConfigService from "hermes/services/config";
+
+const SUPPORT_URL = "https://example.com/support";
+const USER_MENU_TOGGLE_SELECTOR = "[data-test-user-menu-toggle]";
 
 module("Integration | Component | header/nav", function (hooks) {
   setupRenderingTest(hooks);
@@ -28,7 +33,6 @@ module("Integration | Component | header/nav", function (hooks) {
 
   test("it renders correctly", async function (assert) {
     await render(hbs`
-      {{! @glint-nocheck: not typesafe yet }}
       <Header::Nav />
     `);
 
@@ -39,10 +43,14 @@ module("Integration | Component | header/nav", function (hooks) {
 
     assert.dom(".global-search").exists();
 
-    await click("[data-test-user-menu-toggle]");
+    await click(USER_MENU_TOGGLE_SELECTOR);
 
     assert.dom("[data-test-user-menu-title]").hasText("Foo Bar");
     assert.dom("[data-test-user-menu-email]").hasText("foo@example.com");
+    assert
+      .dom("[data-test-user-menu-github]")
+      .hasText("GitHub")
+      .hasAttribute("href", HERMES_GITHUB_REPO_URL);
 
     assert
       .dom('[data-test-user-menu-item="email-notifications"]')
@@ -53,7 +61,6 @@ module("Integration | Component | header/nav", function (hooks) {
 
   test("it shows an icon when the user menu has something to highlight", async function (assert) {
     await render(hbs`
-      {{! @glint-nocheck: not typesafe yet }}
       <Header::Nav />
     `);
 
@@ -64,7 +71,7 @@ module("Integration | Component | header/nav", function (hooks) {
 
     assert.dom("[data-test-user-menu-highlight]").exists("highlight is shown");
 
-    await click("[data-test-user-menu-toggle]");
+    await click(USER_MENU_TOGGLE_SELECTOR);
 
     assert
       .dom("[data-test-user-menu-highlight]")
@@ -79,11 +86,27 @@ module("Integration | Component | header/nav", function (hooks) {
       );
 
     // close and reopen the menu
-    await click("[data-test-user-menu-toggle]");
-    await click("[data-test-user-menu-toggle]");
+    await click(USER_MENU_TOGGLE_SELECTOR);
+    await click(USER_MENU_TOGGLE_SELECTOR);
 
     assert
       .dom(".highlighted-new")
       .doesNotExist("highlight is hidden after the menu is closed");
+  });
+
+  test("it renders a support link if it is configured", async function (assert) {
+    let mockConfigSvc = this.owner.lookup("service:config") as ConfigService;
+    mockConfigSvc.config.support_link_url = SUPPORT_URL;
+
+    await render(hbs`
+      <Header::Nav />
+    `);
+
+    await click(USER_MENU_TOGGLE_SELECTOR);
+
+    assert
+      .dom("[data-test-user-menu-support]")
+      .hasText("Support")
+      .hasAttribute("href", SUPPORT_URL);
   });
 });

--- a/web/tests/integration/components/header/nav-test.ts
+++ b/web/tests/integration/components/header/nav-test.ts
@@ -95,6 +95,9 @@ module("Integration | Component | header/nav", function (hooks) {
   });
 
   test("it renders a support link if it is configured", async function (assert) {
+    // In assertion tests, Mirage automatically loads our mock config.
+    // Rendering tests skip this step, so we need to do it manually.
+
     let mockConfigSvc = this.owner.lookup("service:config") as ConfigService;
     mockConfigSvc.config.support_link_url = SUPPORT_URL;
 

--- a/web/web.go
+++ b/web/web.go
@@ -63,6 +63,7 @@ type ConfigResponse struct {
 	GoogleOAuth2HD           string          `json:"google_oauth2_hd"`
 	ShortLinkBaseURL         string          `json:"short_link_base_url"`
 	SkipGoogleAuth           bool            `json:"skip_google_auth"`
+	SupportLinkURL           string          `json:"support_link_url"`
 }
 
 // ConfigHandler returns runtime configuration for the Hermes frontend.
@@ -116,6 +117,7 @@ func ConfigHandler(
 			GoogleOAuth2HD:           cfg.GoogleWorkspace.OAuth2.HD,
 			ShortLinkBaseURL:         shortLinkBaseURL,
 			SkipGoogleAuth:           skipGoogleAuth,
+			SupportLinkURL:           cfg.SupportLinkURL,
 		}
 
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
- Updates the footer and user nav to include a support-docs link.
- Adds `support_link_url` option in the server configuration. This option will also be available for consumption via the `/config` endpoint.
- Adds external-link-icon support to ExternalLink 
- Adds a Mirage response for `web/config` and tests it.