### PR TITLE
Remove unused references to `sortControlIsHidden`

### DIFF
--- a/web/app/components/header/index.hbs
+++ b/web/app/components/header/index.hbs
@@ -1,8 +1,5 @@
-<header class="bg-color-page-faint border-b border-b-color-border-faint mb-7">
+<header class="mb-7 border-b border-b-color-border-faint bg-color-page-faint">
   <Header::Nav />
 </header>
 
-<Header::Toolbar
-  @facets={{@facets}}
-  @sortControlIsHidden={{@sortControlIsHidden}}
-/>
+<Header::Toolbar @facets={{@facets}} />

--- a/web/app/components/header/index.ts
+++ b/web/app/components/header/index.ts
@@ -3,8 +3,7 @@ import { FacetDropdownGroups } from "hermes/types/facets";
 
 interface HeaderComponentSignature {
   Args: {
-    facets: FacetDropdownGroups;
-    sortControlIsHidden?: boolean;
+    facets?: FacetDropdownGroups;
   };
 }
 

--- a/web/app/templates/authenticated/results.hbs
+++ b/web/app/templates/authenticated/results.hbs
@@ -1,6 +1,5 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{page-title "Search Results"}}
 
-<Header @facets={{@model.facets}} @sortControlIsHidden={{true}} />
+<Header @facets={{@model.facets}} />
 
 <Results @results={{@model.results}} @query={{this.q}} />


### PR DESCRIPTION
Removes references to a no-longer-used property. 