### PR TITLE
Add support for JSON log format

### DIFF
--- a/configs/config.hcl
+++ b/configs/config.hcl
@@ -2,6 +2,10 @@
 // URL of the application.
 base_url = "http://localhost:8000"
 
+// log_format configures the logging format. Supported values are "standard" or
+// "json".
+log_format = "standard"
+
 // algolia configures Hermes to work with Algolia.
 algolia {
   application_id            = ""

--- a/internal/cmd/commands/indexer/indexer.go
+++ b/internal/cmd/commands/indexer/indexer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp-forge/hermes/internal/indexer"
 	"github.com/hashicorp-forge/hermes/pkg/algolia"
 	gw "github.com/hashicorp-forge/hermes/pkg/googleworkspace"
+	"github.com/hashicorp/go-hclog"
 )
 
 type Command struct {
@@ -73,6 +74,19 @@ func (c *Command) Run(args []string) int {
 	cfg, err := config.NewConfig(c.flagConfig)
 	if err != nil {
 		ui.Error(fmt.Sprintf("error parsing configuration file: %v", err))
+		return 1
+	}
+
+	// Configure logger.
+	switch cfg.LogFormat {
+	case "json":
+		log = hclog.New(&hclog.LoggerOptions{
+			JSONFormat: true,
+		})
+	case "standard":
+	case "":
+	default:
+		ui.Error(fmt.Sprintf("invalid value for log format: %s", cfg.LogFormat))
 		return 1
 	}
 

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp-forge/hermes/pkg/links"
 	"github.com/hashicorp-forge/hermes/pkg/models"
 	"github.com/hashicorp-forge/hermes/web"
+	"github.com/hashicorp/go-hclog"
 	"gorm.io/gorm"
 )
 
@@ -156,6 +157,19 @@ func (c *Command) Run(args []string) int {
 			c.UI.Error("email from_address must be set if email is enabled")
 			return 1
 		}
+	}
+
+	// Configure logger.
+	switch cfg.LogFormat {
+	case "json":
+		c.Log = hclog.New(&hclog.LoggerOptions{
+			JSONFormat: true,
+		})
+	case "standard":
+	case "":
+	default:
+		c.UI.Error(fmt.Sprintf("invalid value for log format: %s", cfg.LogFormat))
+		return 1
 	}
 
 	// Build configuration for Okta authentication.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,10 @@ type Config struct {
 	// Indexer contains the configuration for the Hermes indexer.
 	Indexer *Indexer `hcl:"indexer,block"`
 
+	// LogFormat configures the logging format. Supported values are "standard" or
+	// "json".
+	LogFormat string `hcl:"log_format,optional"`
+
 	// Okta configures Hermes to work with Okta.
 	Okta *oktaalb.Config `hcl:"okta,block"`
 


### PR DESCRIPTION
This PR adds support for a `json` log format.

New config attribute:

```hcl
// log_format configures the logging format. Supported values are "standard" or
// "json".
log_format = "standard"
```