### PR TITLE
Don't assume names of document types are all uppercase

### DIFF
--- a/configs/config.hcl
+++ b/configs/config.hcl
@@ -64,7 +64,7 @@ document_types {
     }
   }
 
-  // document_type "MEMO" {
+  // document_type "Memo" {
   //   long_name = "Memo"
   //   description = "Create a Memo document to share an idea or brief note with colleagues."
   //   template = "file-id-for-a-blank-doc"

--- a/internal/api/drafts.go
+++ b/internal/api/drafts.go
@@ -1149,7 +1149,7 @@ func getDocTypeTemplate(
 	template := ""
 
 	for _, t := range docTypes {
-		if strings.ToUpper(t.Name) == docType {
+		if t.Name == docType {
 			template = t.Template
 			break
 		}


### PR DESCRIPTION
A small part of the code in #328 assumed that the names of document types are all uppercase. This supports mixed (or lower) case document types, and switches the example Memo type to mixed-case to improve UX.