### PR TITLE
Fix ProductBadge query value

### DIFF
--- a/web/app/components/product-badge-link.ts
+++ b/web/app/components/product-badge-link.ts
@@ -28,6 +28,11 @@ export default class ProductBadgeLinkComponent extends Component<ProductBadgeLin
     if (this.args.productArea) {
       return {
         product: [this.args.productArea],
+        docType: [],
+        owners: [],
+        page: 1,
+        sortBy: "dateDesc",
+        status: [],
       };
     } else {
       return {};

--- a/web/tests/acceptance/authenticated/all-test.ts
+++ b/web/tests/acceptance/authenticated/all-test.ts
@@ -35,4 +35,16 @@ module("Acceptance | authenticated/all", function (hooks) {
       .dom(PRODUCT_BADGE_LINK_SELECTOR)
       .hasAttribute("href", "/all?product=%5B%22Labs%22%5D");
   });
+
+  /**
+   * We want to test that clicking the product badge replaces filters
+   * rather than compound them, but we don't yet have the Mirage
+   * factories to support this.
+   */
+  todo(
+    "product badges have the correct hrefs when other filters are active",
+    async function (this: AuthenticatedAllRouteTestContext, assert) {
+      assert.true(false);
+    }
+  );
 });


### PR DESCRIPTION
Fixes a bug where clicking a ProductBadge would compound rather than replace any active filters.

**How to test:**

- From the `all` route, enable a non-product filter

THEN

- Click a product badge on one of the results

OR

- Click a document from the results, then click its productArea badge in the sidebar

**Expected results**
The productArea filter replaces the active filter

**Actual results**
The productArea filter compounds the active filter

