### PR TITLE
Add database updates to APIs

### DIFF
--- a/pkg/models/document.go
+++ b/pkg/models/document.go
@@ -139,6 +139,32 @@ func (d *Document) Create(db *gorm.DB) error {
 	})
 }
 
+// Delete deletes a document in database db.
+func (d *Document) Delete(db *gorm.DB) error {
+	if err := validation.ValidateStruct(d,
+		validation.Field(
+			&d.ID,
+			validation.When(d.GoogleFileID == "",
+				validation.Required.Error("either ID or GoogleFileID is required"),
+			),
+		),
+		validation.Field(
+			&d.GoogleFileID,
+			validation.When(d.ID == 0,
+				validation.Required.Error("either ID or GoogleFileID is required"),
+			),
+		),
+	); err != nil {
+		return err
+	}
+
+	return db.
+		Model(&d).
+		Where(Document{GoogleFileID: d.GoogleFileID}).
+		Delete(&d).
+		Error
+}
+
 // Find finds all documents from database db with the provided query, and
 // assigns them to the receiver.
 func (d *Documents) Find(

--- a/pkg/models/document.go
+++ b/pkg/models/document.go
@@ -530,6 +530,14 @@ func (d *Document) getAssociations(db *gorm.DB) error {
 	}
 	d.Contributors = contributors
 
+	// Get document type.
+	dt := d.DocumentType
+	if err := dt.Get(db); err != nil {
+		return fmt.Errorf("error getting document type: %w", err)
+	}
+	d.DocumentType = dt
+	d.DocumentTypeID = dt.ID
+
 	// Get custom fields.
 	var customFields []*DocumentCustomField
 	for _, c := range d.CustomFields {
@@ -557,14 +565,6 @@ func (d *Document) getAssociations(db *gorm.DB) error {
 		customFields = append(customFields, c)
 	}
 	d.CustomFields = customFields
-
-	// Get document type.
-	dt := d.DocumentType
-	if err := dt.Get(db); err != nil {
-		return fmt.Errorf("error getting document type: %w", err)
-	}
-	d.DocumentType = dt
-	d.DocumentTypeID = dt.ID
 
 	// Get owner.
 	if d.Owner != nil && d.Owner.EmailAddress != "" {

--- a/pkg/models/document_custom_field.go
+++ b/pkg/models/document_custom_field.go
@@ -1,8 +1,8 @@
 package models
 
 import (
+	"encoding/json"
 	"fmt"
-	"time"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"gorm.io/gorm"
@@ -10,10 +10,6 @@ import (
 )
 
 type DocumentCustomField struct {
-	CreatedAt time.Time
-	UpdatedAt time.Time
-	DeletedAt gorm.DeletedAt `gorm:"index"`
-
 	DocumentID                uint `gorm:"primaryKey"`
 	DocumentTypeCustomFieldID uint `gorm:"primaryKey"`
 	DocumentTypeCustomField   DocumentTypeCustomField
@@ -23,35 +19,31 @@ type DocumentCustomField struct {
 
 // BeforeSave is a hook to find or create associations before saving.
 func (d *DocumentCustomField) BeforeSave(tx *gorm.DB) error {
-	// Validate required fields.
-	if err := validation.ValidateStruct(&d.DocumentTypeCustomField,
-		validation.Field(
-			&d.DocumentTypeCustomField.Name, validation.Required),
-	); err != nil {
-		return err
-	}
-	if err := validation.ValidateStruct(&d.DocumentTypeCustomField.DocumentType,
-		validation.Field(
-			&d.DocumentTypeCustomField.DocumentType.Name, validation.Required),
-	); err != nil {
-		return err
-	}
+	// Get document type custom field, if necessary.
+	if d.DocumentTypeCustomFieldID == 0 {
+		if err := validation.ValidateStruct(&d.DocumentTypeCustomField,
+			validation.Field(
+				&d.DocumentTypeCustomField.Name, validation.Required),
+		); err != nil {
+			return err
+		}
 
-	// Get document type custom field.
-	// dt := d.DocumentTypeCustomField.DocumentType
-	if err := d.DocumentTypeCustomField.Get(tx); err != nil {
-		return fmt.Errorf("error getting document type custom field: %w", err)
+		if err := d.DocumentTypeCustomField.Get(tx); err != nil {
+			return fmt.Errorf("error getting document type custom field: %w", err)
+		}
+		d.DocumentTypeCustomFieldID = d.DocumentTypeCustomField.DocumentType.ID
 	}
-	// d.DocumentType = dt
-	d.DocumentTypeCustomFieldID = d.DocumentTypeCustomField.DocumentType.ID
 
 	return nil
 }
 
-// FirstOrCreate finds the first user by email address or creates a user record
-// if it does not exist in database db. The result is saved back to the
-// receiver.
-// TODO: not upsert.
+func (d *DocumentCustomField) Create(db *gorm.DB) error {
+	return db.
+		Omit(clause.Associations).
+		Create(&d).
+		Error
+}
+
 func (d *DocumentCustomField) Upsert(db *gorm.DB) error {
 	return db.
 		Where(DocumentCustomField{
@@ -60,4 +52,131 @@ func (d *DocumentCustomField) Upsert(db *gorm.DB) error {
 		}).
 		Preload(clause.Associations).
 		FirstOrCreate(&d).Error
+}
+
+// UpsertStringDocumentCustomField upserts a string document custom field with
+// the provided document type name (documentTypeName), document type custom
+// field name (documentTypeCustomFieldName), and value (customFieldValue) into a
+// document's custom fields (documentCustomFields), and returns the resulting
+// custom field (pointer) slice. If the value is an empty string, the custom
+// field will be removed from the result.
+func UpsertStringDocumentCustomField(
+	documentCustomFields []*DocumentCustomField,
+	documentTypeName string,
+	documentTypeCustomFieldName string,
+	customFieldValue string,
+) []*DocumentCustomField {
+	// If custom field value is empty, remove it from the document.
+	if customFieldValue == "" {
+		newCFs := []*DocumentCustomField{}
+		for _, cf := range documentCustomFields {
+			// If custom field isn't the target one, append it to
+			// replacement custom fields.
+			if cf.DocumentTypeCustomField.Name != documentTypeCustomFieldName {
+				newCFs = append(newCFs, cf)
+			}
+		}
+		return newCFs
+	} else {
+		// Custom field value isn't empty so upsert it into existing custom
+		// fields.
+		newCFs := []*DocumentCustomField{}
+		foundCF := false
+		for _, cf := range documentCustomFields {
+			// If custom field is the target one, replace the value and append
+			// to replacement custom fields.
+			if cf.DocumentTypeCustomField.Name == documentTypeCustomFieldName {
+				cf.Value = customFieldValue
+				newCFs = append(newCFs, cf)
+				foundCF = true
+			} else {
+				// If custom field isn't the target one, just append it to
+				// replacement custom fields.
+				newCFs = append(newCFs, cf)
+			}
+		}
+		// If we didn't find and replace the custom field, insert it.
+		if !foundCF {
+			newCFs = append(newCFs,
+				&DocumentCustomField{
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: documentTypeCustomFieldName,
+						DocumentType: DocumentType{
+							Name: documentTypeName,
+						},
+					},
+					Value: customFieldValue,
+				},
+			)
+			documentCustomFields = newCFs
+		}
+		return newCFs
+	}
+}
+
+// UpsertStringSliceDocumentCustomField upserts a string slice document custom
+// field with the provided document type name (documentTypeName), document type
+// custom field name (documentTypeCustomFieldName), and value (customFieldValue)
+// into a document's custom fields (documentCustomFields), and returns the
+// resulting custom field (pointer) slice. If the value is an empty string
+// slice, the custom field will be removed from the result.
+func UpsertStringSliceDocumentCustomField(
+	documentCustomFields []*DocumentCustomField,
+	documentTypeName string,
+	documentTypeCustomFieldName string,
+	customFieldValue []string,
+) ([]*DocumentCustomField, error) {
+	if len(customFieldValue) > 0 {
+		jsonVal, err := json.Marshal(customFieldValue)
+		if err != nil {
+			return nil,
+				fmt.Errorf("error marshaling custom field value to JSON: %w", err)
+		}
+
+		// Custom field value isn't empty so upsert it into existing custom
+		// fields.
+		newCFs := []*DocumentCustomField{}
+		foundCF := false
+		for _, cf := range documentCustomFields {
+			// If custom field is the target one, replace the value and append
+			// to replacement custom fields.
+			if cf.DocumentTypeCustomField.Name == documentTypeCustomFieldName {
+				cf.Value = string(jsonVal)
+				newCFs = append(newCFs, cf)
+				foundCF = true
+			} else {
+				// If custom field isn't the target one, just append it to
+				// replacement custom fields.
+				newCFs = append(newCFs, cf)
+			}
+		}
+		// If we didn't find and replace the custom field, insert it.
+		if !foundCF {
+			newCFs = append(newCFs,
+				&DocumentCustomField{
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: documentTypeCustomFieldName,
+						DocumentType: DocumentType{
+							Name: documentTypeName,
+						},
+					},
+					Value: string(jsonVal),
+				},
+			)
+		}
+		return newCFs, nil
+	} else {
+		// Custom field value is empty, so remove it from the document.
+		newCFs := []*DocumentCustomField{}
+		for _, cf := range documentCustomFields {
+			// If custom field isn't the target one, append it to
+			// replacement custom fields.
+			if cf.DocumentTypeCustomField.Name != documentTypeCustomFieldName {
+				newCFs = append(newCFs, cf)
+			}
+		}
+		documentCustomFields = newCFs
+
+		return newCFs, nil
+	}
 }

--- a/pkg/models/document_custom_field_test.go
+++ b/pkg/models/document_custom_field_test.go
@@ -1,0 +1,587 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpsertStringDocumentCustomField(t *testing.T) {
+	cases := map[string]struct {
+		documentCustomFields        []*DocumentCustomField
+		documentTypeName            string
+		documentTypeCustomFieldName string
+		customFieldValue            string
+		wantDocumentCustomFields    []*DocumentCustomField
+	}{
+		"upsert nothing into empty document custom fields": {
+			documentCustomFields:        []*DocumentCustomField{},
+			documentTypeName:            "DT1",
+			documentTypeCustomFieldName: "DocumentTypeCustomFieldName1",
+			customFieldValue:            "",
+			wantDocumentCustomFields:    []*DocumentCustomField{},
+		},
+		"insert one custom field into empty document custom fields": {
+			documentCustomFields:        []*DocumentCustomField{},
+			documentTypeName:            "DT1",
+			documentTypeCustomFieldName: "DocumentTypeCustomFieldName1",
+			customFieldValue:            "Value1",
+			wantDocumentCustomFields: []*DocumentCustomField{
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName1",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value1",
+				},
+			},
+		},
+		"insert one custom field into document custom fields with one item": {
+			documentCustomFields: []*DocumentCustomField{
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName1",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value1",
+				},
+			},
+			documentTypeName:            "DT1",
+			documentTypeCustomFieldName: "DocumentTypeCustomFieldName2",
+			customFieldValue:            "Value2",
+			wantDocumentCustomFields: []*DocumentCustomField{
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName1",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value1",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName2",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value2",
+				},
+			},
+		},
+		"insert one custom field into document custom fields with more than one item": {
+			documentCustomFields: []*DocumentCustomField{
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName1",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value1",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName2",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value2",
+				},
+			},
+			documentTypeName:            "DT1",
+			documentTypeCustomFieldName: "DocumentTypeCustomFieldName3",
+			customFieldValue:            "Value3",
+			wantDocumentCustomFields: []*DocumentCustomField{
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName1",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value1",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName2",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value2",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName3",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value3",
+				},
+			},
+		},
+		"update one custom field into document custom fields with more than one item": {
+			documentCustomFields: []*DocumentCustomField{
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName1",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value1",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName2",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value2",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName3",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value3",
+				},
+			},
+			documentTypeName:            "DT1",
+			documentTypeCustomFieldName: "DocumentTypeCustomFieldName2",
+			customFieldValue:            "NewValue",
+			wantDocumentCustomFields: []*DocumentCustomField{
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName1",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value1",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName2",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "NewValue",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName3",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value3",
+				},
+			},
+		},
+		"remove one custom field from document custom fields with more than one item": {
+			documentCustomFields: []*DocumentCustomField{
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName1",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value1",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName2",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value2",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName3",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value3",
+				},
+			},
+			documentTypeName:            "DT1",
+			documentTypeCustomFieldName: "DocumentTypeCustomFieldName2",
+			customFieldValue:            "",
+			wantDocumentCustomFields: []*DocumentCustomField{
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName1",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value1",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName3",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value3",
+				},
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			got := UpsertStringDocumentCustomField(
+				c.documentCustomFields,
+				c.documentTypeName,
+				c.documentTypeCustomFieldName,
+				c.customFieldValue,
+			)
+
+			require.Len(got, len(c.wantDocumentCustomFields))
+			for i := range got {
+				assert.Equal(c.wantDocumentCustomFields[i].Value, got[i].Value)
+				assert.Equal(
+					c.wantDocumentCustomFields[i].DocumentTypeCustomField.Name,
+					got[i].DocumentTypeCustomField.Name,
+				)
+				assert.Equal(
+					c.documentTypeName,
+					got[i].DocumentTypeCustomField.DocumentType.Name,
+				)
+			}
+		})
+	}
+}
+
+func TestUpsertStringSliceDocumentCustomField(t *testing.T) {
+	cases := map[string]struct {
+		documentCustomFields        []*DocumentCustomField
+		documentTypeName            string
+		documentTypeCustomFieldName string
+		customFieldValue            []string
+		wantDocumentCustomFields    []*DocumentCustomField
+		shouldErr                   bool
+	}{
+		"upsert nothing into empty document custom fields": {
+			documentCustomFields:        []*DocumentCustomField{},
+			documentTypeName:            "DT1",
+			documentTypeCustomFieldName: "DocumentTypeCustomFieldName1",
+			customFieldValue:            []string{},
+			wantDocumentCustomFields:    []*DocumentCustomField{},
+		},
+		"insert one custom field into empty document custom fields": {
+			documentCustomFields:        []*DocumentCustomField{},
+			documentTypeName:            "DT1",
+			documentTypeCustomFieldName: "DocumentTypeCustomFieldName1",
+			customFieldValue:            []string{"Value1"},
+			wantDocumentCustomFields: []*DocumentCustomField{
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName1",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "[\"Value1\"]",
+				},
+			},
+		},
+		"insert one custom field into document custom fields with one item": {
+			documentCustomFields: []*DocumentCustomField{
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName1",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value1",
+				},
+			},
+			documentTypeName:            "DT1",
+			documentTypeCustomFieldName: "DocumentTypeCustomFieldName2",
+			customFieldValue:            []string{"Value2"},
+			wantDocumentCustomFields: []*DocumentCustomField{
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName1",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value1",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName2",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "[\"Value2\"]",
+				},
+			},
+		},
+		"insert one custom field into document custom fields with more than one item": {
+			documentCustomFields: []*DocumentCustomField{
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName1",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value1",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName2",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "[\"Value2\"]",
+				},
+			},
+			documentTypeName:            "DT1",
+			documentTypeCustomFieldName: "DocumentTypeCustomFieldName3",
+			customFieldValue:            []string{"Value3"},
+			wantDocumentCustomFields: []*DocumentCustomField{
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName1",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value1",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName2",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "[\"Value2\"]",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName3",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "[\"Value3\"]",
+				},
+			},
+		},
+		"update one custom field into document custom fields with more than one item": {
+			documentCustomFields: []*DocumentCustomField{
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName1",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value1",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName2",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "[\"Value2\"]",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName3",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "[\"Value3\"]",
+				},
+			},
+			documentTypeName:            "DT1",
+			documentTypeCustomFieldName: "DocumentTypeCustomFieldName2",
+			customFieldValue:            []string{"NewValue"},
+			wantDocumentCustomFields: []*DocumentCustomField{
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName1",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value1",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName2",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "[\"NewValue\"]",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName3",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "[\"Value3\"]",
+				},
+			},
+		},
+		"remove one custom field from document custom fields with more than one item": {
+			documentCustomFields: []*DocumentCustomField{
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName1",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value1",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName2",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "[\"Value2\"]",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName3",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "[\"Value3\"]",
+				},
+			},
+			documentTypeName:            "DT1",
+			documentTypeCustomFieldName: "DocumentTypeCustomFieldName2",
+			customFieldValue:            []string{},
+			wantDocumentCustomFields: []*DocumentCustomField{
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName1",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "Value1",
+				},
+				{
+					DocumentID: 1,
+					DocumentTypeCustomField: DocumentTypeCustomField{
+						Name: "DocumentTypeCustomFieldName3",
+						DocumentType: DocumentType{
+							Name: "DT1",
+						},
+					},
+					Value: "[\"Value3\"]",
+				},
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+
+			got, err := UpsertStringSliceDocumentCustomField(
+				c.documentCustomFields,
+				c.documentTypeName,
+				c.documentTypeCustomFieldName,
+				c.customFieldValue,
+			)
+
+			if c.shouldErr {
+				require.Error(err)
+			}
+			require.Len(got, len(c.wantDocumentCustomFields))
+			for i := range got {
+				assert.Equal(c.wantDocumentCustomFields[i].Value, got[i].Value)
+				assert.Equal(
+					c.wantDocumentCustomFields[i].DocumentTypeCustomField.Name,
+					got[i].DocumentTypeCustomField.Name,
+				)
+				assert.Equal(
+					c.documentTypeName,
+					got[i].DocumentTypeCustomField.DocumentType.Name,
+				)
+			}
+		})
+	}
+}

--- a/pkg/models/document_test.go
+++ b/pkg/models/document_test.go
@@ -835,6 +835,73 @@ func TestDocumentModel(t *testing.T) {
 			assert.Equal("string value 1", d.CustomFields[0].Value)
 		})
 	})
