### PR TITLE
Improve RecentlyViewedDocs/Dashboard performance

### DIFF
--- a/web/app/routes/authenticated/dashboard.ts
+++ b/web/app/routes/authenticated/dashboard.ts
@@ -61,13 +61,13 @@ export default class DashboardRoute extends Route {
      *
      * If a user leaves and returns to the dashboard, we call `fetchAll`
      * but don't await it. This speeds up the transition and is especially
-     * efficient when the RecentDocs list hasn't changed since last load.
+     * efficient when the RecentDocs list hasn't changed since its last load.
      *
      * It's possible for the user to see the RecentDocs list update
      * in real time (by visiting a document and very quickly clicking back),
-     * but it's unlikely., since we call `fetchAll` in the `afterModel` hook
-     * of the `/document` route, just after the doc is marked viewed. In most cases,
-     * the task will be finished by the time the user returns to the dashboard.
+     * but unlikely, since we call `fetchAll` in the `/document` route,
+     * just after the doc is marked viewed. In most cases, the task will be
+     * finished by the time the user returns to the dashboard.
      *
      */
     if (this.recentDocs.all) {

--- a/web/app/routes/authenticated/document.ts
+++ b/web/app/routes/authenticated/document.ts
@@ -97,6 +97,10 @@ export default class DocumentRoute extends Route {
       }
     }
 
+    // With the document fetched and added to the db's RecentlyViewedDocs index,
+    // make a background call to update the front-end index.
+    void this.recentDocs.fetchAll.perform();
+
     if (!!doc.createdTime) {
       doc.createdDate = parseDate(doc.createdTime * 1000, "long");
     }

--- a/web/app/services/recently-viewed-docs.ts
+++ b/web/app/services/recently-viewed-docs.ts
@@ -1,6 +1,6 @@
 import Service from "@ember/service";
 import { inject as service } from "@ember/service";
-import { enqueueTask, restartableTask } from "ember-concurrency";
+import { keepLatestTask } from "ember-concurrency";
 import FetchService from "./fetch";
 import { tracked } from "@glimmer/tracking";
 import { HermesDocument } from "hermes/types/document";
@@ -41,7 +41,7 @@ export default class RecentlyViewedDocsService extends Service {
    * Fetches an array of recently viewed docs.
    * Called in the dashboard route if the docs are not already loaded.
    */
-  fetchAll = restartableTask(async () => {
+  fetchAll = keepLatestTask(async () => {
     try {
       /**
        * Fetch the file IDs from the backend.
@@ -99,6 +99,7 @@ export default class RecentlyViewedDocsService extends Service {
        */
       this.all = newAll;
     } catch (e: unknown) {
+      this.all = null; // Causes the dashboard to show an error message.
       console.error("Error fetching recently viewed docs", e);
       throw e;
     }


### PR DESCRIPTION
Improves performance of the RecentlyViewedDocs service and Dashboard load times.

To test:
1. Load the Hermes Dashboard
2. Click to another route
3. Return to the Dashboard
4. Compare performance vs. main