### PR TITLE
Add DocumentType types

### DIFF
--- a/web/app/types/document-type.d.ts
+++ b/web/app/types/document-type.d.ts
@@ -1,0 +1,26 @@
+import { CustomEditableField } from "./document";
+
+export interface HermesDocumentType {
+  Template: string;
+
+  checks?: {
+    label: string;
+    helperText?: string;
+    links?: {
+      text: string;
+      url: string;
+    }[];
+  };
+  name: string;
+  longName: string;
+  description: string;
+  moreInfoLink?: {
+    text: string;
+    url: string;
+  };
+  customFields?: {
+    name: string;
+    readOnly: boolean;
+    type: "string" | "people";
+  };
+}


### PR DESCRIPTION
Adds types for DocumentType. We'll eventually use this in the `document` and `new` routes.