### PR TITLE
Make shortlinks case-insensitive

### DIFF
--- a/pkg/links/redirect.go
+++ b/pkg/links/redirect.go
@@ -99,7 +99,8 @@ func parseAndValidatePath(p string) (string, error) {
 		return "", fmt.Errorf("invalid url path")
 	}
 
-	return fmt.Sprintf("/%s/%s", resultPath[0], resultPath[1]), nil
+	return fmt.Sprintf("/%s/%s",
+		strings.ToLower(resultPath[0]), strings.ToLower(resultPath[1])), nil
 }
 
 // matchStaticPathRedirects matches the URL path provided


### PR DESCRIPTION
Without this change, errors are returned for shortlink redirects when the document type or document number in the shortlink URL contain uppercase characters.