+
+	t.Run("Create, get, and delete a draft document",
+		func(t *testing.T) {
+			db, tearDownTest := setupTest(t, dsn)
+			defer tearDownTest(t)
+
+			t.Run("Create a document type", func(t *testing.T) {
+				_, require := assert.New(t), require.New(t)
+				dt := DocumentType{
+					Name:     "DT1",
+					LongName: "DocumentType1",
+				}
+				err := dt.FirstOrCreate(db)
+				require.NoError(err)
+			})
+
+			t.Run("Create a product", func(t *testing.T) {
+				_, require := assert.New(t), require.New(t)
+
+				p := Product{
+					Name:         "Product1",
+					Abbreviation: "P1",
+				}
+				err := p.FirstOrCreate(db)
+				require.NoError(err)
+			})
+
+			t.Run("Create a document", func(t *testing.T) {
+				assert, require := assert.New(t), require.New(t)
+
+				d := Document{
+					GoogleFileID: "GoogleFileID1",
+					DocumentType: DocumentType{
+						Name: "DT1",
+					},
+					Product: Product{
+						Name: "Product1",
+					},
+					Status: WIPDocumentStatus,
+				}
+				err := d.Create(db)
+				require.NoError(err)
+				assert.EqualValues(1, d.ID)
+			})
+
+			t.Run("Get the document", func(t *testing.T) {
+				assert, require := assert.New(t), require.New(t)
+				d := Document{
+					GoogleFileID: "GoogleFileID1",
+				}
+				err := d.Get(db)
+				require.NoError(err)
+				assert.EqualValues(1, d.ID)
+				assert.False(d.DeletedAt.Valid)
+			})
+
+			t.Run("Delete a document", func(t *testing.T) {
+				assert, require := assert.New(t), require.New(t)
+
+				d := Document{
+					GoogleFileID: "GoogleFileID1",
+				}
+				err := d.Delete(db)
+				require.NoError(err)
+				assert.True(d.DeletedAt.Valid)
+			})
+		})
 }
 
 func TestGetLatestProductNumber(t *testing.T) {
@@ -1162,5 +1229,4 @@ func TestDocumentReplaceRelatedResources(t *testing.T) {
 			assert.Equal(3, hdrrs[1].RelatedResource.SortOrder)
 		})
 	})
-
 }


### PR DESCRIPTION
This PR adds functionality to current APIs to make database updates in addition to Algolia updates, as we migrate to the database being the source of truth for this information. Database errors for these APIs won't return HTTP errors and instead just log them because this data (in the DB) isn't critical yet.