### PR TITLE
Replace `modifiedAgo` property with template helper

### DIFF
--- a/web/app/components/dashboard/latest-updates.hbs
+++ b/web/app/components/dashboard/latest-updates.hbs
@@ -1,4 +1,4 @@
-<div class="flex items-center space-x-2 mb-6">
+<div class="mb-6 flex items-center space-x-2">
   <FlightIcon @name="collections" @size="24" />
   <h2
     class="hds-typography-display-300 hds-font-weight-semibold hds-foreground-strong"
@@ -38,7 +38,7 @@
           @avatar={{get doc.ownerPhotos 0}}
           @docID={{doc.objectID}}
           @docNumber={{doc.docNumber}}
-          @modifiedAgo={{doc.modifiedAgo}}
+          @modifiedTime={{doc.modifiedTime}}
           @owner={{get doc.owners 0}}
           @productArea={{doc.product}}
           @status={{lowercase doc.status}}
@@ -48,7 +48,7 @@
       {{/each}}
     </div>
   {{else}}
-    <div class="text-display-200 mt-8">
+    <div class="mt-8 text-display-200">
       {{this.emptyStateMessage}}
     </div>
   {{/if}}

--- a/web/app/components/dashboard/latest-updates.ts
+++ b/web/app/components/dashboard/latest-updates.ts
@@ -85,16 +85,7 @@ export default class DashboardLatestUpdatesComponent extends Component<Dashboard
           hitsPerPage: 4,
         }
       )
-      .then((result: SearchResponse<unknown>) => {
-        // Add modifiedAgo for each doc.
-        for (const hit of result.hits as HermesDocument[]) {
-          if (hit.modifiedTime) {
-            const modifiedAgo = new Date(hit.modifiedTime * 1000);
-            hit.modifiedAgo = `Modified ${timeAgo(modifiedAgo)}`;
-          }
-        }
-        return result.hits;
-      });
+      .then((result: SearchResponse<unknown>) => result.hits);
 
     // Update the docsToShow array with the new docs.
     this.docsToShow = newDocsToShow as HermesDocument[];

--- a/web/app/components/doc/tile.hbs
+++ b/web/app/components/doc/tile.hbs
@@ -41,6 +41,7 @@
           @email="{{@owner}}"
         />
         <p class="text-body-100 text-color-foreground-faint">
+          Modified
           {{time-ago @modifiedTime}}
         </p>
       </div>

--- a/web/app/components/doc/tile.hbs
+++ b/web/app/components/doc/tile.hbs
@@ -40,11 +40,9 @@
           @imgURL={{@avatar}}
           @email="{{@owner}}"
         />
