### PR TITLE
Tweak margins of DocsAwaitingReview

### DIFF
--- a/web/app/components/dashboard/docs-awaiting-review.hbs
+++ b/web/app/components/dashboard/docs-awaiting-review.hbs
@@ -14,7 +14,7 @@
 
   </div>
 
-  <ul class="mt-4 gap-1 space-y-0.5">
+  <ul class="mt-4">
     {{#each this.docsToShow as |doc|}}
       <Dashboard::DocsAwaitingReview::Doc @doc={{doc}} />
     {{/each}}

--- a/web/app/components/dashboard/docs-awaiting-review/doc.hbs
+++ b/web/app/components/dashboard/docs-awaiting-review/doc.hbs
@@ -1,13 +1,13 @@
-<li class="w-full flex">
+<li class="doc-awaiting-review flex w-full">
   <LinkTo
     data-test-doc-awaiting-review-link
     @route="authenticated.document"
     @model={{@doc.objectID}}
-    class="w-full bg-white px-3.5 py-3 rounded border border-color-border-primary overflow-hidden hover:bg-color-surface-faint group"
+    class="group w-full overflow-hidden border border-color-border-primary bg-white px-3.5 py-3 hover:bg-color-surface-faint"
   >
     <div class="w-full">
       <div
-        class="relative w-full flex flex-wrap md:flex-nowrap items-center gap-2.5"
+        class="relative flex w-full flex-wrap items-center gap-2.5 md:flex-nowrap"
       >
 
         {{! Avatar }}
@@ -19,14 +19,14 @@
           class="shrink-0"
         />
 
-        <div class="w-full block overflow-hidden">
+        <div class="block w-full overflow-hidden">
 
           {{! DocNumber & Title }}
           <div class="w-full md:flex">
             <TruncatedText
               @tagName="h4"
               @startingBreakpoint="md"
-              class="text-display-200 max-w-[60%] font-semibold text-color-foreground-strong"
+              class="max-w-[60%] text-display-200 font-semibold text-color-foreground-strong"
               data-test-doc-awaiting-review-number-and-title
             >
               <span class="mr-0.5">
@@ -37,11 +37,11 @@
 
             {{! Email }}
             <div
-              class="self-center my-1 md:my-0 md:ml-2 flex space-x-2 w-full md:w-auto md:max-w-[40%]"
+              class="my-1 flex w-full space-x-2 self-center md:my-0 md:ml-2 md:w-auto md:max-w-[40%]"
             >
               <TruncatedText
                 @startingBreakpoint="md"
-                class="text-body-200 w-full"
+                class="w-full text-body-200"
                 data-test-doc-awaiting-review-owner
               >
                 {{get @doc.owners 0}}
@@ -52,7 +52,7 @@
 
         {{! Product & DocType }}
         <div
-          class="absolute top-[3px] left-9 md:relative md:top-0 md:left-0 flex shrink-0 items-center space-x-1"
+          class="absolute top-[3px] left-9 flex shrink-0 items-center space-x-1 md:relative md:top-0 md:left-0"
         >
           <Hds::Badge
             data-test-doc-awaiting-review-product-badge

--- a/web/app/styles/app.scss
+++ b/web/app/styles/app.scss
@@ -26,6 +26,7 @@
 @use "components/header/active-filter-list-item";
 @use "components/header/search";
 @use "components/inputs/product-select/index.scss";
+@use "components/dashboard/docs-awaiting-review/doc";
 @use "components/doc/tile-list";
 @use "components/doc/thumbnail";
 @use "components/doc/folder-affordance";

--- a/web/app/styles/components/dashboard/docs-awaiting-review/doc.scss
+++ b/web/app/styles/components/dashboard/docs-awaiting-review/doc.scss
@@ -1,0 +1,13 @@
+.doc-awaiting-review {
+  &:first-child > a {
+    @apply rounded-t;
+  }
+
+  &:last-child > a {
+    @apply rounded-b;
+  }
+
+  + .doc-awaiting-review > a {
+    @apply border-t-0;
+  }
+}


### PR DESCRIPTION
Removes spacing between DocsAwaitingReview; reworks border-radius to only apply to first and last children.

<img width="985" alt="CleanShot 2023-08-24 at 21 53 58@2x" src="https://github.com/hashicorp-forge/hermes/assets/754957/05593f0c-5ce1-4cac-816c-4bcd742b3c05">
