### PR TITLE
Enable removing custom fields by providing an empty value

### DIFF
--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -277,12 +277,22 @@ func (d *Document) UpsertCustomField(cf CustomField) error {
 						return fmt.Errorf("incorrect value type for custom field")
 					}
 				}
+				// If the value is empty, remove it from the document (by not appending
+				// here).
+				if len(cf.Value.([]any)) > 0 {
+					newCFs = append(newCFs, cf)
+				}
 			case "STRING":
-				if _, ok := cf.Value.(string); !ok {
+				v, ok := cf.Value.(string)
+				if !ok {
 					return fmt.Errorf("incorrect value type for custom field")
 				}
+				// If the value is empty, remove it from the document (by not appending
+				// here).
+				if v != "" {
+					newCFs = append(newCFs, cf)
+				}
 			}
-			newCFs = append(newCFs, cf)
 			foundCF = true
 		} else {
 			newCFs = append(newCFs, docCF)


### PR DESCRIPTION
Currently attempting to remove an `RFC` or `PRD` custom field value fails when rewriting the document header, but this is due to a larger issue where you couldn't remove custom fields from a document after adding a value for them. This PR enables removing custom fields from a document by providing an empty value (empty string for a `STRING` type, and an empty array for a `PERSON` type).