### PR TITLE
Update notification width and `out` animation

### DIFF
--- a/web/app/styles/components/notification.scss
+++ b/web/app/styles/components/notification.scss
@@ -13,12 +13,29 @@
   }
 }
 
+@keyframes notificationOut {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(8px);
+  }
+}
+
 .notification {
   animation: notificationIn 700ms cubic-bezier(0.68, -0.55, 0.265, 1.55)
     forwards;
 
   &.exiting {
-    animation: notificationIn 300ms cubic-bezier(0.68, -0.55, 0.265, 1.55)
-      reverse forwards;
+    animation: notificationOut 300ms cubic-bezier(0.68, -0.55, 0.265, 1.55)
+      forwards;
+  }
+}
+
+.flash-message {
+  .hds-toast {
+    @apply w-[400px];
   }
 }


### PR DESCRIPTION
Fixes a couple FlashNotification bugs:

- Notifications are now fixed width rather than `fit-content` avoiding a case where stacked notifications would be different -widths:
<img width="414" alt="CleanShot 2023-09-25 at 09 40 15@2x" src="https://github.com/hashicorp-forge/hermes/assets/754957/1092ab92-dfea-48db-a65c-92f6d2f74e65">

- The `notificationOut` animation now works as expected. Currently you have to mouseover the div to trigger it.