### PR TITLE
Use HERMES_SERVER_DB_PASSWORD env var for postgresql password

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Hermes can be configured to point to any PostgreSQL database, but for running lo
 make docker/postgres/start
 ```
 
+Configure the database password with the `HERMES_SERVER_DB_PASSWORD` environment variable.
+
 ### Run the Server
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Hermes can be configured to point to any PostgreSQL database, but for running lo
 make docker/postgres/start
 ```
 
-Configure the database password with the `HERMES_SERVER_DB_PASSWORD` environment variable.
+The database password can be configured via the Hermes config.hcl or the `HERMES_SERVER_POSTGRES_PASSWORD` environment variable.
 
 ### Run the Server
 

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -216,6 +216,9 @@ func (c *Command) Run(args []string) int {
 	}
 
 	// Initialize database.
+	if val, ok := os.LookupEnv("HERMES_SERVER_DB_PASSWORD"); ok {
+		cfg.Postgres.Password = val
+	}
 	db, err := db.NewDB(*cfg.Postgres)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("error initializing database: %v", err))

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -216,7 +216,7 @@ func (c *Command) Run(args []string) int {
 	}
 
 	// Initialize database.
-	if val, ok := os.LookupEnv("HERMES_SERVER_DB_PASSWORD"); ok {
+	if val, ok := os.LookupEnv("HERMES_SERVER_POSTGRES_PASSWORD"); ok {
 		cfg.Postgres.Password = val
 	}
 	db, err := db.NewDB(*cfg.Postgres)


### PR DESCRIPTION
For security reasons, it's important not to have the database password in the `config.hcl` in plain text.
This PR adds the `HERMES_SERVER_DB_PASSWORD` environment variable optionally to set the database password.

Closes #287