### PR TITLE
Fix PATCHing a draft's Product

### DIFF
--- a/internal/api/drafts.go
+++ b/internal/api/drafts.go
@@ -989,6 +989,7 @@ func DraftsDocumentHandler(
 
 			// Product.
 			if req.Product != nil {
+				doc.Product = *req.Product
 				model.Product = models.Product{Name: *req.Product}
 
 				// Update doc number in document.

--- a/pkg/hashicorpdocs/locked.go
+++ b/pkg/hashicorpdocs/locked.go
@@ -68,10 +68,6 @@ func IsLocked(
 			log.Info("unlocked document",
 				"google_file_id", fileID,
 			)
-		} else {
-			log.Warn("document was already unlocked",
-				"google_file_id", fileID,
-			)
 		}
 	}
 


### PR DESCRIPTION
#328 broke PATCHing a draft's Product field and this PR fixes it. It also removes bad logic that's causing unnecessary `document was already unlocked` warning log messages.