### PR TITLE
Add version number to footer

### DIFF
--- a/web/app/components/footer.hbs
+++ b/web/app/components/footer.hbs
@@ -2,11 +2,15 @@
   <div class="footer" ...attributes>
     <div class="x-container">
       <div class="footer-inner">
-        <div class="flex items-center">
+        <div class="flex items-center space-x-4">
           <div data-test-footer-copyright>
             ©
             {{this.currentYear}}
             HashiCorp
+          </div>
+          <div data-test-footer-version>
+            Version
+            {{this.version}}
           </div>
         </div>
 

--- a/web/app/components/footer.hbs
+++ b/web/app/components/footer.hbs
@@ -9,8 +9,8 @@
             HashiCorp
           </div>
           <div data-test-footer-version>
-            Version
-            {{this.version}}
+            Hermes v{{this.version}}
+            ({{this.revision}})
           </div>
         </div>
 

--- a/web/app/components/footer.ts
+++ b/web/app/components/footer.ts
@@ -16,6 +16,10 @@ export default class FooterComponent extends Component<FooterComponentSignature>
     return this.config.config.version;
   }
 
+  protected get revision() {
+    return this.config.config.short_revision;
+  }
+
   protected get currentRouteName(): string {
     return this.router.currentRouteName;
   }

--- a/web/app/components/footer.ts
+++ b/web/app/components/footer.ts
@@ -12,6 +12,10 @@ export default class FooterComponent extends Component<FooterComponentSignature>
   @service declare router: RouterService;
   @service declare config: ConfigService;
 
+  protected get version() {
+    return this.config.config.version;
+  }
+
   protected get currentRouteName(): string {
     return this.router.currentRouteName;
   }

--- a/web/app/routes/application.ts
+++ b/web/app/routes/application.ts
@@ -11,7 +11,6 @@ import window from "ember-window-mock";
 import { REDIRECT_STORAGE_KEY } from "hermes/services/session";
 import Transition from "@ember/routing/transition";
 import MetricsService from "hermes/services/metrics";
-import { HERMES_GITHUB_REPO_URL } from "hermes/utils/hermes-urls";
 
 export default class ApplicationRoute extends Route {
   @service declare config: ConfigService;

--- a/web/app/routes/application.ts
+++ b/web/app/routes/application.ts
@@ -11,6 +11,7 @@ import window from "ember-window-mock";
 import { REDIRECT_STORAGE_KEY } from "hermes/services/session";
 import Transition from "@ember/routing/transition";
 import MetricsService from "hermes/services/metrics";
+import { HERMES_GITHUB_REPO_URL } from "hermes/utils/hermes-urls";
 
 export default class ApplicationRoute extends Route {
   @service declare config: ConfigService;

--- a/web/app/services/config.ts
+++ b/web/app/services/config.ts
@@ -16,6 +16,7 @@ export default class ConfigService extends Service {
     google_analytics_tag_id: undefined,
     support_link_url: config.supportLinkURL,
     version: config.version,
+    short_revision: config.shortRevision,
   };
 
   setConfig(param) {

--- a/web/app/services/config.ts
+++ b/web/app/services/config.ts
@@ -15,6 +15,7 @@ export default class ConfigService extends Service {
     skip_google_auth: config.skipGoogleAuth,
     google_analytics_tag_id: undefined,
     support_link_url: config.supportLinkURL,
+    version: config.version,
   };
 
   setConfig(param) {

--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -280,6 +280,7 @@ export default function (mirageConfig) {
             skip_google_auth: false,
             google_analytics_tag_id: undefined,
             support_link_url: TEST_SUPPORT_URL,
+            version: "1.2.3",
           }
         );
       });

--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -281,6 +281,7 @@ export default function (mirageConfig) {
             google_analytics_tag_id: undefined,
             support_link_url: TEST_SUPPORT_URL,
             version: "1.2.3",
+            short_revision: "abc123",
           }
         );
       });

--- a/web/tests/integration/components/footer-test.ts
+++ b/web/tests/integration/components/footer-test.ts
@@ -2,7 +2,7 @@ import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
 import { setupRenderingTest } from "ember-qunit";
-import { module, test } from "qunit";
+import { config, module, test } from "qunit";
 import MockDate from "mockdate";
 import { HERMES_GITHUB_REPO_URL } from "hermes/utils/hermes-urls";
 import ConfigService from "hermes/services/config";
@@ -19,6 +19,7 @@ module("Integration | Component | footer", function (hooks) {
     const configService = this.owner.lookup("service:config") as ConfigService;
 
     configService.config.version = "1.2.3";
+    configService.config.short_revision = "abc123";
 
     await render(hbs`<Footer />`);
 
@@ -28,7 +29,10 @@ module("Integration | Component | footer", function (hooks) {
 
     assert
       .dom("[data-test-footer-version]")
-      .containsText("Version 1.2.3", "The version is shown");
+      .containsText(
+        "Hermes v1.2.3 (abc123)",
+        "The version and revision are shown"
+      );
 
     assert
       .dom("[data-test-footer-github-link]")

--- a/web/tests/integration/components/footer-test.ts
+++ b/web/tests/integration/components/footer-test.ts
@@ -16,11 +16,19 @@ module("Integration | Component | footer", function (hooks) {
   test("it renders as expected (default setup)", async function (assert) {
     MockDate.set("2000-01-01T06:00:00.000-07:00");
 
+    const configService = this.owner.lookup("service:config") as ConfigService;
+
+    configService.config.version = "1.2.3";
+
     await render(hbs`<Footer />`);
 
     assert
       .dom("[data-test-footer-copyright]")
       .containsText("2000", "The current year is shown");
+
+    assert
+      .dom("[data-test-footer-version]")
+      .containsText("Version 1.2.3", "The version is shown");
 
     assert
       .dom("[data-test-footer-github-link]")


### PR DESCRIPTION
Adds the Hermes version number and revision to the footer.

<img width="1054" alt="CleanShot 2023-08-24 at 19 35 43@2x" src="https://github.com/hashicorp-forge/hermes/assets/754957/bc2faa5a-1c9b-4a95-98c7-5ad3fe7dc42a">

Note: This is a follow up from https://github.com/hashicorp-forge/hermes/pull/297
