### PR TITLE
Add HermesLogo to Glint registry

### DIFF
--- a/web/app/components/hermes-logo.hbs
+++ b/web/app/components/hermes-logo.hbs
@@ -1,8 +1,4 @@
-{{! @glint-nocheck: not typesafe yet }}
-<div
-  class="hermes-logo"
-  ...attributes
->
+<div class="hermes-logo" ...attributes>
   <FlightIcon @name="hashicorp" @size="24" />
   <div class="hermes-logo-divider"></div>
   <div class="hermes-logo-text">

--- a/web/app/components/hermes-logo.ts
+++ b/web/app/components/hermes-logo.ts
@@ -2,7 +2,12 @@ import Component from "@glimmer/component";
 
 interface HermesLogoComponentSignature {
   Element: HTMLDivElement;
-  Args: {};
 }
 
 export default class HermesLogoComponent extends Component<HermesLogoComponentSignature> {}
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry {
+    HermesLogo: typeof HermesLogoComponent;
+  }
+}


### PR DESCRIPTION
Adds the `<HermesLogo/>` component to the Glint registry and removes a `@glint-nocheck`