### PR TITLE
Replace back button with Hermes button

### DIFF
--- a/web/app/components/document/sidebar/header.hbs
+++ b/web/app/components/document/sidebar/header.hbs
@@ -5,12 +5,13 @@
     @route="authenticated.dashboard"
     {{(if @isCollapsed (modifier "tooltip" "Dashboard" placement="right"))}}
   >
-    <FlightIcon
-      @name={{if @isCollapsed "hashicorp" "arrow-left"}}
-      @size={{if @isCollapsed "24"}}
-    />
+    <FlightIcon @name="hashicorp" @size={{if @isCollapsed "24"}} />
     {{#unless @isCollapsed}}
-      <span class="ml-2">Dashboard</span>
+      <span
+        class="border-l tracking-[-0.15px] border-l-color-border-strong pl-2 ml-2 font-semibold text-body-300"
+      >
+        Hermes
+      </span>
     {{/unless}}
   </LinkTo>
   <div class="sidebar-header-icon-controls">

--- a/web/tests/integration/components/document/sidebar/header-test.ts
+++ b/web/tests/integration/components/document/sidebar/header-test.ts
@@ -59,27 +59,27 @@ module("Integration | Component | document/sidebar/header", function (hooks) {
     assert.dom(googleDocsLinkSelector).exists("external link shown");
     assert
       .dom(dashboardLinkSelector)
-      .hasText("Dashboard", "the dashboard text link is shown");
+      .hasText("Hermes", "the hermes link is shown");
 
     assert
       .dom(dashboardLinkSelector + " .flight-icon")
-      .hasAttribute("data-test-icon", "arrow-left", "back arrow is shown");
+      .hasAttribute("data-test-icon", "hashicorp", "hashicorp logo is shown");
     assert
       .dom(toggleButtonSelector)
       .doesNotHaveAttribute(
         "data-test-is-collapsed",
-        "the sidebar is not collapsed"
+        "the sidebar is not collapsed",
       );
     assert
       .dom(toggleButtonSelector + " .flight-icon")
       .hasAttribute(
         "data-test-icon",
         "sidebar-hide",
-        "the collapse-sidebar icon is shown"
+        "the collapse-sidebar icon is shown",
       );
 
     const externalLinkHref = htmlElement(googleDocsLinkSelector).getAttribute(
-      "href"
+      "href",
     );
     const urlStart = "https://docs.google.com/document/d/";
     const docID = this.document.objectID;
@@ -87,7 +87,7 @@ module("Integration | Component | document/sidebar/header", function (hooks) {
     assert.equal(
       externalLinkHref,
       urlStart + docID,
-      "Google Docs link is correct"
+      "Google Docs link is correct",
     );
 
     this.server.schema.document.first().update({ isDraft: true });
@@ -107,21 +107,14 @@ module("Integration | Component | document/sidebar/header", function (hooks) {
       .hasAttribute(
         "data-test-icon",
         "sidebar-show",
-        "the expand-sidebar icon is shown"
+        "the expand-sidebar icon is shown",
       );
 
     assert
       .dom(dashboardLinkSelector)
       .doesNotHaveTextContaining(
-        "Dashboard",
-        "dashboard text is not shown when sidebar is collapsed"
-      );
-    assert
-      .dom(dashboardLinkSelector + " .flight-icon")
-      .hasAttribute(
-        "data-test-icon",
-        "hashicorp",
-        "the hashicorp logo becomes the dashboard link when the sidebar is collapsed"
+        "Hermes",
+        "hermes text is not shown when sidebar is collapsed",
       );
 
     this.set("userHasScrolled", true);


### PR DESCRIPTION
Replaces the "← Dashboard" button on the document sidebar with a "Hermes" link.

Although the text said "Dashboard," the back arrow implied contextual awareness, i.e., that clicking it could navigate to the previous screen, even if it wasn't the dashboard. I think the new affordance clears things up:

<img width="289" alt="CleanShot 2023-09-25 at 20 49 54@2x" src="https://github.com/hashicorp-forge/hermes/assets/754957/c8bfc753-0fcb-45eb-b192-27d560e1abd5">
(Shown with hover outline)
