### PR TITLE
Add tests for doc creation

### DIFF
--- a/web/app/components/new/doc-form.hbs
+++ b/web/app/components/new/doc-form.hbs
@@ -1,6 +1,8 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{#if this.docIsBeingCreated}}
-  <div class="hds-typography-display-400 mt-3 text-center">
+  <div
+    data-test-creating-new-doc
+    class="hds-typography-display-400 mt-3 text-center"
+  >
     <FlightIcon @name="loading" @size="24" />
     <div class="mt-8 text-display-200 font-semibold">
       Creating draft in Google Drive...
@@ -10,6 +12,7 @@
   </div>
 {{else}}
   <form
+    data-test-new-doc-form
     class="grid grid-cols-[1fr_250px] grid-rows-1 gap-10"
     {{on "submit" this.submit}}
     {{did-insert this.registerForm}}
@@ -21,6 +24,7 @@
       </div>
       <div class="space-y-7 pt-10">
         <Hds::Form::TextInput::Field
+          data-test-title-input
           @type="text"
           @isRequired={{true}}
           @value={{this.title}}
@@ -37,6 +41,7 @@
 
         <div class="relative">
           <Hds::Form::Textarea::Field
+            data-test-summary-input
             @value={{this.summary}}
             rows="3"
             name="summary"
@@ -73,43 +78,6 @@
             class="w-[300px]"
           />
         </div>
-
-        {{! Note: We are still refining the subscribe/follow feature set.
-                As part of that effort we will be looking into how the concept
-                of "tags" would be useful. For now, we are choosing to
-                comment out defining tags as part of the document draft
-                creation workflow.
-          }}
-        {{!-- <Hds::Form::Field @layout="vertical" @isOptional={{true}} as |F|>
-          {{yield
-            (hash
-              Error=F.Error
-              HelperText=F.HelperText
-              Label=F.Label
-              isRequired=F.isRequired
-              isOptional=F.isOptional
-            )
-          }}
-          <F.Control>
-            <Inputs::TagSelect
-              @selected={{this.tags}}
-              @onChange={{this.updateTags}}
-            />
-          </F.Control>
-          <F.Label><FlightIcon @name="tag" />
-            Add tags
-          </F.Label>
-          {{#if this.formErrors.tags}}
-            <F.Error as |E|>
-              <E.Message>{{this.formErrors.tags}}</E.Message>
-            </F.Error>
-          {{/if}}
-          <F.HelperText>
-            Use tags to help people discover this document based on their
-            cross-functional interests. For instance, "raft", "design" or
-            "a11y". There is a maximum of 5 tags.
-          </F.HelperText>
-        </Hds::Form::Field> --}}
 
         <Hds::Form::Field @layout="vertical" as |F|>
           {{yield
@@ -157,6 +125,7 @@
           @owner={{this.authenticatedUser.info.email}}
         />
         <Hds::Button
+          data-test-create-button
           @text="Create draft in Google Drive"
           type="submit"
           disabled={{not this.formRequirementsMet}}

--- a/web/app/components/new/doc-form.ts
+++ b/web/app/components/new/doc-form.ts
@@ -18,7 +18,6 @@ interface DocFormErrors {
   title: string | null;
   summary: string | null;
   productAbbreviation: string | null;
-  tags: string | null;
   contributors: string | null;
 }
 
@@ -26,7 +25,6 @@ const FORM_ERRORS: DocFormErrors = {
   title: null,
   summary: null,
   productAbbreviation: null,
-  tags: null,
   contributors: null,
 };
 
@@ -48,7 +46,7 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
 
   @tracked protected title: string = "";
   @tracked protected summary: string = "";
-  @tracked protected productArea: string | null = null;
+  @tracked protected productArea?: string;
   @tracked protected productAbbreviation: string | null = null;
   @tracked protected contributors: HermesUser[] = [];
 
@@ -118,14 +116,7 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
    * Validates the form and updates the `formErrors` property.
    */
   private validate() {
-    const errors = { ...FORM_ERRORS };
-    if (this.productAbbreviation) {
-      if (/\d/.test(this.productAbbreviation)) {
-        errors.productAbbreviation =
-          "Product abbreviation can't include a number";
-      }
-    }
-    this.formErrors = errors;
+    this.formErrors = { ...FORM_ERRORS };
   }
 
   /**
@@ -175,7 +166,7 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
 
   @action protected onProductSelect(
     productName: string,
-    attributes: ProductArea
+    attributes: ProductArea,
   ) {
     this.productArea = productName;
     this.productAbbreviation = attributes.abbreviation;
@@ -224,7 +215,7 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
       // Set modal on a delay so it appears after transition.
       this.modalAlerts.setActive.perform(
         "draftCreated",
-        AWAIT_DOC_CREATED_MODAL_DELAY
+        AWAIT_DOC_CREATED_MODAL_DELAY,
       );
 
       this.router.transitionTo("authenticated.document", doc.id, {
@@ -232,6 +223,8 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
       });
     } catch (err: unknown) {
       this.docIsBeingCreated = false;
+
+      // TODO: Improve error handling.
       this.flashMessages.add({
         title: "Error creating document draft",
         message: `${err}`,

--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -44,7 +44,7 @@ export default function (mirageConfig) {
               return new Response(
                 200,
                 {},
-                { facetHits: [{ value: facetMatch.attrs.product }] }
+                { facetHits: [{ value: facetMatch.attrs.product }] },
               );
             } else {
               return new Response(200, {}, { facetHits: [] });
@@ -131,7 +131,7 @@ export default function (mirageConfig) {
             return new Response(
               200,
               {},
-              { hits: schema.document.all().models }
+              { hits: schema.document.all().models },
             );
           }
         } else {
@@ -214,6 +214,22 @@ export default function (mirageConfig) {
       });
 
       /**
+       * Called when a user creates a new document.
+       */
+      this.post("/drafts", (schema, request) => {
+        const document = schema.document.create({
+          ...JSON.parse(request.requestBody),
+        });
+
+        document.update({
+          objectID: document.id,
+          owners: ["testuser@example.com"],
+        });
+
+        return new Response(200, {}, document.attrs);
+      });
+
+      /**
        * Used when publishing a draft for review.
        * Updates the document's status and isDraft properties.
        *
@@ -282,7 +298,7 @@ export default function (mirageConfig) {
             support_link_url: TEST_SUPPORT_URL,
             version: "1.2.3",
             short_revision: "abc123",
-          }
+          },
         );
       });
 
@@ -375,7 +391,9 @@ export default function (mirageConfig) {
         return new Response(
           200,
           {},
-          schema.document.findBy({ objectID: request.params.document_id }).attrs
+          schema.document.findBy({
+            objectID: request.params.document_id,
+          }).attrs,
         );
       });
 
@@ -386,7 +404,9 @@ export default function (mirageConfig) {
         return new Response(
           200,
           {},
-          schema.document.findBy({ objectID: request.params.document_id }).attrs
+          schema.document.findBy({
+            objectID: request.params.document_id,
+          }).attrs,
         );
       });
 
@@ -433,7 +453,7 @@ export default function (mirageConfig) {
             });
 
           return new Response(200, {}, { hermesDocuments, externalLinks });
-        }
+        },
       );
 
       /**
@@ -454,7 +474,7 @@ export default function (mirageConfig) {
             Hits: drafts,
             params: "",
             page: 0,
-          }
+          },
         );
       });
 
@@ -486,7 +506,7 @@ export default function (mirageConfig) {
           return new Response(
             200,
             {},
-            { "Default Fetched Product": { abbreviation: "NONE" } }
+            { "Default Fetched Product": { abbreviation: "NONE" } },
           );
         } else {
           let objects = this.schema.products.all().models.map((product) => {
@@ -559,7 +579,7 @@ export default function (mirageConfig) {
           schema.db.recentlyViewedDocs.remove();
           schema.db.recentlyViewedDocs.insert(index);
           return new Response(200, {}, schema.recentlyViewedDocs.all().models);
-        }
+        },
       );
 
       /**
@@ -633,7 +653,7 @@ export default function (mirageConfig) {
                 type: mirageDocument.docType,
                 documentNumber: mirageDocument.docNumber,
               });
-            }
+            },
           );
 
           externalLinks.forEach((link) => {
@@ -646,7 +666,7 @@ export default function (mirageConfig) {
           });
 
           return new Response(200, {}, {});
-        }
+        },
       );
 
       // Update whether a draft is shareable.

--- a/web/tests/acceptance/authenticated/new/doc-test.ts
+++ b/web/tests/acceptance/authenticated/new/doc-test.ts
@@ -1,9 +1,25 @@
-import { click, visit } from "@ember/test-helpers";
+import { click, fillIn, visit, waitFor } from "@ember/test-helpers";
 import { setupApplicationTest } from "ember-qunit";
 import { module, test } from "qunit";
 import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
+import { Response } from "miragejs";
+import RouterService from "@ember/routing/router-service";
+import window from "ember-window-mock";
+import { DRAFT_CREATED_LOCAL_STORAGE_KEY } from "hermes/components/modals/draft-created";
+
+const DOC_FORM_SELECTOR = "[data-test-new-doc-form]";
+const PRODUCT_SELECT_SELECTOR = `${DOC_FORM_SELECTOR} [data-test-product-select]`;
+const PRODUCT_SELECT_TOGGLE_SELECTOR = `${PRODUCT_SELECT_SELECTOR} [data-test-x-dropdown-list-toggle-action]`;
+const CREATE_BUTTON_SELECTOR = `${DOC_FORM_SELECTOR} [data-test-create-button]`;
+const TITLE_INPUT_SELECTOR = `${DOC_FORM_SELECTOR} [data-test-title-input]`;
+const SUMMARY_INPUT_SELECTOR = `${DOC_FORM_SELECTOR} [data-test-summary-input]`;
+const PRODUCT_SELECT_LIST_ITEM_SELECTOR = `${PRODUCT_SELECT_SELECTOR} [data-test-x-dropdown-list-item]`;
+const FIRST_PRODUCT_SELECT_LIST_ITEM_BUTTON_SELECTOR = `${PRODUCT_SELECT_LIST_ITEM_SELECTOR}:first-child button`;
+const CREATING_NEW_DOC_SELECTOR = "[data-test-creating-new-doc]";
+const FLASH_NOTIFICATION_SELECTOR = "[data-test-flash-notification]";
+const DRAFT_CREATED_MODAL_SELECTOR = "[data-test-draft-created-modal]";
 
 interface AuthenticatedNewDocRouteTestContext extends MirageTestContext {}
 
@@ -36,25 +52,25 @@ module("Acceptance | authenticated/new/doc", function (hooks) {
 
     await visit("/new/doc?docType=RFC");
 
-    const toggleSelector = "[data-test-x-dropdown-list-toggle-action]";
     const thumbnailBadgeSelector = "[data-test-doc-thumbnail-product-badge]";
 
-    assert.dom(toggleSelector).exists();
-    assert.dom(`${toggleSelector} span`).hasText("Select a product/area");
+    assert.dom(PRODUCT_SELECT_TOGGLE_SELECTOR).exists();
     assert
-      .dom(`${toggleSelector} .flight-icon`)
+      .dom(`${PRODUCT_SELECT_TOGGLE_SELECTOR} span`)
+      .hasText("Select a product/area");
+    assert
+      .dom(`${PRODUCT_SELECT_TOGGLE_SELECTOR} .flight-icon`)
       .hasAttribute("data-test-icon", "folder");
 
     assert
       .dom(thumbnailBadgeSelector)
       .doesNotExist("badge not shown unless a product shortname exists");
 
-    await click(toggleSelector);
+    await click(PRODUCT_SELECT_TOGGLE_SELECTOR);
 
-    const listItemSelector = "[data-test-x-dropdown-list-item]";
-    const lastItemSelector = `${listItemSelector}:last-child`;
+    const lastItemSelector = `${PRODUCT_SELECT_LIST_ITEM_SELECTOR}:last-child`;
 
-    assert.dom(listItemSelector).exists({ count: 5 });
+    assert.dom(PRODUCT_SELECT_LIST_ITEM_SELECTOR).exists({ count: 5 });
     assert.dom(lastItemSelector).hasText("Terraform TF");
     assert
       .dom(lastItemSelector + " .flight-icon")
@@ -62,10 +78,121 @@ module("Acceptance | authenticated/new/doc", function (hooks) {
 
     await click(lastItemSelector + " button");
 
-    assert.dom(toggleSelector).hasText("Terraform TF");
+    assert.dom(PRODUCT_SELECT_TOGGLE_SELECTOR).hasText("Terraform TF");
     assert
-      .dom(toggleSelector + " .flight-icon")
+      .dom(PRODUCT_SELECT_TOGGLE_SELECTOR + " .flight-icon")
       .hasAttribute("data-test-icon", "terraform");
     assert.dom(thumbnailBadgeSelector).exists();
+  });
+
+  test("the create button is disabled until the form requirements are met", async function (this: AuthenticatedNewDocRouteTestContext, assert) {
+    this.server.createList("product", 1);
+
+    await visit("/new/doc?docType=RFC");
+
+    assert.dom(CREATE_BUTTON_SELECTOR).isDisabled();
+
+    await fillIn(TITLE_INPUT_SELECTOR, "Foo");
+
+    assert.dom(CREATE_BUTTON_SELECTOR).isDisabled();
+
+    await click(PRODUCT_SELECT_TOGGLE_SELECTOR);
+    await click(FIRST_PRODUCT_SELECT_LIST_ITEM_BUTTON_SELECTOR);
+
+    assert.dom(CREATE_BUTTON_SELECTOR).isNotDisabled();
+
+    await fillIn(TITLE_INPUT_SELECTOR, "");
+
+    assert.dom(CREATE_BUTTON_SELECTOR).isDisabled();
+  });
+
+  test("it shows a loading screen while the doc is being created", async function (this: AuthenticatedNewDocRouteTestContext, assert) {
+    this.server.createList("product", 1);
+
+    await visit("/new/doc?docType=RFC");
+
+    await fillIn(TITLE_INPUT_SELECTOR, "Foo");
+    await click(PRODUCT_SELECT_TOGGLE_SELECTOR);
+    await click(FIRST_PRODUCT_SELECT_LIST_ITEM_BUTTON_SELECTOR);
+
+    const clickPromise = click(CREATE_BUTTON_SELECTOR);
+
+    await waitFor(CREATING_NEW_DOC_SELECTOR);
+
+    assert.dom(CREATING_NEW_DOC_SELECTOR).exists();
+
+    await clickPromise;
+  });
+
+  test("it shows an error screen if the doc creation fails", async function (this: AuthenticatedNewDocRouteTestContext, assert) {
+    this.server.createList("product", 1);
+
+    this.server.post("/drafts", () => {
+      return new Response(500);
+    });
+
+    await visit("/new/doc?docType=RFC");
+
+    await fillIn(TITLE_INPUT_SELECTOR, "Foo");
+    await click(PRODUCT_SELECT_TOGGLE_SELECTOR);
+    await click(FIRST_PRODUCT_SELECT_LIST_ITEM_BUTTON_SELECTOR);
+
+    const clickPromise = click(CREATE_BUTTON_SELECTOR);
+
+    await waitFor(FLASH_NOTIFICATION_SELECTOR);
+
+    assert
+      .dom(FLASH_NOTIFICATION_SELECTOR)
+      .containsText("Error creating document draft");
+
+    await clickPromise;
+  });
+
+  test("it redirects to the doc page if the doc is created successfully", async function (this: AuthenticatedNewDocRouteTestContext, assert) {
+    this.server.create("product", {
+      name: "Terraform",
+    });
+
+    // Turn off the modal
+    window.localStorage.setItem(DRAFT_CREATED_LOCAL_STORAGE_KEY, "true");
+
+    await visit("/new/doc?docType=RFC");
+
+    await fillIn(TITLE_INPUT_SELECTOR, "Foo");
+
+    await fillIn(SUMMARY_INPUT_SELECTOR, "Bar");
+
+    await click(PRODUCT_SELECT_TOGGLE_SELECTOR);
+    await click(FIRST_PRODUCT_SELECT_LIST_ITEM_BUTTON_SELECTOR);
+
+    await click(CREATE_BUTTON_SELECTOR);
+
+    const routerService = this.owner.lookup("service:router") as RouterService;
+
+    assert.equal(routerService.currentRouteName, "authenticated.document");
+    assert.equal(routerService.currentURL, "/document/1?draft=true");
+
+    assert.dom("[data-test-document-title]").includesText("Foo");
+    assert.dom("[data-test-document-summary]").includesText("Bar");
+    assert.dom("[data-test-badge-dropdown-list]").includesText("Terraform");
+  });
+
+  test("it shows a confirmation modal when a draft is created", async function (this: AuthenticatedNewDocRouteTestContext, assert) {
+    // Reset the localStorage item
+    window.localStorage.removeItem(DRAFT_CREATED_LOCAL_STORAGE_KEY);
+
+    this.server.createList("product", 1);
+
+    await visit("/new/doc?docType=RFC");
+
+    await fillIn(TITLE_INPUT_SELECTOR, "Foo");
+    await click(PRODUCT_SELECT_TOGGLE_SELECTOR);
+    await click(FIRST_PRODUCT_SELECT_LIST_ITEM_BUTTON_SELECTOR);
+
+    await click(CREATE_BUTTON_SELECTOR);
+
+    await waitFor(DRAFT_CREATED_MODAL_SELECTOR);
+
+    assert.dom(DRAFT_CREATED_MODAL_SELECTOR).exists();
   });
 });

--- a/web/tests/acceptance/authenticated/new/doc-test.ts
+++ b/web/tests/acceptance/authenticated/new/doc-test.ts
@@ -9,17 +9,18 @@ import RouterService from "@ember/routing/router-service";
 import window from "ember-window-mock";
 import { DRAFT_CREATED_LOCAL_STORAGE_KEY } from "hermes/components/modals/draft-created";
 
-const DOC_FORM_SELECTOR = "[data-test-new-doc-form]";
-const PRODUCT_SELECT_SELECTOR = `${DOC_FORM_SELECTOR} [data-test-product-select]`;
-const PRODUCT_SELECT_TOGGLE_SELECTOR = `${PRODUCT_SELECT_SELECTOR} [data-test-x-dropdown-list-toggle-action]`;
-const CREATE_BUTTON_SELECTOR = `${DOC_FORM_SELECTOR} [data-test-create-button]`;
-const TITLE_INPUT_SELECTOR = `${DOC_FORM_SELECTOR} [data-test-title-input]`;
-const SUMMARY_INPUT_SELECTOR = `${DOC_FORM_SELECTOR} [data-test-summary-input]`;
-const PRODUCT_SELECT_LIST_ITEM_SELECTOR = `${PRODUCT_SELECT_SELECTOR} [data-test-x-dropdown-list-item]`;
-const FIRST_PRODUCT_SELECT_LIST_ITEM_BUTTON_SELECTOR = `${PRODUCT_SELECT_LIST_ITEM_SELECTOR}:first-child button`;
-const CREATING_NEW_DOC_SELECTOR = "[data-test-creating-new-doc]";
-const FLASH_NOTIFICATION_SELECTOR = "[data-test-flash-notification]";
-const DRAFT_CREATED_MODAL_SELECTOR = "[data-test-draft-created-modal]";
+// Selectors
+const DOC_FORM = "[data-test-new-doc-form]";
+const PRODUCT_SELECT = `${DOC_FORM} [data-test-product-select]`;
+const PRODUCT_SELECT_TOGGLE = `${PRODUCT_SELECT} [data-test-x-dropdown-list-toggle-action]`;
+const CREATE_BUTTON = `${DOC_FORM} [data-test-create-button]`;
+const TITLE_INPUT = `${DOC_FORM} [data-test-title-input]`;
+const SUMMARY_INPUT = `${DOC_FORM} [data-test-summary-input]`;
+const PRODUCT_SELECT_ITEM = `${PRODUCT_SELECT} [data-test-x-dropdown-list-item]`;
+const FIRST_PRODUCT_SELECT_ITEM_BUTTON = `${PRODUCT_SELECT_ITEM}:first-child button`;
+const CREATING_NEW_DOC = "[data-test-creating-new-doc]";
+const FLASH_NOTIFICATION = "[data-test-flash-notification]";
+const DRAFT_CREATED_MODAL = "[data-test-draft-created-modal]";
 
 interface AuthenticatedNewDocRouteTestContext extends MirageTestContext {}
 
@@ -54,23 +55,23 @@ module("Acceptance | authenticated/new/doc", function (hooks) {
 
     const thumbnailBadgeSelector = "[data-test-doc-thumbnail-product-badge]";
 
-    assert.dom(PRODUCT_SELECT_TOGGLE_SELECTOR).exists();
+    assert.dom(PRODUCT_SELECT_TOGGLE).exists();
     assert
-      .dom(`${PRODUCT_SELECT_TOGGLE_SELECTOR} span`)
+      .dom(`${PRODUCT_SELECT_TOGGLE} span`)
       .hasText("Select a product/area");
     assert
-      .dom(`${PRODUCT_SELECT_TOGGLE_SELECTOR} .flight-icon`)
+      .dom(`${PRODUCT_SELECT_TOGGLE} .flight-icon`)
       .hasAttribute("data-test-icon", "folder");
 
     assert
       .dom(thumbnailBadgeSelector)
       .doesNotExist("badge not shown unless a product shortname exists");
 
-    await click(PRODUCT_SELECT_TOGGLE_SELECTOR);
+    await click(PRODUCT_SELECT_TOGGLE);
 
-    const lastItemSelector = `${PRODUCT_SELECT_LIST_ITEM_SELECTOR}:last-child`;
+    const lastItemSelector = `${PRODUCT_SELECT_ITEM}:last-child`;
 
-    assert.dom(PRODUCT_SELECT_LIST_ITEM_SELECTOR).exists({ count: 5 });
+    assert.dom(PRODUCT_SELECT_ITEM).exists({ count: 5 });
     assert.dom(lastItemSelector).hasText("Terraform TF");
     assert
       .dom(lastItemSelector + " .flight-icon")
@@ -78,9 +79,9 @@ module("Acceptance | authenticated/new/doc", function (hooks) {
 
     await click(lastItemSelector + " button");
 
-    assert.dom(PRODUCT_SELECT_TOGGLE_SELECTOR).hasText("Terraform TF");
+    assert.dom(PRODUCT_SELECT_TOGGLE).hasText("Terraform TF");
     assert
-      .dom(PRODUCT_SELECT_TOGGLE_SELECTOR + " .flight-icon")
+      .dom(PRODUCT_SELECT_TOGGLE + " .flight-icon")
       .hasAttribute("data-test-icon", "terraform");
     assert.dom(thumbnailBadgeSelector).exists();
   });
@@ -90,20 +91,20 @@ module("Acceptance | authenticated/new/doc", function (hooks) {
 
     await visit("/new/doc?docType=RFC");
 
-    assert.dom(CREATE_BUTTON_SELECTOR).isDisabled();
+    assert.dom(CREATE_BUTTON).isDisabled();
 
-    await fillIn(TITLE_INPUT_SELECTOR, "Foo");
+    await fillIn(TITLE_INPUT, "Foo");
 
-    assert.dom(CREATE_BUTTON_SELECTOR).isDisabled();
+    assert.dom(CREATE_BUTTON).isDisabled();
 
-    await click(PRODUCT_SELECT_TOGGLE_SELECTOR);
-    await click(FIRST_PRODUCT_SELECT_LIST_ITEM_BUTTON_SELECTOR);
+    await click(PRODUCT_SELECT_TOGGLE);
+    await click(FIRST_PRODUCT_SELECT_ITEM_BUTTON);
 
-    assert.dom(CREATE_BUTTON_SELECTOR).isNotDisabled();
+    assert.dom(CREATE_BUTTON).isNotDisabled();
 
-    await fillIn(TITLE_INPUT_SELECTOR, "");
+    await fillIn(TITLE_INPUT, "");
 
-    assert.dom(CREATE_BUTTON_SELECTOR).isDisabled();
+    assert.dom(CREATE_BUTTON).isDisabled();
   });
 
   test("it shows a loading screen while the doc is being created", async function (this: AuthenticatedNewDocRouteTestContext, assert) {
@@ -111,15 +112,15 @@ module("Acceptance | authenticated/new/doc", function (hooks) {
 
     await visit("/new/doc?docType=RFC");
 
-    await fillIn(TITLE_INPUT_SELECTOR, "Foo");
-    await click(PRODUCT_SELECT_TOGGLE_SELECTOR);
-    await click(FIRST_PRODUCT_SELECT_LIST_ITEM_BUTTON_SELECTOR);
+    await fillIn(TITLE_INPUT, "Foo");
+    await click(PRODUCT_SELECT_TOGGLE);
+    await click(FIRST_PRODUCT_SELECT_ITEM_BUTTON);
 
-    const clickPromise = click(CREATE_BUTTON_SELECTOR);
+    const clickPromise = click(CREATE_BUTTON);
 
-    await waitFor(CREATING_NEW_DOC_SELECTOR);
+    await waitFor(CREATING_NEW_DOC);
 
-    assert.dom(CREATING_NEW_DOC_SELECTOR).exists();
+    assert.dom(CREATING_NEW_DOC).exists();
 
     await clickPromise;
   });
@@ -133,16 +134,16 @@ module("Acceptance | authenticated/new/doc", function (hooks) {
 
     await visit("/new/doc?docType=RFC");
 
-    await fillIn(TITLE_INPUT_SELECTOR, "Foo");
-    await click(PRODUCT_SELECT_TOGGLE_SELECTOR);
-    await click(FIRST_PRODUCT_SELECT_LIST_ITEM_BUTTON_SELECTOR);
+    await fillIn(TITLE_INPUT, "Foo");
+    await click(PRODUCT_SELECT_TOGGLE);
+    await click(FIRST_PRODUCT_SELECT_ITEM_BUTTON);
 
-    const clickPromise = click(CREATE_BUTTON_SELECTOR);
+    const clickPromise = click(CREATE_BUTTON);
 
-    await waitFor(FLASH_NOTIFICATION_SELECTOR);
+    await waitFor(FLASH_NOTIFICATION);
 
     assert
-      .dom(FLASH_NOTIFICATION_SELECTOR)
+      .dom(FLASH_NOTIFICATION)
       .containsText("Error creating document draft");
 
     await clickPromise;
@@ -158,14 +159,14 @@ module("Acceptance | authenticated/new/doc", function (hooks) {
 
     await visit("/new/doc?docType=RFC");
 
-    await fillIn(TITLE_INPUT_SELECTOR, "Foo");
+    await fillIn(TITLE_INPUT, "Foo");
 
-    await fillIn(SUMMARY_INPUT_SELECTOR, "Bar");
+    await fillIn(SUMMARY_INPUT, "Bar");
 
-    await click(PRODUCT_SELECT_TOGGLE_SELECTOR);
-    await click(FIRST_PRODUCT_SELECT_LIST_ITEM_BUTTON_SELECTOR);
+    await click(PRODUCT_SELECT_TOGGLE);
+    await click(FIRST_PRODUCT_SELECT_ITEM_BUTTON);
 
-    await click(CREATE_BUTTON_SELECTOR);
+    await click(CREATE_BUTTON);
 
     const routerService = this.owner.lookup("service:router") as RouterService;
 
@@ -185,14 +186,14 @@ module("Acceptance | authenticated/new/doc", function (hooks) {
 
     await visit("/new/doc?docType=RFC");
 
-    await fillIn(TITLE_INPUT_SELECTOR, "Foo");
-    await click(PRODUCT_SELECT_TOGGLE_SELECTOR);
-    await click(FIRST_PRODUCT_SELECT_LIST_ITEM_BUTTON_SELECTOR);
+    await fillIn(TITLE_INPUT, "Foo");
+    await click(PRODUCT_SELECT_TOGGLE);
+    await click(FIRST_PRODUCT_SELECT_ITEM_BUTTON);
 
-    await click(CREATE_BUTTON_SELECTOR);
+    await click(CREATE_BUTTON);
 
-    await waitFor(DRAFT_CREATED_MODAL_SELECTOR);
+    await waitFor(DRAFT_CREATED_MODAL);
 
-    assert.dom(DRAFT_CREATED_MODAL_SELECTOR).exists();
+    assert.dom(DRAFT_CREATED_MODAL).exists();
   });
 });


### PR DESCRIPTION
Adds a Mirage response for the `/drafts` endpoint and tests the doc-creation flow.