### PR TITLE
Remove `docType` from NewDocForm submit button

### DIFF
--- a/web/app/components/new/doc-form.hbs
+++ b/web/app/components/new/doc-form.hbs
@@ -1,6 +1,6 @@
 {{! @glint-nocheck: not typesafe yet }}
 {{#if this.docIsBeingCreated}}
-  <div class="text-center hds-typography-display-400 mt-3">
+  <div class="hds-typography-display-400 mt-3 text-center">
     <FlightIcon @name="loading" @size="24" />
     <div class="mt-8 text-display-200 font-semibold">
       Creating
@@ -12,7 +12,7 @@
   </div>
 {{else}}
   <form
-    class="grid gap-10 grid-cols-[1fr_250px] grid-rows-1"
+    class="grid grid-cols-[1fr_250px] grid-rows-1 gap-10"
     {{on "submit" this.submit}}
     {{did-insert this.registerForm}}
   >
@@ -22,7 +22,7 @@
           class="hds-typography-display-500 hds-font-weight-bold hds-foreground-strong"
         >Create your {{@docType}}</h1>
       </div>
-      <div class="pt-10 space-y-7">
+      <div class="space-y-7 pt-10">
         <Hds::Form::TextInput::Field
           @type="text"
           @isRequired={{true}}
@@ -51,7 +51,7 @@
               <span
                 class={{if
                   this.summaryIsLong
-                  "transition-colors bg-color-surface-warning text-color-foreground-warning-on-surface"
+                  "bg-color-surface-warning text-color-foreground-warning-on-surface transition-colors"
                 }}
               >One or two sentences</span>
               outlining your doc.
@@ -160,7 +160,7 @@
           @owner={{this.authenticatedUser.info.email}}
         />
         <Hds::Button
-          @text="Create {{@docType}} in Google Drive"
+          @text="Create doc in Google Drive"
           type="submit"
           disabled={{not this.formRequirementsMet}}
           class="w-full"


### PR DESCRIPTION
Removes the `docType` from the NewDocForm submit button.

Previous:
`Create MEMO in Google Drive`
`Create RFC in Google Drive`

New:
`Create doc in Google Drive`