-        {{#if @modifiedAgo}}
-          <p class="text-body-100 text-color-foreground-faint">
-            {{@modifiedAgo}}
-          </p>
-        {{/if}}
+        <p class="text-body-100 text-color-foreground-faint">
+          {{time-ago @modifiedTime}}
+        </p>
       </div>
       {{#if (and @isResult @snippet)}}
         <Doc::Snippet @snippet={{@snippet}} class="mt-2" />

--- a/web/app/components/doc/tile.hbs
+++ b/web/app/components/doc/tile.hbs
@@ -40,10 +40,12 @@
           @imgURL={{@avatar}}
           @email="{{@owner}}"
         />
-        <p class="text-body-100 text-color-foreground-faint">
-          Modified
-          {{time-ago @modifiedTime}}
-        </p>
+        {{#if @modifiedTime}}
+          <p class="text-body-100 text-color-foreground-faint">
+            Modified
+            {{time-ago @modifiedTime}}
+          </p>
+        {{/if}}
       </div>
       {{#if (and @isResult @snippet)}}
         <Doc::Snippet @snippet={{@snippet}} class="mt-2" />

--- a/web/app/components/doc/tile.ts
+++ b/web/app/components/doc/tile.ts
@@ -8,7 +8,7 @@ interface DocTileComponentSignature {
     docNumber?: string;
     isResult?: boolean;
     isDraft?: boolean;
-    modifiedAgo?: string;
+    modifiedTime: number;
     owner?: string;
     productArea?: string;
     snippet?: string;

--- a/web/app/components/doc/tile.ts
+++ b/web/app/components/doc/tile.ts
@@ -8,7 +8,7 @@ interface DocTileComponentSignature {
     docNumber?: string;
     isResult?: boolean;
     isDraft?: boolean;
-    modifiedTime: number;
+    modifiedTime?: number;
     owner?: string;
     productArea?: string;
     snippet?: string;

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -290,7 +290,7 @@
 
       <div class="flex flex-col items-start space-y-2">
         <Document::Sidebar::SectionHeader @title="Last modified" />
-        <p>{{@document.lastModified}}</p>
+        <p>{{time-ago @document.modifiedTime}}</p>
       </div>
 
       <div class="flex flex-col items-start">

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -290,7 +290,9 @@
 
       <div class="flex flex-col items-start space-y-2">
         <Document::Sidebar::SectionHeader @title="Last modified" />
-        <p>{{time-ago @document.modifiedTime}}</p>
+        {{#if @document.modifiedTime}}
+          <p>{{time-ago @document.modifiedTime}}</p>
+        {{/if}}
       </div>
 
       <div class="flex flex-col items-start">

--- a/web/app/helpers/time-ago.ts
+++ b/web/app/helpers/time-ago.ts
@@ -1,0 +1,22 @@
+import { helper } from "@ember/component/helper";
+import timeAgo from "hermes/utils/time-ago";
+
+export interface TimeAgoHelperSignature {
+  Args: {
+    Positional: [time: number];
+  };
+  Return: string;
+}
+
+const timeAgoHelper = helper<TimeAgoHelperSignature>(([time]: [number]) => {
+  time = time * 1000;
+  return `${timeAgo(time)}`;
+});
+
+export default timeAgoHelper;
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry {
+    "time-ago": typeof timeAgoHelper;
+  }
+}

--- a/web/app/helpers/time-ago.ts
+++ b/web/app/helpers/time-ago.ts
@@ -9,7 +9,10 @@ export interface TimeAgoHelperSignature {
 }
 
 const timeAgoHelper = helper<TimeAgoHelperSignature>(([time]: [number]) => {
-  time = time * 1000;
+  // if the time is in seconds, convert to milliseconds
+  if (time < 10000000000) {
+    time = time * 1000;
+  }
   return `${timeAgo(time)}`;
 });
 

--- a/web/app/helpers/time-ago.ts
+++ b/web/app/helpers/time-ago.ts
@@ -8,13 +8,11 @@ export interface TimeAgoHelperSignature {
   Return: string;
 }
 
-const timeAgoHelper = helper<TimeAgoHelperSignature>(([time]: [number]) => {
-  // if the time is in seconds, convert to milliseconds
-  if (time < 10000000000) {
-    time = time * 1000;
+const timeAgoHelper = helper<TimeAgoHelperSignature>(
+  ([secondsAgo]: [number]) => {
+    return `${timeAgo(secondsAgo)}`;
   }
-  return `${timeAgo(time)}`;
-});
+);
 
 export default timeAgoHelper;
 

--- a/web/app/routes/authenticated/dashboard.ts
+++ b/web/app/routes/authenticated/dashboard.ts
@@ -6,8 +6,6 @@ import FetchService from "hermes/services/fetch";
 import RecentlyViewedDocsService from "hermes/services/recently-viewed-docs";
 import SessionService from "hermes/services/session";
 import AuthenticatedUserService from "hermes/services/authenticated-user";
-
-// @ts-ignore - Not yet typed
 import timeAgo from "hermes/utils/time-ago";
 import { HermesDocument } from "hermes/types/document";
 
@@ -31,28 +29,7 @@ export default class DashboardRoute extends Route {
           " AND appCreated:true" +
           " AND status:In-Review",
       })
-      .then((result) => {
-        // Add modifiedAgo for each doc.
-        for (const hit of result.hits) {
-          this.fetchSvc
-            .fetch("/api/v1/documents/" + hit.objectID)
-            .then((resp) => resp?.json())
-            .then((doc) => {
-              if (doc.modifiedTime) {
-                const modifiedDate = new Date(doc.modifiedTime * 1000);
-                // @ts-ignore
-                hit.modifiedAgo = `Modified ${timeAgo(modifiedDate)}`;
-              }
-            })
-            .catch((err) => {
-              console.log(
-                `Error getting document waiting for review (${hit.objectID}):`,
-                err
-              );
-            });
-        }
-        return result.hits as HermesDocument[];
-      });
+      .then((result) => result.hits as HermesDocument[]);
 
     /**
      * If the user is loading the dashboard for the first time,

--- a/web/app/routes/authenticated/document.ts
+++ b/web/app/routes/authenticated/document.ts
@@ -105,9 +105,6 @@ export default class DocumentRoute extends Route {
       doc.createdDate = parseDate(doc.createdTime * 1000, "long");
     }
 
-    // Build strings for created and last-modified.
-    doc.lastModified = `${timeAgo(new Date(doc.modifiedTime * 1000))}`;
-
     // Record analytics.
     try {
       await this.fetchSvc.fetch("/api/v1/web/analytics", {

--- a/web/app/services/recently-viewed-docs.ts
+++ b/web/app/services/recently-viewed-docs.ts
@@ -86,10 +86,6 @@ export default class RecentlyViewedDocsService extends Service {
        */
       docResponses.forEach((response) => {
         if (response.status == "fulfilled") {
-          let recentlyViewed = response.value as RecentlyViewedDoc;
-          recentlyViewed.doc.modifiedAgo = `Modified ${timeAgo(
-            new Date(recentlyViewed.doc.modifiedTime * 1000)
-          )}`;
           newAll.push(response.value);
         }
       });

--- a/web/app/templates/authenticated/dashboard.hbs
+++ b/web/app/templates/authenticated/dashboard.hbs
@@ -34,7 +34,7 @@
             @avatar={{get r.doc.ownerPhotos 0}}
             @docID={{r.doc.objectID}}
             @docNumber={{r.doc.docNumber}}
-            @modifiedAgo={{r.doc.modifiedAgo}}
+            @modifiedTime={{r.doc.modifiedTime}}
             @owner={{get r.doc.owners 0}}
             @productArea={{r.doc.product}}
             @status={{lowercase r.doc.status}}

--- a/web/app/types/document.d.ts
+++ b/web/app/types/document.d.ts
@@ -9,7 +9,7 @@ export interface HermesDocument {
 
   status: string;
   product?: string;
-  modifiedTime: number;
+  modifiedTime?: number; // Not available on drafts fetched as Hits from backend
   docNumber: string;
   docType: string;
   title: string;

--- a/web/app/types/document.d.ts
+++ b/web/app/types/document.d.ts
@@ -9,7 +9,6 @@ export interface HermesDocument {
 
   status: string;
   product?: string;
-  modifiedAgo: string;
   modifiedTime: number;
   docNumber: string;
   docType: string;

--- a/web/app/utils/time-ago.ts
+++ b/web/app/utils/time-ago.ts
@@ -1,3 +1,10 @@
+/**
+ * A simplified "time ago" calculation, based on 28-day months.
+ * Intended to give a rough estimate of how long ago something happened.
+ * Used by the `time-ago` helper to convert numeric timestamps to strings.
+ *
+ * TODO: Replace with something more precise.
+ */
 export default function timeAgo(timeInSeconds: number) {
   const now = Date.now();
   const before = new Date(timeInSeconds * 1000).getTime();

--- a/web/app/utils/time-ago.ts
+++ b/web/app/utils/time-ago.ts
@@ -1,6 +1,6 @@
-export default function timeAgo(dateString) {
+export default function timeAgo(date: number) {
   const now = Date.now();
-  const before = new Date(Date.parse(dateString));
+  const before = new Date(date).getTime();
   const elapsed = now - before;
 
   const elapsedSeconds = elapsed / 1000;

--- a/web/app/utils/time-ago.ts
+++ b/web/app/utils/time-ago.ts
@@ -1,6 +1,6 @@
-export default function timeAgo(date: number) {
+export default function timeAgo(timeInSeconds: number) {
   const now = Date.now();
-  const before = new Date(date).getTime();
+  const before = new Date(timeInSeconds * 1000).getTime();
   const elapsed = now - before;
 
   const elapsedSeconds = elapsed / 1000;

--- a/web/mirage/factories/document.ts
+++ b/web/mirage/factories/document.ts
@@ -26,7 +26,6 @@ export default Factory.extend({
   status: "Draft",
   product: "Vault",
   docType: "RFC",
-  modifiedAgo: 1000000000,
   modifiedTime: 1,
   createdTime: 1,
   appCreated: true,

--- a/web/tests/integration/helpers/time-ago-test.ts
+++ b/web/tests/integration/helpers/time-ago-test.ts
@@ -1,0 +1,45 @@
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+import { TestContext, render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import MockDate from "mockdate";
+
+interface TimeAgoTestContext extends TestContext {
+  fiveSecondsAgo: number;
+  twoYearsAgo: number;
+  sevenMonthsAgo: number;
+}
+
+module("Integration | Helper | time-ago", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("it computes the time ago", async function (assert) {
+    MockDate.set("2000-01-01T06:00:00.000-07:00");
+    const now = Date.now();
+    const fiveSecondsAgo = now - 5000;
+    const sevenMonthsAgo = now - 18144000000;
+    const twoYearsAgo = now - 63072000000;
+
+    this.set("fiveSecondsAgo", fiveSecondsAgo);
+    this.set("twoYearsAgo", twoYearsAgo);
+    this.set("sevenMonthsAgo", sevenMonthsAgo);
+
+    await render<TimeAgoTestContext>(hbs`
+      <div class="one">
+        {{time-ago this.fiveSecondsAgo}}
+      </div>
+      <div class="two">
+        {{time-ago this.twoYearsAgo}}
+      </div>
+      <div class="three">
+        {{time-ago this.sevenMonthsAgo}}
+      </div>
+    `);
+
+    assert.dom(".one").hasText("5 seconds ago");
+    assert.dom(".two").hasText("2 years ago");
+    assert.dom(".three").hasText("7 months ago");
+
+    MockDate.reset();
+  });
+});

--- a/web/tests/integration/helpers/time-ago-test.ts
+++ b/web/tests/integration/helpers/time-ago-test.ts
@@ -15,10 +15,10 @@ module("Integration | Helper | time-ago", function (hooks) {
 
   test("it computes the time ago", async function (assert) {
     MockDate.set("2000-01-01T06:00:00.000-07:00");
-    const now = Date.now();
-    const fiveSecondsAgo = now - 5000;
-    const sevenMonthsAgo = now - 18144000000;
-    const twoYearsAgo = now - 63072000000;
+    const now = Date.now() / 1000;
+    const fiveSecondsAgo = now - 5;
+    const twoYearsAgo = now - 63072000;
+    const sevenMonthsAgo = now - 18144000;
 
     this.set("fiveSecondsAgo", fiveSecondsAgo);
     this.set("twoYearsAgo", twoYearsAgo);

--- a/web/tests/unit/services/recently-viewed-docs-test.ts
+++ b/web/tests/unit/services/recently-viewed-docs-test.ts
@@ -1,8 +1,6 @@
 import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
-import RecentlyViewedDocsService, {
-  RecentlyViewedDoc,
-} from "hermes/services/recently-viewed-docs";
+import RecentlyViewedDocsService from "hermes/services/recently-viewed-docs";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { waitUntil } from "@ember/test-helpers";
 import MockDate from "mockdate";
@@ -36,20 +34,6 @@ module("Unit | Service | recently-viewed-docs", function (hooks) {
       4,
       "recently viewed docs retrieved and trimmed to 4"
     );
-
-    this.recentDocs.all?.forEach((recentDoc: RecentlyViewedDoc) => {
-      /**
-       * The Mirage factory sets the modifiedTime to 1 (1970),
-       * while we set our MockDate to 2000. That's obviously a 30 year difference,
-       * but our `timeAgo` function is inexact, assuming 28-day months, so it computes
-       * the difference as 32 years.
-       */
-      assert.equal(
-        recentDoc.doc.modifiedAgo,
-        "Modified 32 years ago",
-        "modifiedAgo property is added"
-      );
-    });
 
     MockDate.reset();
   });

--- a/web/tests/unit/utils/time-ago-test.ts
+++ b/web/tests/unit/utils/time-ago-test.ts
@@ -6,13 +6,14 @@ module("Unit | Utility | time-ago", function () {
   test('it returns a "time ago" value for a date', function (assert) {
     MockDate.set("2000-01-01T06:00:00.000-07:00");
 
-    const now = Date.now();
+    const now = Date.now() / 1000;
 
-    assert.equal("5 seconds ago", timeAgo(now - 5000));
-    assert.equal("1 minute ago", timeAgo(now - 60000));
-    assert.equal("5 hours ago", timeAgo(now - 18000000));
-    assert.equal("3 months ago", timeAgo(now - 7776000000));
-    assert.equal("2 years ago", timeAgo(now - 63072000000));
+    assert.equal("5 seconds ago", timeAgo(now - 5));
+    assert.equal("1 minute ago", timeAgo(now - 60));
+    assert.equal("5 minutes ago", timeAgo(now - 300));
+    assert.equal("6 hours ago", timeAgo(now - 21600));
+    assert.equal("2 months ago", timeAgo(now - 5184000));
+    assert.equal("2 years ago", timeAgo(now - 63072000));
 
     MockDate.reset();
   });

--- a/web/tests/unit/utils/time-ago-test.ts
+++ b/web/tests/unit/utils/time-ago-test.ts
@@ -1,0 +1,20 @@
+import timeAgo from "hermes/utils/time-ago";
+import { module, test } from "qunit";
+import MockDate from "mockdate";
+
+module("Unit | Utility | time-ago", function () {
+  test('it returns a "time ago" value for a date', function (assert) {
+    MockDate.set("2000-01-01T06:00:00.000-07:00");
+
+    const now = Date.now();
+
+    assert.equal("2 years ago", timeAgo(now - 63072000000));
+    assert.equal("5 seconds ago", timeAgo(now - 5000));
+    assert.equal("1 minute ago", timeAgo(now - 60000));
+    assert.equal("5 hours ago", timeAgo(now - 18000000));
+    assert.equal("3 months ago", timeAgo(now - 7776000000));
+    assert.equal("2 years ago", timeAgo(now - 63072000000));
+
+    MockDate.reset();
+  });
+});

--- a/web/tests/unit/utils/time-ago-test.ts
+++ b/web/tests/unit/utils/time-ago-test.ts
@@ -8,7 +8,6 @@ module("Unit | Utility | time-ago", function () {
 
     const now = Date.now();
 
-    assert.equal("2 years ago", timeAgo(now - 63072000000));
     assert.equal("5 seconds ago", timeAgo(now - 5000));
     assert.equal("1 minute ago", timeAgo(now - 60000));
     assert.equal("5 hours ago", timeAgo(now - 18000000));


### PR DESCRIPTION
Replaces the computed `modifiedAgo` property from the Document model with template-calculated equivalents.

For now, this feels more ergonomic and Ember-like (until we use Ember Data).
