### PR TITLE
Remove teardownContext calls

### DIFF
--- a/web/tests/acceptance/application-test.ts
+++ b/web/tests/acceptance/application-test.ts
@@ -1,4 +1,4 @@
-import { click, teardownContext, visit, waitFor } from "@ember/test-helpers";
+import { click, visit, waitFor } from "@ember/test-helpers";
 import { setupApplicationTest } from "ember-qunit";
 import { module, test } from "qunit";
 import {
@@ -49,16 +49,6 @@ module("Acceptance | application", function (hooks) {
     assert
       .dom("[data-test-flash-notification-button]")
       .hasText("Authenticate with Google");
-
-    /**
-     * FIXME: Investigate unresolved promises
-     *
-     * For reasons not yet clear, this test has unresolved promises
-     * that prevent it from completing naturally. Because of this,
-     * we handle teardown manually.
-     *
-     */
-    teardownContext(this);
   });
 
   test("a message shows when the back-end auth token expires", async function (this: ApplicationTestContext, assert) {
@@ -77,16 +67,6 @@ module("Acceptance | application", function (hooks) {
     assert
       .dom("[data-test-flash-notification]")
       .exists("flash notification is shown when session is invalid");
-
-    /**
-     * FIXME: Investigate unresolved promises
-     *
-     * For reasons not yet clear, this test has unresolved promises
-     * that prevent it from completing naturally. Because of this,
-     * we handle teardown manually.
-     *
-     */
-    teardownContext(this);
   });
 
   test("the reauthenticate button works as expected (success)", async function (this: ApplicationTestContext, assert) {
@@ -126,16 +106,6 @@ module("Acceptance | application", function (hooks) {
       .hasText("Welcome back, Test!");
 
     assert.equal(authCount, 1, "session.authenticate() was called");
-
-    /**
-     * FIXME: Investigate unresolved promises
-     *
-     * For reasons not yet clear, this test has unresolved promises
-     * that prevent it from completing naturally. Because of this,
-     * we handle teardown manually.
-     *
-     */
-    teardownContext(this);
   });
 
   test("the reauthenticate button works as expected (failure)", async function (this: ApplicationTestContext, assert) {
@@ -164,16 +134,6 @@ module("Acceptance | application", function (hooks) {
     assert
       .dom(criticalSelector)
       .exists("flash notification is shown on re-auth failure");
-
-    /**
-     * FIXME: Investigate unresolved promises
-     *
-     * For reasons not yet clear, this test has unresolved promises
-     * that prevent it from completing naturally. Because of this,
-     * we handle teardown manually.
-     *
-     */
-    teardownContext(this);
   });
 
   test("the config is grabbed from the backend when the app loads", async function (this: ApplicationTestContext, assert) {


### PR DESCRIPTION
Removes `teardownContext` calls that are no longer necessary given our current Mirage coverage. 