### PR TITLE
Remove default margin from H1

### DIFF
--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -109,9 +109,7 @@
             @isRequired={{true}}
           >
             <:default as |F|>
-              <h1
-                class="hds-typography-display-300 hds-font-weight-semibold hds-foreground-strong"
-              >
+              <h1 class="text-display-300 font-semibold">
                 {{F.value}}
               </h1>
             </:default>

--- a/web/app/components/new/doc-form.hbs
+++ b/web/app/components/new/doc-form.hbs
@@ -16,9 +16,8 @@
   >
     <div>
       <div class="space-y-4">
-        <h1
-          class="hds-typography-display-500 hds-font-weight-bold hds-foreground-strong"
-        >Create your {{@docType}}</h1>
+        <h1>Create your
+          {{@docType}}</h1>
       </div>
       <div class="space-y-7 pt-10">
         <Hds::Form::TextInput::Field

--- a/web/app/components/results/index.hbs
+++ b/web/app/components/results/index.hbs
@@ -27,9 +27,8 @@
       </div>
     {{/if}}
 
-    <h1
-      class="hds-typography-display-300 hds-font-weight-semibold hds-foreground-strong"
-    >{{@results.nbHits}} documents matching “{{@query}}”</h1>
+    <h1 class="text-display-300 font-semibold">{{@results.nbHits}}
+      documents matching “{{@query}}”</h1>
     <div class="flex w-full flex-col space-y-12 py-10">
       <div class="tile-list">
         {{#each @results.hits as |doc index|}}

--- a/web/app/styles/app.scss
+++ b/web/app/styles/app.scss
@@ -96,7 +96,7 @@ ol {
 }
 
 h1 {
-  @apply mb-1.5 text-display-500 font-bold text-color-foreground-strong;
+  @apply text-display-500 font-bold text-color-foreground-strong;
 
   + p {
     @apply text-body-300;

--- a/web/app/templates/authenticate.hbs
+++ b/web/app/templates/authenticate.hbs
@@ -13,7 +13,7 @@
       class="relative flex w-full flex-col items-center px-20 pt-24 pb-32 text-center"
     >
       <HermesLogo class="mb-8" />
-      <h1 class="">
+      <h1 class="mb-1.5">
         Welcome to Hermes.
       </h1>
       <p class="mb-8 text-display-300">

--- a/web/app/templates/authenticated/new/index.hbs
+++ b/web/app/templates/authenticated/new/index.hbs
@@ -1,6 +1,6 @@
 {{page-title "New Doc"}}
 
-<h1>Choose a template</h1>
+<h1 class="mb-1.5">Choose a template</h1>
 <ol class="mt-9 grid grid-cols-3 gap-4">
   {{#each @model as |docType|}}
     <li class="relative">

--- a/web/app/templates/authenticated/settings.hbs
+++ b/web/app/templates/authenticated/settings.hbs
@@ -7,7 +7,7 @@
   <div class="x-container">
     <div class="max-w-2xl">
 
-      <h1 class="hds-typography-display-500 mb-2.5">Email notifications</h1>
+      <h1 class="mb-2.5">Email notifications</h1>
       <p class="hds-typography-display-200">Get notified when docs are created
         in the following areas...</p>
       <Settings::SubscriptionList @allProductAreas={{@model}} />


### PR DESCRIPTION
Removes the default `margin-bottom` styles from `<h1>` elements, and, where necessary, replaces it with contextual styles.

It was getting annoying to negate in cases where `margin-bottom:0` is desirable.