### PR TITLE
Move table sorting function to column header

### DIFF
--- a/web/app/components/header/toolbar.hbs
+++ b/web/app/components/header/toolbar.hbs
@@ -1,9 +1,9 @@
 {{#if @facets}}
   <div class="toolbar mb-7">
     <div class="x-container">
-      <div class="flex justify-between w-full">
+      <div class="flex w-full justify-between">
         <div class="flex items-center">
-          <h4 class="mr-4 hermes-h4">
+          <h4 class="hermes-h4 mr-4">
             Filter by:
           </h4>
           <div class="facets flex items-center space-x-1.5">
@@ -26,19 +26,10 @@
             <Header::FacetDropdown
               @label="Owner"
               @facets={{@facets.owners}}
-              @disabled={{this.ownerFacetIsDisabled}}
+              @disabled={{not @facets.owners}}
             />
           </div>
         </div>
-        {{#if (and @facets (not @sortControlIsHidden))}}
-          <Header::SortDropdown
-            @label={{this.getSortByLabel}}
-            @facets={{this.sortByFacets}}
-            @disabled={{this.sortControlIsDisabled}}
-            @currentSortByValue={{this.currentSortByValue}}
-            @dropdownPlacement="bottom-end"
-          />
-        {{/if}}
       </div>
       <Header::ActiveFilterList />
     </div>

--- a/web/app/components/header/toolbar.ts
+++ b/web/app/components/header/toolbar.ts
@@ -40,8 +40,7 @@ export type ActiveFilters = {
 
 interface ToolbarComponentSignature {
   Args: {
-    facets: FacetDropdownGroups;
-    sortControlIsHidden?: boolean;
+    facets?: FacetDropdownGroups;
   };
 }
 
@@ -49,52 +48,8 @@ export default class ToolbarComponent extends Component<ToolbarComponentSignatur
   @service declare router: RouterService;
   @service declare activeFilters: ActiveFiltersService;
 
-  get currentSortByValue() {
-    if (!this.router.currentRoute) {
-      return SortByValue.DateDesc;
-    }
-    let sortBy = this.router.currentRoute.queryParams["sortBy"];
-
-    switch (sortBy) {
-      case SortByValue.DateAsc:
-        return sortBy;
-      default:
-        return SortByValue.DateDesc;
-    }
-  }
-
-  protected get getSortByLabel(): SortByLabel {
-    if (this.currentSortByValue === SortByValue.DateDesc) {
-      return SortByLabel.Newest;
-    } else {
-      return SortByLabel.Oldest;
-    }
-  }
-
   get currentRouteName(): string {
     return this.router.currentRouteName;
-  }
-
-  /**
-   * Whether the owner facet is disabled.
-   * True on the My Docs and My Drafts screens.
-   */
-  protected get ownerFacetIsDisabled() {
-    switch (this.currentRouteName) {
-      case "authenticated.my":
-      case "authenticated.drafts":
-        return true;
-      default:
-        return false;
-    }
-  }
-
-  /**
-   * Whether the sort control is disabled.
-   * True when there are no drafts or docs.
-   */
-  protected get sortControlIsDisabled() {
-    return Object.keys(this.args.facets).length === 0;
   }
 
   /**
@@ -102,7 +57,7 @@ export default class ToolbarComponent extends Component<ToolbarComponentSignatur
    */
   protected get statuses(): FacetDropdownObjects | null {
     let statuses: FacetDropdownObjects = {};
-    for (let status in this.args.facets.status) {
+    for (let status in this.args.facets?.status) {
       if (
         status === "Approved" ||
         status === "In-Review" ||
@@ -110,7 +65,7 @@ export default class ToolbarComponent extends Component<ToolbarComponentSignatur
         status === "Obsolete" ||
         status === "WIP"
       ) {
-        statuses[status] = this.args.facets.status[
+        statuses[status] = this.args.facets?.status[
           status
         ] as FacetDropdownObjectDetails;
       }
@@ -122,19 +77,6 @@ export default class ToolbarComponent extends Component<ToolbarComponentSignatur
     } else {
       return statuses;
     }
-  }
-
-  get sortByFacets(): SortByFacets {
-    return {
-      Newest: {
-        count: 0,
-        isSelected: this.currentSortByValue === SortByValue.DateDesc,
-      },
-      Oldest: {
-        count: 0,
-        isSelected: this.currentSortByValue === SortByValue.DateAsc,
-      },
-    };
   }
 
   /**

--- a/web/app/components/pagination.hbs
+++ b/web/app/components/pagination.hbs
@@ -1,9 +1,8 @@
-{{! @glint-nocheck: not typesafe yet }}
 <div class="flex justify-center">
   {{#if (eq @nbPages 1)}}
     {{! There is only one page of results }}
     <Pagination::Link @icon="chevron-left" @disabled={{true}} />
-    <Pagination::Link @page="1" @disabled={{true}} />
+    <Pagination::Link @page={{1}} @disabled={{true}} />
     <Pagination::Link @icon="chevron-right" @disabled={{true}} />
   {{else}}
     {{! There is more than one page of results }}

--- a/web/app/components/pagination.ts
+++ b/web/app/components/pagination.ts
@@ -44,3 +44,9 @@ export default class PaginationComponent extends Component<PaginationComponentSi
     return pages;
   }
 }
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry {
+    Pagination: typeof PaginationComponent;
+  }
+}

--- a/web/app/components/pagination/link.hbs
+++ b/web/app/components/pagination/link.hbs
@@ -1,7 +1,6 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{#if @disabled}}
   <span
-    class="w-9 h-12 grid place-items-center relative
+    class="relative grid h-12 w-9 place-items-center
       {{if @icon 'opacity-50' 'text-color-foreground-action'}}"
   >
     {{#if @icon}}
@@ -9,7 +8,7 @@
     {{else}}
       {{@page}}
       <div
-        class="absolute h-0.5 w-6 bg-color-palette-blue-200 bottom-0 left-1/2 -translate-x-1/2"
+        class="absolute bottom-0 left-1/2 h-0.5 w-6 -translate-x-1/2 bg-color-palette-blue-200"
       ></div>
     {{/if}}
   </span>
@@ -17,7 +16,7 @@
   <LinkTo
     @route={{this.currentRouteName}}
     @query={{hash page=@page}}
-    class="w-9 h-12 hover:text-color-foreground-strong grid place-items-center"
+    class="grid h-12 w-9 place-items-center hover:text-color-foreground-strong"
   >
     {{#if @icon}}
       <FlightIcon @name={{@icon}} />

--- a/web/app/components/pagination/link.ts
+++ b/web/app/components/pagination/link.ts
@@ -4,7 +4,11 @@ import Component from "@glimmer/component";
 
 interface PaginationLinkComponentSignature {
   Element: HTMLAnchorElement;
-  Args: {};
+  Args: {
+    disabled?: boolean;
+    icon?: string;
+    page?: number;
+  };
 }
 
 export default class PaginationLinkComponent extends Component<PaginationLinkComponentSignature> {
@@ -12,5 +16,11 @@ export default class PaginationLinkComponent extends Component<PaginationLinkCom
 
   protected get currentRouteName(): string {
     return this.router.currentRouteName;
+  }
+}
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry {
+    "Pagination::Link": typeof PaginationLinkComponent;
   }
 }

--- a/web/app/components/row-results.hbs
+++ b/web/app/components/row-results.hbs
@@ -1,14 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
-{{!
-  Displays the results of an Algolia search in a rows format.
-
-  <RowResults /> properties:
-    @docs: Algolia result's "hits" element from a docs search response.
-    @isDraft: Document is a draft.
-    @nbPages: Algolia result's "nbPages" element from a docs search response.
-    @page: Algolia result's "page" element from a docs search response.
-}}
-
 <section>
   <div class="x-container">
     <div class="row-results">
@@ -21,7 +10,21 @@
               <H.Th class="status">Status</H.Th>
               <H.Th class="product">Product/Area</H.Th>
               <H.Th class="owner">Owner</H.Th>
-              <H.Th class="created">Created</H.Th>
+              <H.Th class="created">
+                <Table::SortableHeader
+                  @changeSort={{@changeSort}}
+                  @currentSort={{@currentSort}}
+                  @sortDirection={{@sortDirection}}
+                  @queryParam={{hash
+                    sortBy=(if (eq @sortDirection "desc") "dateAsc" "dateDesc")
+                    page=1
+                  }}
+                  @attribute="createdTime"
+                  @defaultSortDirection="desc"
+                >
+                  Created
+                </Table::SortableHeader>
+              </H.Th>
             </H.Tr>
           </:head>
           <:body>
@@ -41,7 +44,9 @@
             {{/each}}
           </:body>
         </Hds::Table>
-        <Pagination @nbPages={{@nbPages}} @currentPage={{@currentPage}} />
+        {{#if this.paginationIsShown}}
+          <Pagination @nbPages={{@nbPages}} @currentPage={{@currentPage}} />
+        {{/if}}
       {{else}}
         {{#if @isDraft}}
           <Hds::Alert @type="inline" as |A|>

--- a/web/app/components/row-results.ts
+++ b/web/app/components/row-results.ts
@@ -1,12 +1,26 @@
 import Component from "@glimmer/component";
+import { HermesDocument } from "hermes/types/document";
+import { SortAttribute, SortDirection } from "./table/sortable-header";
 
 interface RowResultsComponentSignature {
   Args: {
-    // TODO: Add HermesDocument[] when we have a type for it.
-    docs: unknown[];
+    docs: HermesDocument[];
     isDraft?: boolean;
     nbPages: number;
     currentPage: number;
+    changeSort?: (attribute: SortAttribute) => void;
+    currentSort: `${SortAttribute}`;
+    sortDirection: SortDirection;
   };
 }
-export default class RowResultsComponent extends Component<RowResultsComponentSignature> {}
+export default class RowResultsComponent extends Component<RowResultsComponentSignature> {
+  protected get paginationIsShown() {
+    return this.args.nbPages && this.args.currentPage !== undefined;
+  }
+}
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry {
+    RowResults: typeof RowResultsComponent;
+  }
+}

--- a/web/app/components/table/sortable-header.hbs
+++ b/web/app/components/table/sortable-header.hbs
@@ -1,0 +1,24 @@
+{{#if @changeSort}}
+  <Action
+    class="sortable-table-header {{if this.isActive 'active'}}"
+    {{on "click" this.changeSort}}
+    ...attributes
+  >
+    <div class="sort-icon">
+      <FlightIcon @name={{this.iconName}} />
+    </div>
+    {{yield}}
+  </Action>
+{{else}}
+  <LinkTo
+    ...attributes
+    @route={{this.currentRoute}}
+    @query={{@queryParam}}
+    class="sortable-table-header {{if this.isActive 'active'}}"
+  >
+    <div class="sort-icon">
+      <FlightIcon @name={{this.iconName}} />
+    </div>
+    {{yield}}
+  </LinkTo>
+{{/if}}

--- a/web/app/components/table/sortable-header.hbs
+++ b/web/app/components/table/sortable-header.hbs
@@ -1,5 +1,8 @@
 {{#if @changeSort}}
   <Action
+    data-test-sortable-table-header
+    data-test-attribute={{@attribute}}
+    data-test-element="button"
     class="sortable-table-header {{if this.isActive 'active'}}"
     {{on "click" this.changeSort}}
     ...attributes
@@ -11,6 +14,9 @@
   </Action>
 {{else}}
   <LinkTo
+    data-test-sortable-table-header
+    data-test-attribute={{@attribute}}
+    data-test-element="anchor"
     ...attributes
     @route={{this.currentRoute}}
     @query={{@queryParam}}

--- a/web/app/components/table/sortable-header.ts
+++ b/web/app/components/table/sortable-header.ts
@@ -1,0 +1,91 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import { assert } from "@ember/debug";
+import { inject as service } from "@ember/service";
+import RouterService from "@ember/routing/router-service";
+
+export enum SortDirection {
+  Asc = "asc",
+  Desc = "desc",
+}
+
+export enum SortAttribute {
+  CreatedTime = "createdTime",
+  Owner = "owners",
+  Product = "product",
+  Status = "status",
+  DocType = "docType",
+  Name = "title",
+}
+
+interface TableSortableHeaderSignature {
+  Element: HTMLButtonElement | HTMLAnchorElement;
+  Args: {
+    currentSort: `${SortAttribute}`;
+    sortDirection: SortDirection;
+    attribute: `${SortAttribute}`;
+    changeSort?: (
+      attribute: SortAttribute,
+      defaultSortDirection?: SortDirection
+    ) => void;
+    defaultSortDirection?: `${SortDirection}`;
+    queryParam?: Record<string, unknown>;
+  };
+  Blocks: {
+    default: [];
+  };
+}
+
+export default class TableSortableHeader extends Component<TableSortableHeaderSignature> {
+  @service declare router: RouterService;
+
+  protected get currentRoute() {
+    return this.router.currentRouteName;
+  }
+
+  protected get iconName() {
+    if (this.args.currentSort === this.args.attribute) {
+      if (this.args.sortDirection === SortDirection.Asc) {
+        return "arrow-up";
+      } else {
+        return "arrow-down";
+      }
+    } else {
+      return "swap-vertical";
+    }
+  }
+
+  private get sortDirection() {
+    if (!this.isActive) {
+      return (
+        (this.args.defaultSortDirection as SortDirection) ?? SortDirection.Asc
+      );
+    }
+  }
+
+  protected get isReadOnly() {
+    if (this.args.attribute === SortAttribute.CreatedTime) {
+      return false;
+    }
+
+    return true;
+  }
+
+  protected get isActive() {
+    return this.args.currentSort === this.args.attribute;
+  }
+
+  @action protected changeSort() {
+    assert("this.args.changeSort must exists", this.args.changeSort);
+    this.args.changeSort(
+      this.args.attribute as SortAttribute,
+      this.sortDirection
+    );
+  }
+}
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry {
+    "Table::SortableHeader": typeof TableSortableHeader;
+  }
+}

--- a/web/app/controllers/authenticated/all.ts
+++ b/web/app/controllers/authenticated/all.ts
@@ -1,4 +1,8 @@
 import Controller from "@ember/controller";
+import { SortByValue } from "hermes/components/header/toolbar";
+import { SortDirection } from "hermes/components/table/sortable-header";
+import AuthenticatedAllRoute from "hermes/routes/authenticated/all";
+import { ModelFrom } from "hermes/types/route-models";
 
 export default class AuthenticatedAllController extends Controller {
   queryParams = ["docType", "owners", "page", "product", "sortBy", "status"];
@@ -8,4 +12,15 @@ export default class AuthenticatedAllController extends Controller {
   product = [];
   sortBy = "dateDesc";
   status = [];
+
+  declare model: ModelFrom<AuthenticatedAllRoute>;
+
+  get sortDirection() {
+    switch (this.model.sortedBy) {
+      case SortByValue.DateAsc:
+        return SortDirection.Asc;
+      default:
+        return SortDirection.Desc;
+    }
+  }
 }

--- a/web/app/controllers/authenticated/drafts.ts
+++ b/web/app/controllers/authenticated/drafts.ts
@@ -1,4 +1,8 @@
 import Controller from "@ember/controller";
+import { SortByValue } from "hermes/components/header/toolbar";
+import { SortDirection } from "hermes/components/table/sortable-header";
+import AuthenticatedDraftsRoute from "hermes/routes/authenticated/drafts";
+import { ModelFrom } from "hermes/types/route-models";
 
 export default class AuthenticatedDraftsController extends Controller {
   queryParams = ["docType", "owners", "page", "product", "sortBy", "status"];
@@ -8,4 +12,15 @@ export default class AuthenticatedDraftsController extends Controller {
   product = [];
   sortBy = "dateDesc";
   status = [];
+
+  declare model: ModelFrom<AuthenticatedDraftsRoute>;
+
+  get sortDirection() {
+    switch (this.model.sortedBy) {
+      case SortByValue.DateAsc:
+        return SortDirection.Asc;
+      default:
+        return SortDirection.Desc;
+    }
+  }
 }

--- a/web/app/controllers/authenticated/my.ts
+++ b/web/app/controllers/authenticated/my.ts
@@ -1,4 +1,8 @@
 import Controller from "@ember/controller";
+import { SortByValue } from "hermes/components/header/toolbar";
+import { SortDirection } from "hermes/components/table/sortable-header";
+import AuthenticatedMyRoute from "hermes/routes/authenticated/my";
+import { ModelFrom } from "hermes/types/route-models";
 
 export default class AuthenticatedMyController extends Controller {
   queryParams = ["docType", "owners", "page", "product", "sortBy", "status"];
@@ -8,4 +12,15 @@ export default class AuthenticatedMyController extends Controller {
   product = [];
   sortBy = "dateDesc";
   status = [];
+
+  declare model: ModelFrom<AuthenticatedMyRoute>;
+
+  get sortDirection() {
+    switch (this.model.sortedBy) {
+      case SortByValue.DateAsc:
+        return SortDirection.Asc;
+      default:
+        return SortDirection.Desc;
+    }
+  }
 }

--- a/web/app/routes/authenticated/all.ts
+++ b/web/app/routes/authenticated/all.ts
@@ -4,8 +4,9 @@ import ConfigService from "hermes/services/config";
 import AlgoliaService from "hermes/services/algolia";
 import { DocumentsRouteParams } from "hermes/types/document-routes";
 import ActiveFiltersService from "hermes/services/active-filters";
+import { SortByValue } from "hermes/components/header/toolbar";
 
-export default class AllRoute extends Route {
+export default class AuthenticatedAllRoute extends Route {
   @service("config") declare configSvc: ConfigService;
   @service declare algolia: AlgoliaService;
   @service declare activeFilters: ActiveFiltersService;
@@ -32,8 +33,9 @@ export default class AllRoute extends Route {
   };
 
   async model(params: DocumentsRouteParams) {
+    const sortedBy = (params.sortBy as SortByValue) ?? SortByValue.DateDesc;
     const searchIndex =
-      params.sortBy === "dateAsc"
+      params.sortBy === SortByValue.DateAsc
         ? this.configSvc.config.algolia_docs_index_name + "_createdTime_asc"
         : this.configSvc.config.algolia_docs_index_name + "_createdTime_desc";
 
@@ -44,6 +46,6 @@ export default class AllRoute extends Route {
 
     this.activeFilters.update(params);
 
-    return { facets, results };
+    return { facets, results, sortedBy };
   }
 }

--- a/web/app/routes/authenticated/drafts.ts
+++ b/web/app/routes/authenticated/drafts.ts
@@ -14,6 +14,7 @@ import { task } from "ember-concurrency";
 import FetchService from "hermes/services/fetch";
 import { assert } from "@ember/debug";
 import ActiveFiltersService from "hermes/services/active-filters";
+import { SortByValue } from "hermes/components/header/toolbar";
 
 interface DraftResponseJSON {
   facets: AlgoliaFacetsObject;
@@ -22,7 +23,7 @@ interface DraftResponseJSON {
   page: number;
 }
 
-export default class DraftsRoute extends Route {
+export default class AuthenticatedDraftsRoute extends Route {
   @service("fetch") declare fetchSvc: FetchService;
   @service declare algolia: AlgoliaService;
   @service declare activeFilters: ActiveFiltersService;
@@ -133,6 +134,8 @@ export default class DraftsRoute extends Route {
   );
 
   async model(params: DocumentsRouteParams) {
+    const sortedBy = params.sortBy ?? SortByValue.DateDesc;
+
     let [facets, results] = await Promise.all([
       this.getDraftFacets.perform(params),
       this.getDraftResults.perform(params),
@@ -140,6 +143,6 @@ export default class DraftsRoute extends Route {
 
     this.activeFilters.update(params);
 
-    return { facets, results };
+    return { facets, results, sortedBy };
   }
 }

--- a/web/app/routes/authenticated/my.ts
+++ b/web/app/routes/authenticated/my.ts
@@ -4,6 +4,7 @@ import ConfigService from "hermes/services/config";
 import { DocumentsRouteParams } from "hermes/types/document-routes";
 import AlgoliaService from "hermes/services/algolia";
 import ActiveFiltersService from "hermes/services/active-filters";
+import { SortByValue } from "hermes/components/header/toolbar";
 
 export default class AuthenticatedMyRoute extends Route {
   @service("config") declare configSvc: ConfigService;
@@ -32,8 +33,9 @@ export default class AuthenticatedMyRoute extends Route {
   };
 
   async model(params: DocumentsRouteParams) {
+    const sortedBy = (params.sortBy as SortByValue) ?? SortByValue.DateDesc;
     const searchIndex =
-      params.sortBy === "dateAsc"
+      params.sortBy === SortByValue.DateAsc
         ? this.configSvc.config.algolia_docs_index_name + "_createdTime_asc"
         : this.configSvc.config.algolia_docs_index_name + "_createdTime_desc";
 
@@ -44,6 +46,6 @@ export default class AuthenticatedMyRoute extends Route {
 
     this.activeFilters.update(params);
 
-    return { facets, results };
+    return { facets, results, sortedBy };
   }
 }

--- a/web/app/styles/app.scss
+++ b/web/app/styles/app.scss
@@ -31,6 +31,7 @@
 @use "components/doc/folder-affordance";
 @use "components/doc/tile";
 @use "components/doc/state";
+@use "components/table/sortable-header";
 @use "components/preview-card";
 @use "components/notification";
 @use "components/sidebar";

--- a/web/app/styles/components/table/sortable-header.scss
+++ b/web/app/styles/components/table/sortable-header.scss
@@ -1,0 +1,30 @@
+.sortable-table-header {
+  @apply relative;
+
+  .sort-icon {
+    @apply absolute -left-1.5 top-1/2 flex -translate-y-1/2 -translate-x-full;
+    @apply text-color-foreground-faint;
+  }
+
+  &:not(.active) {
+    &:hover,
+    &:focus-within {
+      @keyframes sortIconIn {
+        from {
+          transform: translateX(2px);
+        }
+      }
+
+      .sort-icon {
+        @apply visible;
+        > .flight-icon {
+          animation: sortIconIn 85ms ease-in;
+        }
+      }
+    }
+
+    .sort-icon {
+      @apply invisible text-color-foreground-disabled;
+    }
+  }
+}

--- a/web/app/templates/authenticated/all.hbs
+++ b/web/app/templates/authenticated/all.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{page-title "All Docs"}}
 
 <Header @facets={{@model.facets}} />
@@ -7,4 +6,6 @@
   @docs={{@model.results.hits}}
   @nbPages={{@model.results.nbPages}}
   @currentPage={{(add @model.results.page 1)}}
+  @sortDirection={{this.sortDirection}}
+  @currentSort="createdTime"
 />

--- a/web/app/templates/authenticated/drafts.hbs
+++ b/web/app/templates/authenticated/drafts.hbs
@@ -8,4 +8,6 @@
   @nbPages={{@model.results.nbPages}}
   @currentPage={{(add @model.results.page 1)}}
   @isDraft={{true}}
+  @sortDirection={{this.sortDirection}}
+  @currentSort="createdTime"
 />

--- a/web/app/templates/authenticated/my.hbs
+++ b/web/app/templates/authenticated/my.hbs
@@ -1,4 +1,3 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{page-title "My Docs"}}
 
 <Header @facets={{@model.facets}} />
@@ -7,4 +6,6 @@
   @docs={{@model.results.hits}}
   @nbPages={{@model.results.nbPages}}
   @currentPage={{(add @model.results.page 1)}}
+  @sortDirection={{this.sortDirection}}
+  @currentSort="createdTime"
 />

--- a/web/app/types/route-models.ts
+++ b/web/app/types/route-models.ts
@@ -1,0 +1,12 @@
+// https://docs.ember-cli-typescript.com/cookbook/working-with-route-models
+
+import Route from "@ember/routing/route";
+/**
+ * Get the resolved type of an item.
+ * - If the item is a promise, the result will be the resolved value type
+ * - If the item is not a promise, the result will just be the type of the item
+ */
+export type Resolved<P> = P extends Promise<infer T> ? T : P;
+
+/** Get the resolved model value from a route. */
+export type ModelFrom<R extends Route> = Resolved<ReturnType<R["model"]>>;

--- a/web/mirage/factories/document.ts
+++ b/web/mirage/factories/document.ts
@@ -28,6 +28,7 @@ export default Factory.extend({
   docType: "RFC",
   modifiedAgo: 1000000000,
   modifiedTime: 1,
+  createdTime: 1,
   appCreated: true,
   isDraft: true,
   docNumber() {

--- a/web/tests/acceptance/authenticated/all-test.ts
+++ b/web/tests/acceptance/authenticated/all-test.ts
@@ -1,11 +1,13 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { setupApplicationTest } from "ember-qunit";
-import { module, test, todo } from "qunit";
+import { module, test } from "qunit";
 import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
 
 const PRODUCT_BADGE_LINK_SELECTOR = ".product-badge-link";
+const TABLE_HEADER_CREATED_SELECTOR =
+  "[data-test-sortable-table-header][data-test-attribute=createdTime]";
 
 interface AuthenticatedAllRouteTestContext extends MirageTestContext {}
 
@@ -20,6 +22,32 @@ module("Acceptance | authenticated/all", function (hooks) {
   test("the page title is correct", async function (this: AuthenticatedAllRouteTestContext, assert) {
     await visit("/all");
     assert.equal(getPageTitle(), "All Docs | Hermes");
+  });
+
+  test("documents can be sorted by created date", async function (this: AuthenticatedAllRouteTestContext, assert) {
+    this.server.createList("document", 2);
+
+    await visit("/all");
+
+    assert
+      .dom(TABLE_HEADER_CREATED_SELECTOR)
+      .hasClass("active")
+      .hasAttribute("href", "/all?sortBy=dateAsc");
+
+    assert
+      .dom(`${TABLE_HEADER_CREATED_SELECTOR} .flight-icon`)
+      .hasAttribute("data-test-icon", "arrow-down");
+
+    await click(TABLE_HEADER_CREATED_SELECTOR);
+
+    assert
+      .dom(TABLE_HEADER_CREATED_SELECTOR)
+      .hasClass("active")
+      .hasAttribute("href", "/all");
+
+    assert
+      .dom(`${TABLE_HEADER_CREATED_SELECTOR} .flight-icon`)
+      .hasAttribute("data-test-icon", "arrow-up");
   });
 
   test("product badges have the correct hrefs", async function (this: AuthenticatedAllRouteTestContext, assert) {

--- a/web/tests/acceptance/authenticated/drafts-test.ts
+++ b/web/tests/acceptance/authenticated/drafts-test.ts
@@ -1,9 +1,12 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { setupApplicationTest } from "ember-qunit";
-import { module, test, todo } from "qunit";
+import { module, test } from "qunit";
 import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
+
+const TABLE_HEADER_CREATED_SELECTOR =
+  "[data-test-sortable-table-header][data-test-attribute=createdTime]";
 
 interface AuthenticatedDraftRouteTestContext extends MirageTestContext {}
 
@@ -18,6 +21,32 @@ module("Acceptance | authenticated/drafts", function (hooks) {
   test("the page title is correct", async function (this: AuthenticatedDraftRouteTestContext, assert) {
     await visit("/drafts");
     assert.equal(getPageTitle(), "My Drafts | Hermes");
+  });
+
+  test("documents can be sorted by created date", async function (this: AuthenticatedDraftRouteTestContext, assert) {
+    this.server.createList("document", 2);
+
+    await visit("/drafts");
+
+    assert
+      .dom(TABLE_HEADER_CREATED_SELECTOR)
+      .hasClass("active")
+      .hasAttribute("href", "/drafts?sortBy=dateAsc");
+
+    assert
+      .dom(`${TABLE_HEADER_CREATED_SELECTOR} .flight-icon`)
+      .hasAttribute("data-test-icon", "arrow-down");
+
+    await click(TABLE_HEADER_CREATED_SELECTOR);
+
+    assert
+      .dom(TABLE_HEADER_CREATED_SELECTOR)
+      .hasClass("active")
+      .hasAttribute("href", "/drafts");
+
+    assert
+      .dom(`${TABLE_HEADER_CREATED_SELECTOR} .flight-icon`)
+      .hasAttribute("data-test-icon", "arrow-up");
   });
 
   test("product badges have the correct hrefs", async function (this: AuthenticatedDraftRouteTestContext, assert) {

--- a/web/tests/acceptance/authenticated/my-test.ts
+++ b/web/tests/acceptance/authenticated/my-test.ts
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { setupApplicationTest } from "ember-qunit";
 import { module, test } from "qunit";
 import { authenticateSession } from "ember-simple-auth/test-support";
@@ -6,6 +6,8 @@ import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
 
 const PRODUCT_BADGE_LINK_SELECTOR = ".product-badge-link";
+const TABLE_HEADER_CREATED_SELECTOR =
+  "[data-test-sortable-table-header][data-test-attribute=createdTime]";
 
 interface AuthenticatedMyRouteTestContext extends MirageTestContext {}
 
@@ -20,6 +22,32 @@ module("Acceptance | authenticated/my", function (hooks) {
   test("the page title is correct", async function (this: AuthenticatedMyRouteTestContext, assert) {
     await visit("/my");
     assert.equal(getPageTitle(), "My Docs | Hermes");
+  });
+
+  test("documents can be sorted by created date", async function (this: AuthenticatedMyRouteTestContext, assert) {
+    this.server.createList("document", 2);
+
+    await visit("/my");
+
+    assert
+      .dom(TABLE_HEADER_CREATED_SELECTOR)
+      .hasClass("active")
+      .hasAttribute("href", "/my?sortBy=dateAsc");
+
+    assert
+      .dom(`${TABLE_HEADER_CREATED_SELECTOR} .flight-icon`)
+      .hasAttribute("data-test-icon", "arrow-down");
+
+    await click(TABLE_HEADER_CREATED_SELECTOR);
+
+    assert
+      .dom(TABLE_HEADER_CREATED_SELECTOR)
+      .hasClass("active")
+      .hasAttribute("href", "/my");
+
+    assert
+      .dom(`${TABLE_HEADER_CREATED_SELECTOR} .flight-icon`)
+      .hasAttribute("data-test-icon", "arrow-up");
   });
 
   test("product badges have the correct hrefs", async function (this: AuthenticatedMyRouteTestContext, assert) {

--- a/web/tests/integration/components/header/toolbar-test.ts
+++ b/web/tests/integration/components/header/toolbar-test.ts
@@ -1,9 +1,8 @@
-import { module, test, todo } from "qunit";
+import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
-import { click, findAll, render } from "@ember/test-helpers";
+import { TestContext, click, findAll, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { FacetDropdownObjects } from "hermes/types/facets";
-import { SortByLabel } from "hermes/components/header/toolbar";
+import { FacetDropdownGroups, FacetDropdownObjects } from "hermes/types/facets";
 
 const FACETS = {
   docType: {
@@ -18,58 +17,35 @@ const FACETS = {
   },
 };
 
+interface ToolbarTestContext extends TestContext {
+  facets: FacetDropdownGroups;
+}
+
 module("Integration | Component | header/toolbar", function (hooks) {
   setupRenderingTest(hooks);
 
   test("it renders a search input by default", async function (assert) {
     await render(hbs`
-      {{! @glint-nocheck: not typesafe yet }}
       <Header::Toolbar />
     `);
 
     assert.dom(".facets").doesNotExist("Facets are hidden unless provided");
-    assert
-      .dom(".sort-by-dropdown")
-      .doesNotExist("Sort-by dropdown is hidden unless facets are provided");
   });
 
-  test("it renders facets when provided", async function (assert) {
+  test("it renders facets when provided", async function (this: ToolbarTestContext, assert) {
     this.set("facets", FACETS);
-    this.set("sortControlIsHidden", false);
 
-    await render(hbs`
-      {{! @glint-nocheck: not typesafe yet }}
+    await render<ToolbarTestContext>(hbs`
       <Header::Toolbar
         @facets={{this.facets}}
-        @sortControlIsHidden={{this.sortControlIsHidden}}
       />
     `);
 
     assert.dom(".facets").exists();
-    assert
-      .dom("[data-test-header-sort-dropdown-trigger]")
-      .exists("Sort-by dropdown is shown with facets unless explicitly hidden");
 
     assert
       .dom(".facets [data-test-facet-dropdown-trigger]")
       .exists({ count: 4 });
-    assert
-      .dom("[data-test-header-sort-dropdown-trigger]")
-      .exists({ count: 1 })
-      .hasText(`Sort: ${SortByLabel.Newest}`);
-
-    await click(`[data-test-header-sort-dropdown-trigger]`);
-
-    assert
-      .dom(
-        "[data-test-header-sort-by-dropdown] .x-dropdown-list-item:nth-child(2)"
-      )
-      .hasText("Oldest");
-
-    this.set("sortControlIsHidden", true);
-    assert
-      .dom("[data-test-header-sort-by-dropdown]")
-      .doesNotExist("Sort-by dropdown hides when sortByHidden is true");
   });
 
   test("it handles status values correctly", async function (assert) {
@@ -93,8 +69,7 @@ module("Integration | Component | header/toolbar", function (hooks) {
 
     this.set("facets", { status: statusFacets });
 
-    await render(hbs`
-      {{! @glint-nocheck: not typesafe yet }}
+    await render<ToolbarTestContext>(hbs`
       <Header::Toolbar @facets={{this.facets}} />
     `);
 
@@ -111,43 +86,11 @@ module("Integration | Component | header/toolbar", function (hooks) {
 
   test("it conditionally renders the status facet disabled", async function (assert) {
     this.set("facets", { status: {} });
-    await render(hbs`
-      {{! @glint-nocheck: not typesafe yet }}
+    await render<ToolbarTestContext>(hbs`
       <Header::Toolbar @facets={{this.facets}} />
     `);
     assert
       .dom("[data-test-facet-dropdown-trigger='Status']")
       .hasAttribute("disabled");
-  });
-
-  test("it conditionally disables the sort control", async function (assert) {
-    this.set("facets", FACETS);
-    await render(hbs`
-      {{! @glint-nocheck: not typesafe yet }}
-      <Header::Toolbar @facets={{this.facets}} />
-    `);
-
-    assert
-      .dom(`[data-test-header-sort-dropdown-trigger]`)
-      .doesNotHaveAttribute("disabled");
-
-    this.set("facets", {});
-    assert
-      .dom(`[data-test-header-sort-dropdown-trigger]`)
-      .hasAttribute("disabled");
-  });
-
-  /**
-   * Waiting for acceptance tests to be implemented
-   */
-  todo(
-    "the owner facet is disabled on the 'my' and 'drafts' routes",
-    async function (assert) {
-      throw new Error("Will be implemented in an acceptance test");
-    }
-  );
-
-  todo("the sort can be changed", async function (assert) {
-    throw new Error("Will be implemented in an acceptance test");
   });
 });


### PR DESCRIPTION
![CleanShot 2023-08-24 at 15 48 23@2x](https://github.com/hashicorp-forge/hermes/assets/754957/ce205ccf-85b8-4a39-bac3-401d5cdea2ec)


Replaces the Sort dropdowns on the `/all`, `/my` and `/drafts` routes with interactive table headers. Currently only the "Created" column is sortable but the long-term goal is for all table headers to be interactive.

The `Table::SortableHeader` has a larger API than we're currently using (e.g., ability to render a button instead of an anchor, the ability to pass in a custom sort function) in anticipation of new functionality we're prototyping. When those functions are implemented, test coverage will expand.

Also cleans up some type errors on the Pagination components.