### PR TITLE
Add TailwindCSS plugin to Prettier config

### DIFF
--- a/web/.prettierrc.js
+++ b/web/.prettierrc.js
@@ -1,3 +1,6 @@
 module.exports = {
-  plugins: ["prettier-plugin-ember-template-tag"],
+  plugins: [
+    "prettier-plugin-ember-template-tag",
+    "prettier-plugin-tailwindcss",
+  ],
 };


### PR DESCRIPTION
The Tailwind class-sorting plugin stopped working at some point, likely when we merged #299. Adding it to the Prettier config does the trick.