### PR TITLE
Expand HDS template types

### DIFF
--- a/web/types/hds/badge-count.d.ts
+++ b/web/types/hds/badge-count.d.ts
@@ -1,4 +1,4 @@
-//helios.hashicorp.design/components/badge-count?tab=code#component-api
+// helios.hashicorp.design/components/badge-count?tab=code#component-api
 
 import { ComponentLike } from "@glint/template";
 import { HdsBadgeCountColor, HdsBadgeType } from "hds/_shared";
@@ -7,7 +7,7 @@ import { HdsBadgeCountSize } from "hermes/types/HdsBadgeCountSize";
 interface HdsBadgeCountComponentSignature {
   Element: HTMLDivElement;
   Args: {
-    text: string;
+    text: string | number;
     size?: HdsBadgeCountSize;
     type?: HdsBadgeType;
     color?: HdsBadgeCountColor;

--- a/web/types/hds/badge-count.d.ts
+++ b/web/types/hds/badge-count.d.ts
@@ -7,7 +7,7 @@ import { HdsBadgeCountSize } from "hermes/types/HdsBadgeCountSize";
 interface HdsBadgeCountComponentSignature {
   Element: HTMLDivElement;
   Args: {
-    text: string | number;
+    text: string;
     size?: HdsBadgeCountSize;
     type?: HdsBadgeType;
     color?: HdsBadgeCountColor;

--- a/web/types/hds/badge.d.ts
+++ b/web/types/hds/badge.d.ts
@@ -1,16 +1,12 @@
 // https://helios.hashicorp.design/components/badge?tab=code#component-api
 
 import { ComponentLike } from "@glint/template";
-import {
-  HdsBadgeColor,
-  HdsBadgeType,
-  HdsComponentSize,
-} from "hds/_shared";
+import { HdsBadgeColor, HdsBadgeType, HdsComponentSize } from "hds/_shared";
 
 interface HdsBadgeComponentSignature {
   Element: HTMLDivElement;
   Args: {
-    text: string;
+    text: string | number;
     color?: HdsBadgeColor;
     type?: HdsBadgeType;
     size?: HdsComponentSize;

--- a/web/types/hds/badge.d.ts
+++ b/web/types/hds/badge.d.ts
@@ -6,7 +6,7 @@ import { HdsBadgeColor, HdsBadgeType, HdsComponentSize } from "hds/_shared";
 interface HdsBadgeComponentSignature {
   Element: HTMLDivElement;
   Args: {
-    text: string | number;
+    text: string;
     color?: HdsBadgeColor;
     type?: HdsBadgeType;
     size?: HdsComponentSize;

--- a/web/types/hds/flight-icon.d.ts
+++ b/web/types/hds/flight-icon.d.ts
@@ -1,13 +1,19 @@
-// https://helios.hashicorp.design/icons/usage-guidelines?tab=code
+declare module "@hashicorp/ember-flight-icons/components/flight-icon" {
+  import Component from "@glimmer/component";
+  import { ComponentLike } from "@glint/template";
 
-import { ComponentLike } from "@glint/template";
+  // https://helios.hashicorp.design/icons/usage-guidelines?tab=code
 
-export type FlightIconComponent = ComponentLike<{
-  Element: SVGElement;
-  Args: {
-    name: string;
-    size?: "16" | "24";
-    color?: string;
-    stretched?: boolean;
-  };
-}>;
+  interface FlightIconComponentSignature {
+    Element: SVGElement;
+    Args: {
+      name: string;
+      size?: "16" | "24";
+      color?: string;
+      stretched?: boolean;
+    };
+  }
+
+  export type FlightIconComponent = ComponentLike<FlightIconComponentSignature>;
+  export default class FlightIcon extends Component<FlightIconComponentSignature> {}
+}


### PR DESCRIPTION
- <strike>Adds the `number` type to the `text` argument of the `Hds::BadgeCount` and `Hds::Badge` Glint types. The docs specify `string` but in reality they both take `any` value; I'm specifying `string | number` as an internal type check.</strike>
- Makes the `FlightIcon` component available in `gts` files. 

