### PR TITLE
Add conditional ProductAreas fetch call to `new/doc` route

### DIFF
--- a/web/app/routes/authenticated/new/doc.ts
+++ b/web/app/routes/authenticated/new/doc.ts
@@ -1,17 +1,25 @@
 import Route from "@ember/routing/route";
+import { inject as service } from "@ember/service";
+import ProductAreasService from "hermes/services/product-areas";
 
 interface AuthenticatedNewDocRouteParams {
   docType: string;
 }
 
 export default class AuthenticatedNewDocRoute extends Route {
+  @service declare productAreas: ProductAreasService;
+
   queryParams = {
     docType: {
       refreshModel: true,
     },
   };
 
-  model(params: AuthenticatedNewDocRouteParams) {
+  async model(params: AuthenticatedNewDocRouteParams) {
+    if (!this.productAreas.index) {
+      await this.productAreas.fetch.perform();
+    }
+
     return params.docType;
   }
 }

--- a/web/app/services/product-areas.ts
+++ b/web/app/services/product-areas.ts
@@ -1,8 +1,6 @@
 import Service, { inject as service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
-import { action } from "@ember/object";
-import RouterService from "@ember/routing/router-service";
-import { task, timeout } from "ember-concurrency";
+import { task } from "ember-concurrency";
 import FetchService from "./fetch";
 
 export type ProductArea = {


### PR DESCRIPTION
Adds a check to the `/new/doc` route for whether the ProductAreasService's index is loaded. If it's not already loaded, we now await it before rendering the form. This minimizes layout shift when first loading the index.

Also removes unused imports from the ProductAreasService.