### PR TITLE
Datadog: don't log startup

### DIFF
--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -195,7 +195,10 @@ func (c *Command) Run(args []string) int {
 	// Initialize Datadog.
 	dd := datadog.NewConfig(*cfg)
 	if dd.Enabled {
-		tracerOpts := []tracer.StartOption{}
+		tracerOpts := []tracer.StartOption{
+			tracer.WithLogStartup(false),
+		}
+
 		if dd.Env != "" {
 			tracerOpts = append(tracerOpts, tracer.WithEnv(dd.Env))
 		}


### PR DESCRIPTION
This Datadog startup log line gets interpreted as an error for _reasons_ so this PR removes it so it doesn't set off alerts.