### PR TITLE
Simplify application templating

### DIFF
--- a/web/app/components/footer.hbs
+++ b/web/app/components/footer.hbs
@@ -1,38 +1,34 @@
-{{#unless (eq this.currentRouteName "authenticated.document")}}
-  <div class="footer" ...attributes>
-    <div class="x-container">
-      <div class="footer-inner">
-        <div class="flex items-center space-x-4">
-          <div data-test-footer-copyright>
-            ©
-            {{this.currentYear}}
-            HashiCorp
-          </div>
-          <div data-test-footer-version>
-            Hermes v{{this.version}}
-            ({{this.revision}})
-          </div>
-        </div>
-
-        <div class="flex items-center space-x-4">
-          <ExternalLink
-            data-test-footer-github-link
-            @iconIsShown={{true}}
-            href={{this.gitHubRepoURL}}
-          >
-            GitHub
-          </ExternalLink>
-          {{#if this.supportURL}}
-            <ExternalLink
-              data-test-footer-support-link
-              @iconIsShown={{true}}
-              href={{this.supportURL}}
-            >
-              Support
-            </ExternalLink>
-          {{/if}}
-        </div>
+<div class="footer" ...attributes>
+  <div class="footer-inner">
+    <div class="flex items-center space-x-4">
+      <div data-test-footer-copyright>
+        ©
+        {{this.currentYear}}
+        HashiCorp
+      </div>
+      <div data-test-footer-version>
+        Hermes v{{this.version}}
+        ({{this.revision}})
       </div>
     </div>
+
+    <div class="flex items-center space-x-4">
+      <ExternalLink
+        data-test-footer-github-link
+        @iconIsShown={{true}}
+        href={{this.gitHubRepoURL}}
+      >
+        GitHub
+      </ExternalLink>
+      {{#if this.supportURL}}
+        <ExternalLink
+          data-test-footer-support-link
+          @iconIsShown={{true}}
+          href={{this.supportURL}}
+        >
+          Support
+        </ExternalLink>
+      {{/if}}
+    </div>
   </div>
-{{/unless}}
+</div>

--- a/web/app/components/header.hbs
+++ b/web/app/components/header.hbs
@@ -1,5 +1,3 @@
 <header class="mb-7 border-b border-b-color-border-faint bg-color-page-faint">
   <Header::Nav />
 </header>
-
-<Header::Toolbar @facets={{@facets}} />

--- a/web/app/components/header.ts
+++ b/web/app/components/header.ts
@@ -1,11 +1,6 @@
 import Component from "@glimmer/component";
-import { FacetDropdownGroups } from "hermes/types/facets";
 
-interface HeaderComponentSignature {
-  Args: {
-    facets?: FacetDropdownGroups;
-  };
-}
+interface HeaderComponentSignature {}
 
 export default class HeaderComponent extends Component<HeaderComponentSignature> {}
 

--- a/web/app/components/header/nav.hbs
+++ b/web/app/components/header/nav.hbs
@@ -1,115 +1,109 @@
-<div class="x-container">
+<nav class="header-nav">
+  <LinkTo @route="authenticated.dashboard" class="header-nav-logo">
+    <HermesLogo />
+  </LinkTo>
 
-  <nav class="header-nav">
-    <LinkTo @route="authenticated.dashboard" class="header-nav-logo">
-      <HermesLogo />
+  <div class="primary-links">
+    <LinkTo
+      data-test-nav-link="all"
+      @route="authenticated.documents"
+      @current-when="authenticated.documents"
+      @query={{this.defaultBrowseScreenQueryParams}}
+    >
+      All Docs
     </LinkTo>
+    <LinkTo
+      data-test-nav-link="my"
+      @route="authenticated.my"
+      @current-when="authenticated.my"
+      @query={{this.defaultBrowseScreenQueryParams}}
+    >
+      My Docs
+    </LinkTo>
+    <LinkTo
+      data-test-nav-link="drafts"
+      @route="authenticated.drafts"
+      @current-when="authenticated.drafts"
+      @query={{this.defaultBrowseScreenQueryParams}}
+    >
+      My Drafts
+    </LinkTo>
+  </div>
 
-    <div class="primary-links">
-      <LinkTo
-        data-test-nav-link="all"
-        @route="authenticated.documents"
-        @current-when="authenticated.documents"
-        @query={{this.defaultBrowseScreenQueryParams}}
-      >
-        All Docs
-      </LinkTo>
-      <LinkTo
-        data-test-nav-link="my"
-        @route="authenticated.my"
-        @current-when="authenticated.my"
-        @query={{this.defaultBrowseScreenQueryParams}}
-      >
-        My Docs
-      </LinkTo>
-      <LinkTo
-        data-test-nav-link="drafts"
-        @route="authenticated.drafts"
-        @current-when="authenticated.drafts"
-        @query={{this.defaultBrowseScreenQueryParams}}
-      >
-        My Drafts
-      </LinkTo>
-    </div>
+  <Header::Search class="global-search" />
 
-    <Header::Search class="global-search" />
-
-    <div class="user-buttons">
-      <Hds::Button
-        data-test-create-new-button
-        @route="authenticated.new"
-        @text="New"
-        @icon="plus"
-        class="pl-2.5 pr-4"
-      />
-      <div class="relative">
-        {{#if this.userMenuHighlightIsShown}}
-          <Header::UserMenuHighlight />
-        {{/if}}
-        {{#if this.profile.picture}}
-          {{! Workaround until `referrerPolicy` is supported in dd.ToggleIcon }}
-          <img
-            src={{this.profile.picture}}
-            class="user-avatar"
-            role="presentation"
-            referrerpolicy="no-referrer"
-          />
-        {{/if}}
-        <Hds::Dropdown as |dd|>
-          <dd.ToggleIcon
-            data-test-user-menu-toggle
-            @text="User menu"
-            @icon="user"
-          />
-          <dd.Title
-            data-test-user-menu-title
-            {{did-insert this.onDropdownOpen}}
-            {{will-destroy this.onDropdownClose}}
-            @text={{this.profile.name}}
-            class="text-body-200"
-          />
-          <dd.Description
-            data-test-user-menu-email
-            @text={{this.profile.email}}
-            class="text-body-200"
-          />
-          <dd.Separator class="mt-2" />
+  <div class="user-buttons">
+    <Hds::Button
+      data-test-create-new-button
+      @route="authenticated.new"
+      @text="New"
+      @icon="plus"
+      class="pl-2.5 pr-4"
+    />
+    <div class="relative">
+      {{#if this.userMenuHighlightIsShown}}
+        <Header::UserMenuHighlight />
+      {{/if}}
+      {{#if this.profile.picture}}
+        {{! Workaround until `referrerPolicy` is supported in dd.ToggleIcon }}
+        <img
+          src={{this.profile.picture}}
+          class="user-avatar"
+          role="presentation"
+          referrerpolicy="no-referrer"
+        />
+      {{/if}}
+      <Hds::Dropdown as |dd|>
+        <dd.ToggleIcon
+          data-test-user-menu-toggle
+          @text="User menu"
+          @icon="user"
+        />
+        <dd.Title
+          data-test-user-menu-title
+          {{did-insert this.onDropdownOpen}}
+          {{will-destroy this.onDropdownClose}}
+          @text={{this.profile.name}}
+          class="text-body-200"
+        />
+        <dd.Description
+          data-test-user-menu-email
+          @text={{this.profile.email}}
+          class="text-body-200"
+        />
+        <dd.Separator class="mt-2" />
+        <dd.Interactive
+          data-test-user-menu-item="email-notifications"
+          @route="authenticated.settings"
+          @text="Email notifications"
+          class={{if this.emailNotificationsHighlightIsShown "highlighted-new"}}
+        />
+        <dd.Interactive
+          data-test-user-menu-github
+          @href={{this.gitHubRepoURL}}
+          @isHrefExternal={{true}}
+          @text="GitHub"
+          @icon="external-link"
+          class="user-menu-external-link"
+        />
+        {{#if this.supportDocsURL}}
           <dd.Interactive
-            data-test-user-menu-item="email-notifications"
-            @route="authenticated.settings"
-            @text="Email notifications"
-            class={{if
-              this.emailNotificationsHighlightIsShown
-              "highlighted-new"
-            }}
-          />
-          <dd.Interactive
-            data-test-user-menu-github
-            @href={{this.gitHubRepoURL}}
+            data-test-user-menu-support
+            @href={{this.supportDocsURL}}
             @isHrefExternal={{true}}
-            @text="GitHub"
+            @text="Support"
             @icon="external-link"
             class="user-menu-external-link"
           />
-          {{#if this.supportDocsURL}}
-            <dd.Interactive
-              data-test-user-menu-support
-              @href={{this.supportDocsURL}}
-              @isHrefExternal={{true}}
-              @text="Support"
-              @icon="external-link"
-              class="user-menu-external-link"
-            />
-          {{/if}}
-          {{#if this.showSignOut}}
-            <dd.Interactive
-              data-test-user-menu-item="sign-out"
-              {{on "click" this.invalidateSession}}
-              @text="Sign out"
-            />
-          {{/if}}
-        </Hds::Dropdown>
-      </div>
+        {{/if}}
+        {{#if this.showSignOut}}
+          <dd.Interactive
+            data-test-user-menu-item="sign-out"
+            {{on "click" this.invalidateSession}}
+            @text="Sign out"
+          />
+        {{/if}}
+      </Hds::Dropdown>
     </div>
-  </nav>
-</div>
+  </div>
+</nav>

--- a/web/app/components/header/toolbar.hbs
+++ b/web/app/components/header/toolbar.hbs
@@ -1,41 +1,39 @@
 {{#if @facets}}
   <div class="toolbar mb-7">
-    <div class="x-container">
-      <div class="flex w-full justify-between">
-        <div class="flex items-center">
-          <h4 class="hermes-h4 mr-4">
-            Filter by:
-          </h4>
-          <div class="facets flex items-center">
-            <Header::FacetDropdown
-              @label="Type"
-              @facets={{@facets.docType}}
-              @disabled={{not @facets.docType}}
-              @position="left"
-            />
-            <Header::FacetDropdown
-              @label="Status"
-              @facets={{this.statuses}}
-              @disabled={{not this.statuses}}
-              @position="center"
-              class="medium"
-            />
-            <Header::FacetDropdown
-              @label="Product/Area"
-              @facets={{@facets.product}}
-              @disabled={{not @facets.product}}
-              @position="center"
-            />
-            <Header::FacetDropdown
-              @label="Owner"
-              @facets={{@facets.owners}}
-              @disabled={{not @facets.owners}}
-              @position="right"
-            />
-          </div>
+    <div class="flex w-full justify-between">
+      <div class="flex items-center">
+        <h4 class="hermes-h4 mr-4">
+          Filter by:
+        </h4>
+        <div class="facets flex items-center">
+          <Header::FacetDropdown
+            @label="Type"
+            @facets={{@facets.docType}}
+            @disabled={{not @facets.docType}}
+            @position="left"
+          />
+          <Header::FacetDropdown
+            @label="Status"
+            @facets={{this.statuses}}
+            @disabled={{not this.statuses}}
+            @position="center"
+            class="medium"
+          />
+          <Header::FacetDropdown
+            @label="Product/Area"
+            @facets={{@facets.product}}
+            @disabled={{not @facets.product}}
+            @position="center"
+          />
+          <Header::FacetDropdown
+            @label="Owner"
+            @facets={{@facets.owners}}
+            @disabled={{not @facets.owners}}
+            @position="right"
+          />
         </div>
       </div>
-      <Header::ActiveFilterList />
     </div>
+    <Header::ActiveFilterList />
   </div>
 {{/if}}

--- a/web/app/components/results/index.hbs
+++ b/web/app/components/results/index.hbs
@@ -1,56 +1,51 @@
-<section class="flex min-h-full flex-1 flex-col items-center">
-  <div class="x-container">
-    {{#if (and this.firstPageIsShown this.queryIsProductName)}}
-      <div
-        class="flex w-full flex-col items-start pb-10"
-        data-test-results-product-link
-      >
-        <Hds::Card::Container
-          @level="mid"
-          @hasBorder="true"
-          @overflow="hidden"
-          class="flex flex-col items-start space-y-3 px-4 pt-4 pb-3"
-        >
-          <Hds::Badge
-            @text={{this.capitalizedQuery}}
-            @icon={{or (get-product-id @query) "folder"}}
-          />
-          <Hds::Link::Standalone
-            @text="View all {{this.capitalizedQuery}} documents"
-            @icon="arrow-right-circle"
-            @iconPosition="trailing"
-            @route="authenticated.documents"
-            @query={{hash product=(array this.capitalizedQuery)}}
-          />
-        </Hds::Card::Container>
-      </div>
-    {{/if}}
+{{#if (and this.firstPageIsShown this.queryIsProductName)}}
+  <div
+    class="flex w-full flex-col items-start pb-10"
+    data-test-results-product-link
+  >
+    <Hds::Card::Container
+      @level="mid"
+      @hasBorder="true"
+      @overflow="hidden"
+      class="flex flex-col items-start space-y-3 px-4 pt-4 pb-3"
+    >
+      <Hds::Badge
+        @text={{this.capitalizedQuery}}
+        @icon={{or (get-product-id @query) "folder"}}
+      />
+      <Hds::Link::Standalone
+        @text="View all {{this.capitalizedQuery}} documents"
+        @icon="arrow-right-circle"
+        @iconPosition="trailing"
+        @route="authenticated.documents"
+        @query={{hash product=(array this.capitalizedQuery)}}
+      />
+    </Hds::Card::Container>
+  </div>
+{{/if}}
 
-    <h1 class="text-display-300 font-semibold">{{@results.nbHits}}
-      documents matching “{{@query}}”</h1>
-    <div class="flex w-full flex-col space-y-12 py-10">
-      <div class="tile-list">
-        {{#each @results.hits as |doc|}}
-          <Doc::Tile
-            @avatar="{{get doc.ownerPhotos 0}}"
-            @docID="{{doc.objectID}}"
-            @isResult={{true}}
-            @modifiedTime={{doc.modifiedTime}}
-            @owner="{{get doc.owners 0}}"
-            @productArea="{{doc.product}}"
-            @snippet="{{doc._snippetResult.content.value}}"
-            @status="{{lowercase doc.status}}"
-            @title="{{doc.title}}"
-          />
-        {{/each}}
-      </div>
-
-    </div>
-
-    <Pagination
-      @currentPage={{(add @results.page 1)}}
-      @nbPages={{@results.nbPages}}
-    />
+<h1 class="text-display-300 font-semibold">{{@results.nbHits}}
+  documents matching “{{@query}}”</h1>
+<div class="flex w-full flex-col space-y-12 py-10">
+  <div class="tile-list">
+    {{#each @results.hits as |doc|}}
+      <Doc::Tile
+        @avatar="{{get doc.ownerPhotos 0}}"
+        @docID="{{doc.objectID}}"
+        @isResult={{true}}
+        @modifiedTime={{doc.modifiedTime}}
+        @owner="{{get doc.owners 0}}"
+        @productArea="{{doc.product}}"
+        @snippet="{{doc._snippetResult.content.value}}"
+        @status="{{lowercase doc.status}}"
+        @title="{{doc.title}}"
+      />
+    {{/each}}
   </div>
 
-</section>
+</div>
+
+<Pagination
+  @currentPage={{(add @results.page 1)}}
+  @nbPages={{@results.nbPages}}
+/>

--- a/web/app/components/row-results.hbs
+++ b/web/app/components/row-results.hbs
@@ -1,65 +1,61 @@
-<section>
-  <div class="x-container">
-    <div class="row-results">
-      {{#if @docs}}
-        <Hds::Table @isStriped={{false}} class="row-results__table">
-          <:head as |H|>
-            <H.Tr>
-              <H.Th class="name">Name</H.Th>
-              <H.Th class="type">Type</H.Th>
-              <H.Th class="status">Status</H.Th>
-              <H.Th class="product">Product/Area</H.Th>
-              <H.Th class="owner">Owner</H.Th>
-              <H.Th class="created">
-                <Table::SortableHeader
-                  @changeSort={{@changeSort}}
-                  @currentSort={{@currentSort}}
-                  @sortDirection={{@sortDirection}}
-                  @queryParam={{hash
-                    sortBy=(if (eq @sortDirection "desc") "dateAsc" "dateDesc")
-                    page=1
-                  }}
-                  @attribute="createdTime"
-                  @defaultSortDirection="desc"
-                >
-                  Created
-                </Table::SortableHeader>
-              </H.Th>
-            </H.Tr>
-          </:head>
-          <:body>
-            {{#each @docs as |doc|}}
-              <Doc::Row
-                @avatar="{{get doc.ownerPhotos 0}}"
-                @createdDate="{{parse-date doc.created}}"
-                @docID="{{doc.objectID}}"
-                @docNumber="{{doc.docNumber}}"
-                @docType="{{doc.docType}}"
-                @owner="{{get doc.owners 0}}"
-                @productArea="{{doc.product}}"
-                @status="{{lowercase doc.status}}"
-                @title="{{doc.title}}"
-                @isDraft={{@isDraft}}
-              />
-            {{/each}}
-          </:body>
-        </Hds::Table>
-        {{#if this.paginationIsShown}}
-          <Pagination @nbPages={{@nbPages}} @currentPage={{@currentPage}} />
-        {{/if}}
-      {{else}}
-        {{#if @isDraft}}
-          <Hds::Alert @type="inline" as |A|>
-            <A.Title>No drafts found</A.Title>
-            <A.Button
-              @text="Create a document draft"
-              @color="primary"
-              @icon="file-plus"
-              @route="authenticated.new"
-            />
-          </Hds::Alert>
-        {{/if}}
-      {{/if}}
-    </div>
-  </div>
-</section>
+<div class="row-results">
+  {{#if @docs}}
+    <Hds::Table @isStriped={{false}} class="row-results__table">
+      <:head as |H|>
+        <H.Tr>
+          <H.Th class="name">Name</H.Th>
+          <H.Th class="type">Type</H.Th>
+          <H.Th class="status">Status</H.Th>
+          <H.Th class="product">Product/Area</H.Th>
+          <H.Th class="owner">Owner</H.Th>
+          <H.Th class="created">
+            <Table::SortableHeader
+              @changeSort={{@changeSort}}
+              @currentSort={{@currentSort}}
+              @sortDirection={{@sortDirection}}
+              @queryParam={{hash
+                sortBy=(if (eq @sortDirection "desc") "dateAsc" "dateDesc")
+                page=1
+              }}
+              @attribute="createdTime"
+              @defaultSortDirection="desc"
+            >
+              Created
+            </Table::SortableHeader>
+          </H.Th>
+        </H.Tr>
+      </:head>
+      <:body>
+        {{#each @docs as |doc|}}
+          <Doc::Row
+            @avatar="{{get doc.ownerPhotos 0}}"
+            @createdDate="{{parse-date doc.created}}"
+            @docID="{{doc.objectID}}"
+            @docNumber="{{doc.docNumber}}"
+            @docType="{{doc.docType}}"
+            @owner="{{get doc.owners 0}}"
+            @productArea="{{doc.product}}"
+            @status="{{lowercase doc.status}}"
+            @title="{{doc.title}}"
+            @isDraft={{@isDraft}}
+          />
+        {{/each}}
+      </:body>
+    </Hds::Table>
+    {{#if this.paginationIsShown}}
+      <Pagination @nbPages={{@nbPages}} @currentPage={{@currentPage}} />
+    {{/if}}
+  {{else}}
+    {{#if @isDraft}}
+      <Hds::Alert @type="inline" as |A|>
+        <A.Title>No drafts found</A.Title>
+        <A.Button
+          @text="Create a document draft"
+          @color="primary"
+          @icon="file-plus"
+          @route="authenticated.new"
+        />
+      </Hds::Alert>
+    {{/if}}
+  {{/if}}
+</div>

--- a/web/app/controllers/authenticated.ts
+++ b/web/app/controllers/authenticated.ts
@@ -1,0 +1,12 @@
+import Controller from "@ember/controller";
+import RouterService from "@ember/routing/router-service";
+import { inject as service } from "@ember/service";
+
+export default class AuthenticatedController extends Controller {
+  @service declare router: RouterService;
+
+  protected get standardTemplateIsShown() {
+    const routeName = this.router.currentRouteName;
+    return routeName !== "authenticated.document" && routeName !== "404";
+  }
+}

--- a/web/app/styles/components/footer.scss
+++ b/web/app/styles/components/footer.scss
@@ -2,15 +2,11 @@
   @apply mt-12 mb-16 w-full text-body-200 text-color-foreground-faint;
 
   .footer-inner {
-    @apply border-t border-t-color-border-primary pt-6 flex w-full items-center justify-between;
+    @apply flex w-full items-center justify-between border-t border-t-color-border-primary pt-6;
   }
 
   &.compact {
     @apply mt-0;
-
-    .x-container {
-      @apply px-0;
-    }
 
     .footer-inner {
       @apply border-t-0;

--- a/web/app/templates/authenticated.hbs
+++ b/web/app/templates/authenticated.hbs
@@ -1,4 +1,9 @@
-{{! @glint-nocheck: not typesafe yet }}
-{{outlet}}
-
-<Footer />
+{{#if this.standardTemplateIsShown}}
+  <div class="x-container">
+    <Header />
+    {{outlet}}
+    <Footer />
+  </div>
+{{else}}
+  {{outlet}}
+{{/if}}

--- a/web/app/templates/authenticated/dashboard.hbs
+++ b/web/app/templates/authenticated/dashboard.hbs
@@ -1,74 +1,68 @@
 {{page-title "Dashboard"}}
 
-<Header />
+<Dashboard::NewFeaturesBanner />
 
-<section class="x-container">
+<h1 class="mb-7">
+  Welcome back,
+  {{this.authenticatedUser.info.given_name}}!
+</h1>
 
-  <Dashboard::NewFeaturesBanner />
+{{#if @model}}
+  <Dashboard::DocsAwaitingReview @docs={{@model}} />
+{{/if}}
 
-  <h1 class="mb-7">
-    Welcome back,
-    {{this.authenticatedUser.info.given_name}}!
-  </h1>
+<div
+  class="hds-border-primary mt-10 flex w-full flex-col border-0 border-b pb-10"
+>
+  <div class="mb-8 flex items-center space-x-2">
+    <FlightIcon @name="eye" @size="24" />
+    <h2
+      class="hds-typography-display-300 hds-font-weight-semibold hds-foreground-strong"
+    >Recently viewed</h2>
+  </div>
 
-  {{#if @model}}
-    <Dashboard::DocsAwaitingReview @docs={{@model}} />
+  {{#if this.recentDocs.all}}
+    <div class="tile-list">
+      {{#each this.recentDocs.all as |r|}}
+        <Doc::Tile
+          data-test-recently-viewed-doc
+          @isDraft={{r.doc.isDraft}}
+          @avatar={{get r.doc.ownerPhotos 0}}
+          @docID={{r.doc.objectID}}
+          @docNumber={{r.doc.docNumber}}
+          @modifiedTime={{r.doc.modifiedTime}}
+          @owner={{get r.doc.owners 0}}
+          @productArea={{r.doc.product}}
+          @status={{lowercase r.doc.status}}
+          @title={{r.doc.title}}
+        />
+      {{/each}}
+    </div>
+  {{else if this.recentDocs.fetchAll.isRunning}}
+    <div class="h-[100px]">
+      <FlightIcon @name="loading" class="mt-1" />
+    </div>
+  {{else if (eq this.recentDocs.all null)}}
+    <div class="h-[100px]">
+      <p class="mb-7 text-body-300 text-color-foreground-faint">
+        Error fetching documents.
+      </p>
+      <Hds::Button
+        @text="Retry"
+        @color="secondary"
+        @size="small"
+        @icon="reload"
+        {{on "click" (perform this.recentDocs.fetchAll)}}
+      />
+    </div>
+  {{else}}
+    <div class="text-display-200">
+      You havenʼt viewed any documents yet.
+    </div>
   {{/if}}
 
-  <div
-    class="hds-border-primary mt-10 flex w-full flex-col border-0 border-b pb-10"
-  >
-    <div class="mb-8 flex items-center space-x-2">
-      <FlightIcon @name="eye" @size="24" />
-      <h2
-        class="hds-typography-display-300 hds-font-weight-semibold hds-foreground-strong"
-      >Recently viewed</h2>
-    </div>
+</div>
 
-    {{#if this.recentDocs.all}}
-      <div class="tile-list">
-        {{#each this.recentDocs.all as |r|}}
-          <Doc::Tile
-            data-test-recently-viewed-doc
-            @isDraft={{r.doc.isDraft}}
-            @avatar={{get r.doc.ownerPhotos 0}}
-            @docID={{r.doc.objectID}}
-            @docNumber={{r.doc.docNumber}}
-            @modifiedTime={{r.doc.modifiedTime}}
-            @owner={{get r.doc.owners 0}}
-            @productArea={{r.doc.product}}
-            @status={{lowercase r.doc.status}}
-            @title={{r.doc.title}}
-          />
-        {{/each}}
-      </div>
-    {{else if this.recentDocs.fetchAll.isRunning}}
-      <div class="h-[100px]">
-        <FlightIcon @name="loading" class="mt-1" />
-      </div>
-    {{else if (eq this.recentDocs.all null)}}
-      <div class="h-[100px]">
-        <p class="mb-7 text-body-300 text-color-foreground-faint">
-          Error fetching documents.
-        </p>
-        <Hds::Button
-          @text="Retry"
-          @color="secondary"
-          @size="small"
-          @icon="reload"
-          {{on "click" (perform this.recentDocs.fetchAll)}}
-        />
-      </div>
-    {{else}}
-      <div class="text-display-200">
-        You havenʼt viewed any documents yet.
-      </div>
-    {{/if}}
-
-  </div>
-
-  <div class="flex w-full flex-col py-10">
-    <Dashboard::LatestUpdates />
-  </div>
-
-</section>
+<div class="flex w-full flex-col py-10">
+  <Dashboard::LatestUpdates />
+</div>

--- a/web/app/templates/authenticated/documents.hbs
+++ b/web/app/templates/authenticated/documents.hbs
@@ -1,6 +1,6 @@
 {{page-title "All Docs"}}
 
-<Header @facets={{@model.facets}} />
+<Header::Toolbar @facets={{@model.facets}} />
 
 <RowResults
   @docs={{@model.results.hits}}

--- a/web/app/templates/authenticated/drafts.hbs
+++ b/web/app/templates/authenticated/drafts.hbs
@@ -1,7 +1,7 @@
 {{! @glint-nocheck: not typesafe yet }}
 {{page-title "My Drafts"}}
 
-<Header @facets={{@model.facets}} />
+<Header::Toolbar @facets={{@model.facets}} />
 
 <RowResults
   @docs={{@model.results.Hits}}

--- a/web/app/templates/authenticated/my.hbs
+++ b/web/app/templates/authenticated/my.hbs
@@ -1,6 +1,6 @@
 {{page-title "My Docs"}}
 
-<Header @facets={{@model.facets}} />
+<Header::Toolbar @facets={{@model.facets}} />
 
 <RowResults
   @docs={{@model.results.hits}}

--- a/web/app/templates/authenticated/new.hbs
+++ b/web/app/templates/authenticated/new.hbs
@@ -1,6 +1,1 @@
-<Header />
-<section>
-  <div class="x-container">
-    {{outlet}}
-  </div>
-</section>
+{{outlet}}

--- a/web/app/templates/authenticated/results.hbs
+++ b/web/app/templates/authenticated/results.hbs
@@ -1,5 +1,5 @@
 {{page-title "Search Results"}}
 
-<Header @facets={{@model.facets}} />
+<Header::Toolbar @facets={{@facets}} />
 
 <Results @results={{@model.results}} @query={{this.q}} />

--- a/web/app/templates/authenticated/settings.hbs
+++ b/web/app/templates/authenticated/settings.hbs
@@ -1,16 +1,9 @@
-{{! @glint-nocheck: not typesafe yet }}
 {{page-title "Email Notifications"}}
 
-<Header @toolbarIsHidden={{true}} />
+<div class="max-w-2xl">
 
-<section>
-  <div class="x-container">
-    <div class="max-w-2xl">
-
-      <h1 class="mb-2.5">Email notifications</h1>
-      <p class="hds-typography-display-200">Get notified when docs are created
-        in the following areas...</p>
-      <Settings::SubscriptionList @allProductAreas={{@model}} />
-    </div>
-  </div>
-</section>
+  <h1 class="mb-2.5">Email notifications</h1>
+  <p class="hds-typography-display-200">Get notified when docs are created in
+    the following areas...</p>
+  <Settings::SubscriptionList @allProductAreas={{@model}} />
+</div>


### PR DESCRIPTION
Moves shared templating to `authenticated.hbs` and moves the `Toolbar` out of the `Header`. Basically reduces the number of times we're writing `<div class="x-container">` and `<Header />`.