### PR TITLE
Define global background color

### DIFF
--- a/web/app/styles/app.scss
+++ b/web/app/styles/app.scss
@@ -4,6 +4,7 @@
 
 @use "./variables";
 
+@use "./body";
 @use "./animations";
 @use "./typography";
 
@@ -76,9 +77,6 @@ button {
 body {
   line-height: var(--token-typography-body-200-line-height);
   color: var(--token-color-foreground-primary);
-}
-.ember-application {
-  background-color: var(--token-color-surface-primary);
 }
 
 a {

--- a/web/app/styles/app.scss
+++ b/web/app/styles/app.scss
@@ -77,6 +77,9 @@ body {
   line-height: var(--token-typography-body-200-line-height);
   color: var(--token-color-foreground-primary);
 }
+.ember-application {
+  background-color: var(--token-color-surface-primary);
+}
 
 a {
   text-decoration: none;

--- a/web/app/styles/body.scss
+++ b/web/app/styles/body.scss
@@ -1,0 +1,11 @@
+.ember-application {
+  @apply bg-color-page-primary;
+}
+
+.secondary-screen {
+  @apply bg-color-page-faint;
+
+  .ember-application {
+    @apply bg-color-page-faint;
+  }
+}

--- a/web/app/templates/authenticate.hbs
+++ b/web/app/templates/authenticate.hbs
@@ -1,6 +1,6 @@
 {{! @glint-nocheck: not typesafe yet }}
 {{page-title "Authenticate"}}
-{{set-body-class "bg-color-page-faint"}}
+{{set-body-class "secondary-screen"}}
 
 <div
   class="relative flex min-h-full flex-1 flex-col items-center justify-center py-12"

--- a/web/app/templates/authenticated/document.hbs
+++ b/web/app/templates/authenticated/document.hbs
@@ -1,5 +1,5 @@
 {{page-title (or @model.doc.title "Document")}}
-{{set-body-class "bg-color-page-faint"}}
+{{set-body-class "secondary-screen"}}
 
 <Document
   @document={{@model.doc}}

--- a/web/tests/integration/components/floating-u-i/content-test.ts
+++ b/web/tests/integration/components/floating-u-i/content-test.ts
@@ -48,7 +48,6 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
     assert
       .dom(`.ember-application ${CONTENT_SELECTOR}`)
       .exists("content is rendered in the root element");
-    await this.pauseTest();
   });
 
   test("it is positioned by floating-ui", async function (this: FloatingUIComponentTestContext, assert) {

--- a/web/tests/integration/components/floating-u-i/content-test.ts
+++ b/web/tests/integration/components/floating-u-i/content-test.ts
@@ -48,6 +48,7 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
     assert
       .dom(`.ember-application ${CONTENT_SELECTOR}`)
       .exists("content is rendered in the root element");
+    await this.pauseTest();
   });
 
   test("it is positioned by floating-ui", async function (this: FloatingUIComponentTestContext, assert) {


### PR DESCRIPTION
Defines the app's global background color. This fixes the checkerboard background that QUnit shows when there isn't a background defined.

Current
<img width="1037" alt="CleanShot 2023-08-25 at 12 23 07@2x" src="https://github.com/hashicorp-forge/hermes/assets/754957/31669b7b-a9e1-4015-b5af-ceb62b375d4d">

New
<img width="1022" alt="CleanShot 2023-08-25 at 12 25 13@2x" src="https://github.com/hashicorp-forge/hermes/assets/754957/bd6d8202-ed15-4d6b-be66-4dfdb1f38ff1">
