### PR TITLE
Update filter button styles

### DIFF
--- a/web/app/components/header/facet-dropdown.hbs
+++ b/web/app/components/header/facet-dropdown.hbs
@@ -7,7 +7,15 @@
   ...attributes
 >
   <:anchor as |dd|>
-    <dd.ToggleButton @text={{@label}} disabled={{@disabled}} />
+    <dd.ToggleButton
+      class="focus:z-10 focus-visible:z-10 active:z-10
+        {{if this.positionIsLeft 'rounded-r-none'}}
+        {{if this.positionIsCenter 'rounded-none border-l-0'}}
+        {{if this.positionIsRight 'rounded-l-none border-l-0'}}
+        "
+      @text={{@label}}
+      disabled={{@disabled}}
+    />
   </:anchor>
   <:item as |dd|>
     <dd.LinkTo

--- a/web/app/components/header/facet-dropdown.ts
+++ b/web/app/components/header/facet-dropdown.ts
@@ -3,12 +3,19 @@ import { FacetDropdownObjects } from "hermes/types/facets";
 import { inject as service } from "@ember/service";
 import RouterService from "@ember/routing/router-service";
 
+enum FacetDropdownPosition {
+  Left = "left",
+  Center = "center",
+  Right = "right",
+}
+
 interface HeaderFacetDropdownComponentSignature {
   Element: HTMLDivElement;
   Args: {
     label: string;
     facets: FacetDropdownObjects | null;
     disabled?: boolean;
+    position: `${FacetDropdownPosition}`;
   };
 }
 
@@ -17,6 +24,18 @@ export default class HeaderFacetDropdownComponent extends Component<HeaderFacetD
 
   protected get currentRouteName() {
     return this.router.currentRouteName;
+  }
+
+  protected get positionIsLeft() {
+    return this.args.position === FacetDropdownPosition.Left;
+  }
+
+  protected get positionIsCenter() {
+    return this.args.position === FacetDropdownPosition.Center;
+  }
+
+  protected get positionIsRight() {
+    return this.args.position === FacetDropdownPosition.Right;
   }
 }
 

--- a/web/app/components/header/toolbar.hbs
+++ b/web/app/components/header/toolbar.hbs
@@ -34,6 +34,15 @@
             />
           </div>
         </div>
+        {{#if (and @facets (not @sortControlIsHidden))}}
+          <Header::SortDropdown
+            @label={{this.getSortByLabel}}
+            @facets={{this.sortByFacets}}
+            @disabled={{this.sortControlIsDisabled}}
+            @currentSortByValue={{this.currentSortByValue}}
+            @dropdownPlacement="bottom-end"
+          />
+        {{/if}}
       </div>
       <Header::ActiveFilterList />
     </div>

--- a/web/app/components/header/toolbar.hbs
+++ b/web/app/components/header/toolbar.hbs
@@ -1,44 +1,39 @@
 {{#if @facets}}
   <div class="toolbar mb-7">
     <div class="x-container">
-      <div class="flex justify-between w-full">
+      <div class="flex w-full justify-between">
         <div class="flex items-center">
-          <h4 class="mr-4 hermes-h4">
+          <h4 class="hermes-h4 mr-4">
             Filter by:
           </h4>
-          <div class="facets flex items-center space-x-1.5">
+          <div class="facets flex items-center">
             <Header::FacetDropdown
               @label="Type"
               @facets={{@facets.docType}}
               @disabled={{not @facets.docType}}
+              @position="left"
             />
             <Header::FacetDropdown
               @label="Status"
               @facets={{this.statuses}}
               @disabled={{not this.statuses}}
+              @position="center"
               class="medium"
             />
             <Header::FacetDropdown
               @label="Product/Area"
               @facets={{@facets.product}}
               @disabled={{not @facets.product}}
+              @position="center"
             />
             <Header::FacetDropdown
               @label="Owner"
               @facets={{@facets.owners}}
               @disabled={{this.ownerFacetIsDisabled}}
+              @position="right"
             />
           </div>
         </div>
-        {{#if (and @facets (not @sortControlIsHidden))}}
-          <Header::SortDropdown
-            @label={{this.getSortByLabel}}
-            @facets={{this.sortByFacets}}
-            @disabled={{this.sortControlIsDisabled}}
-            @currentSortByValue={{this.currentSortByValue}}
-            @dropdownPlacement="bottom-end"
-          />
-        {{/if}}
       </div>
       <Header::ActiveFilterList />
     </div>

--- a/web/tests/integration/components/header/facet-dropdown-test.ts
+++ b/web/tests/integration/components/header/facet-dropdown-test.ts
@@ -1,0 +1,45 @@
+import { TestContext, find, render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import { setupRenderingTest } from "ember-qunit";
+import { FacetDropdownObjects } from "hermes/types/facets";
+import { module, test } from "qunit";
+
+interface HeaderFacetDropdownTestContext extends TestContext {
+  facets: FacetDropdownObjects | null;
+  label: string;
+}
+
+module("Integration | Component | header/facet-dropdown", function (hooks) {
+  setupRenderingTest(hooks);
+  hooks.beforeEach(function () {
+    this.set("facets", null);
+    this.set("label", "");
+  });
+
+  test("it renders the correct styles based on position", async function (this: HeaderFacetDropdownTestContext, assert) {
+    await render<HeaderFacetDropdownTestContext>(
+      hbs`
+        <Header::FacetDropdown
+          @facets={{this.facets}}
+          @label={{this.label}}
+          @position="left"
+        />
+        <Header::FacetDropdown
+          @facets={{this.facets}}
+          @label={{this.label}}
+          @position="center"
+        />
+        <Header::FacetDropdown
+          @facets={{this.facets}}
+          @label={{this.label}}
+          @position="right"
+        />
+      `
+    );
+
+    assert.dom("button").hasClass("rounded-r-none");
+    assert.dom(find("button:nth-child(2)")).hasClass("border-l-0");
+    assert.dom(find("button:nth-child(2)")).hasClass("rounded-none");
+    assert.dom(find("button:nth-child(3)")).hasClass("rounded-l-none");
+  });
+});


### PR DESCRIPTION
Updates the filter buttons to use the new-ish [Segmented Group](https://helios.hashicorp.design/components/segmented-group#within-a-filter-pattern) styles. Pretty clean!

<img width="1018" alt="CleanShot 2023-08-24 at 21 17 39@2x" src="https://github.com/hashicorp-forge/hermes/assets/754957/154d9160-6c3f-4e2a-aa65-c154249c9523">


