### PR TITLE
RelatedResources: Fix `documentType` bug

### DIFF
--- a/web/app/components/document/sidebar/related-resources/list-item/resource.ts
+++ b/web/app/components/document/sidebar/related-resources/list-item/resource.ts
@@ -26,7 +26,7 @@ export default class DocumentSidebarRelatedResourcesListItemResourceComponent ex
    */
   protected get docType() {
     this.assertResourceIsDocument(this.args.resource);
-    return this.args.resource.type;
+    return this.args.resource.documentType;
   }
 
   /**
@@ -73,7 +73,7 @@ export default class DocumentSidebarRelatedResourcesListItemResourceComponent ex
    * with the correct data model.
    */
   private assertResourceIsDocument(
-    document: RelatedResource
+    document: RelatedResource,
   ): asserts document is RelatedHermesDocument {
     if (!("googleFileID" in document)) {
       throw new Error("resource must be a document");

--- a/web/app/components/related-resources.ts
+++ b/web/app/components/related-resources.ts
@@ -26,10 +26,6 @@ export interface RelatedHermesDocument {
   documentType: string;
   documentNumber: string;
   sortOrder: number;
-  status: string;
-  owners?: string[];
-  ownerPhotos?: string[];
-  product?: string;
 }
 
 export enum RelatedResourcesScope {

--- a/web/app/components/related-resources.ts
+++ b/web/app/components/related-resources.ts
@@ -23,9 +23,13 @@ export interface RelatedHermesDocument {
   id: number;
   googleFileID: string;
   title: string;
-  type: string;
+  documentType: string;
   documentNumber: string;
   sortOrder: number;
+  status: string;
+  owners?: string[];
+  ownerPhotos?: string[];
+  product?: string;
 }
 
 export enum RelatedResourcesScope {

--- a/web/app/components/related-resources/add.ts
+++ b/web/app/components/related-resources/add.ts
@@ -331,9 +331,6 @@ export default class RelatedResourcesAddComponent extends Component<RelatedResou
       title: attrs.title,
       documentType: attrs.docType,
       documentNumber: attrs.docNumber,
-      owners: attrs.owners,
-      ownerPhotos: attrs.ownerPhotos,
-      product: attrs.product,
       sortOrder: 1,
     } as RelatedHermesDocument;
 

--- a/web/app/components/related-resources/add.ts
+++ b/web/app/components/related-resources/add.ts
@@ -33,7 +33,7 @@ interface RelatedResourcesAddComponentSignature {
       dd: XDropdownListAnchorAPI | null,
       query: string,
       shouldIgnoreDelay?: boolean,
-      options?: SearchOptions
+      options?: SearchOptions,
     ) => Promise<void>;
     getObject: (dd: XDropdownListAnchorAPI | null, id: string) => Promise<void>;
     headerTitle: string;
@@ -329,8 +329,11 @@ export default class RelatedResourcesAddComponent extends Component<RelatedResou
     const relatedHermesDocument = {
       googleFileID: attrs.objectID,
       title: attrs.title,
-      type: attrs.docType,
+      documentType: attrs.docType,
       documentNumber: attrs.docNumber,
+      owners: attrs.owners,
+      ownerPhotos: attrs.ownerPhotos,
+      product: attrs.product,
       sortOrder: 1,
     } as RelatedHermesDocument;
 
@@ -352,7 +355,7 @@ export default class RelatedResourcesAddComponent extends Component<RelatedResou
    */
   @action private checkForDuplicate(
     urlOrID: string,
-    resourceIsHermesDocument = false
+    resourceIsHermesDocument = false,
   ) {
     let isDuplicate = false;
     if (resourceIsHermesDocument) {
@@ -400,7 +403,7 @@ export default class RelatedResourcesAddComponent extends Component<RelatedResou
    */
   @action protected didInsertInput(
     dd: XDropdownListAnchorAPI,
-    e: HTMLInputElement
+    e: HTMLInputElement,
   ) {
     this.searchInput = e;
     this._dd = dd;
@@ -626,7 +629,7 @@ export default class RelatedResourcesAddComponent extends Component<RelatedResou
   private getAlgoliaObject = restartableTask(async (id: string) => {
     assert(
       "full url format expected",
-      this.firstPartyURLFormat === FirstPartyURLFormat.FullURL
+      this.firstPartyURLFormat === FirstPartyURLFormat.FullURL,
     );
 
     this.checkForDuplicate(id, true);

--- a/web/mirage/factories/related-hermes-document.ts
+++ b/web/mirage/factories/related-hermes-document.ts
@@ -17,7 +17,4 @@ export default Factory.extend({
   documentNumber() {
     return `LAB-00${this.id}`;
   },
-  status: "In review",
-  product: "Labs",
-  owners: ["testuser@example.com"],
 });

--- a/web/mirage/factories/related-hermes-document.ts
+++ b/web/mirage/factories/related-hermes-document.ts
@@ -13,8 +13,11 @@ export default Factory.extend({
   title() {
     return `Related Document ${this.id}`;
   },
-  type: "RFC",
+  documentType: "RFC",
   documentNumber() {
     return `LAB-00${this.id}`;
   },
+  status: "In review",
+  product: "Labs",
+  owners: ["testuser@example.com"],
 });

--- a/web/tests/integration/components/document/sidebar/related-resources/list-item-test.ts
+++ b/web/tests/integration/components/document/sidebar/related-resources/list-item-test.ts
@@ -36,7 +36,7 @@ module(
     setupMirage(hooks);
 
     hooks.beforeEach(async function (
-      this: DocumentSidebarRelatedResourcesListItemTestContext
+      this: DocumentSidebarRelatedResourcesListItemTestContext,
     ) {
       this.server.create("document");
 
@@ -44,7 +44,7 @@ module(
       this.set("document", {
         googleFileID: documentAttrs.objectID,
         title: documentAttrs.title,
-        type: documentAttrs.docType,
+        documentType: documentAttrs.docType,
         documentNumber: documentAttrs.docNumber,
         sortOrder: 1,
       });
@@ -166,7 +166,7 @@ module(
         .exists({ count: 2 }, "two buttons are present for external resources");
 
       const editButton = htmlElement(
-        `${DROPDOWN_LIST_ITEM_SELECTOR}:nth-child(1) button`
+        `${DROPDOWN_LIST_ITEM_SELECTOR}:nth-child(1) button`,
       );
 
       assert.dom(editButton).hasText("Edit", "edit button is present");
@@ -187,7 +187,7 @@ module(
       await click(OVERFLOW_BUTTON_SELECTOR);
 
       const removeButton = htmlElement(
-        `${DROPDOWN_LIST_ITEM_SELECTOR}:nth-child(2) button`
+        `${DROPDOWN_LIST_ITEM_SELECTOR}:nth-child(2) button`,
       );
       assert.dom(removeButton).hasText("Remove", "remove button is present");
 
@@ -195,5 +195,5 @@ module(
 
       assert.equal(count, 2, "remove button was clicked");
     });
-  }
+  },
 );


### PR DESCRIPTION
Fixes a bug preventing a `RelatedHermesDocument`'s `documentType` from saving, and similarly fixes the Mirage type that was incorrectly giving us a passing test.