### PR TITLE
Fix RecentlyViewedDocs draft hrefs

### DIFF
--- a/web/app/components/doc/tile.hbs
+++ b/web/app/components/doc/tile.hbs
@@ -1,4 +1,4 @@
-<div class="group relative">
+<div class="group relative" ...attributes>
   <LinkTo
     @route="authenticated.document"
     @model={{@docID}}

--- a/web/app/components/doc/tile.ts
+++ b/web/app/components/doc/tile.ts
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 
 interface DocTileComponentSignature {
+  Element: HTMLDivElement;
   Args: {
     avatar?: string;
     docID?: string;

--- a/web/app/services/recently-viewed-docs.ts
+++ b/web/app/services/recently-viewed-docs.ts
@@ -67,13 +67,13 @@ export default class RecentlyViewedDocsService extends Service {
       let docResponses = await Promise.allSettled(
         (this.index as IndexedDoc[]).map(async ({ id, isDraft }) => {
           let endpoint = isDraft ? "drafts" : "documents";
-          let fetchResponse = await this.fetchSvc.fetch(
-            `/api/v1/${endpoint}/${id}`
-          );
-          return {
-            doc: await fetchResponse?.json(),
-            isDraft,
-          };
+          let doc = await this.fetchSvc
+            .fetch(`/api/v1/${endpoint}/${id}`)
+            .then((resp) => resp?.json());
+
+          doc.isDraft = isDraft;
+
+          return { doc, isDraft };
         })
       );
       /**

--- a/web/app/templates/authenticated/dashboard.hbs
+++ b/web/app/templates/authenticated/dashboard.hbs
@@ -29,6 +29,7 @@
       <div class="tile-list">
         {{#each this.recentDocs.all as |r|}}
           <Doc::Tile
+            data-test-recently-viewed-doc
             @isDraft={{r.doc.isDraft}}
             @avatar={{get r.doc.ownerPhotos 0}}
             @docID={{r.doc.objectID}}

--- a/web/tests/acceptance/authenticated/dashboard-test.ts
+++ b/web/tests/acceptance/authenticated/dashboard-test.ts
@@ -5,6 +5,8 @@ import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
 
+const RECENTLY_VIEWED_DOC_SELECTOR = "[data-test-recently-viewed-doc]";
+
 interface AuthenticatedDashboardRouteTestContext extends MirageTestContext {}
 
 module("Acceptance | authenticated/dashboard", function (hooks) {
@@ -18,5 +20,27 @@ module("Acceptance | authenticated/dashboard", function (hooks) {
   test("the page title is correct", async function (this: AuthenticatedDashboardRouteTestContext, assert) {
     await visit("/dashboard");
     assert.equal(getPageTitle(), "Dashboard | Hermes");
+  });
+
+  test("recently viewed docs have the correct href", async function (this: AuthenticatedDashboardRouteTestContext, assert) {
+    this.server.create("recently-viewed-doc", { id: "1", isDraft: false });
+    this.server.create("recently-viewed-doc", { id: "2", isDraft: true });
+
+    this.server.create("document", { objectID: "1", title: "Foo" });
+    this.server.create("document", { objectID: "2", title: "Bar" });
+
+    await visit("/dashboard");
+
+    assert.dom(RECENTLY_VIEWED_DOC_SELECTOR).exists({ count: 2 });
+
+    assert
+      .dom(RECENTLY_VIEWED_DOC_SELECTOR)
+      .containsText("Foo")
+      .hasAttribute("href", "/document/1");
+
+    assert
+      .dom(`${RECENTLY_VIEWED_DOC_SELECTOR}:nth-child(2)`)
+      .containsText("Bar")
+      .hasAttribute("href", "/document/2?draft=true");
   });
 });


### PR DESCRIPTION
Fixes a queryParameters bug in the RecentlyViewedDocs service causing draft links to break.