### PR TITLE
Fix nav container bug

### DIFF
--- a/web/app/components/header/nav.hbs
+++ b/web/app/components/header/nav.hbs
@@ -1,4 +1,4 @@
-<nav class="header-nav">
+<nav class="header-nav x-container">
   <LinkTo @route="authenticated.dashboard" class="header-nav-logo">
     <HermesLogo />
   </LinkTo>

--- a/web/app/templates/authenticated.hbs
+++ b/web/app/templates/authenticated.hbs
@@ -1,6 +1,6 @@
 {{#if this.standardTemplateIsShown}}
+  <Header />
   <div class="x-container">
-    <Header />
     {{outlet}}
     <Footer />
   </div>


### PR DESCRIPTION
Fixes a CSS bug in the application header introduced in #367  I had incorrectly nested the nav inside the global container when in fact it needs to live outside of it.