### PR TITLE
Add version and revision in config response

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,31 @@
 package version
 
+import (
+	"runtime/debug"
+)
+
 const Version = "0.2.0"
+
+// GetVersion returns
+// the version number
+func GetVersion() string {
+	return Version
+}
+
+// GetShortRevision returns a short
+// commit or checkout revision
+// from build information
+func GetShortRevision() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				var shortRevision string
+				if len(setting.Value) > 7 {
+					shortRevision = setting.Value[:7]
+				}
+				return shortRevision
+			}
+		}
+	}
+	return ""
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -19,8 +19,8 @@ func GetShortRevision() string {
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, setting := range info.Settings {
 			if setting.Key == "vcs.revision" {
-				var shortRevision string
-				if len(setting.Value) > 7 {
+				shortRevision := setting.Value
+				if len(shortRevision) > 7 {
 					shortRevision = setting.Value[:7]
 				}
 				return shortRevision

--- a/web/web.go
+++ b/web/web.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp-forge/hermes/internal/config"
 	"github.com/hashicorp-forge/hermes/internal/pkg/featureflags"
+	"github.com/hashicorp-forge/hermes/internal/version"
 	"github.com/hashicorp-forge/hermes/pkg/algolia"
 	"github.com/hashicorp/go-hclog"
 )
@@ -64,6 +65,8 @@ type ConfigResponse struct {
 	ShortLinkBaseURL         string          `json:"short_link_base_url"`
 	SkipGoogleAuth           bool            `json:"skip_google_auth"`
 	SupportLinkURL           string          `json:"support_link_url"`
+	ShortRevision            string          `json:"short_revision"`
+	Version                  string          `json:"version"`
 }
 
 // ConfigHandler returns runtime configuration for the Hermes frontend.
@@ -118,6 +121,8 @@ func ConfigHandler(
 			ShortLinkBaseURL:         shortLinkBaseURL,
 			SkipGoogleAuth:           skipGoogleAuth,
 			SupportLinkURL:           cfg.SupportLinkURL,
+			ShortRevision:            version.GetShortRevision(),
+			Version:                  version.GetVersion(),
 		}
 
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
This PR adds `version` and `short_revision` in the `/api/v1/web/config` API response.

Note: This change won't affect the `hermes version` command output. It will continue showing the version number of the application.