### PR TITLE
Return `undefined` instead of `null` in `get-product-id` files

### DIFF
--- a/web/app/components/doc/thumbnail.ts
+++ b/web/app/components/doc/thumbnail.ts
@@ -24,12 +24,8 @@ export default class DocThumbnailComponent extends Component<DocThumbnailCompone
     return this.args.size === "large";
   }
 
-  protected get productShortName(): string | null {
-    if (this.args.product) {
-      return getProductId(this.args.product);
-    } else {
-      return null;
-    }
+  protected get productShortName(): string | undefined {
+    return getProductId(this.args.product);
   }
 
   protected get isApproved(): boolean {

--- a/web/app/helpers/get-product-id.ts
+++ b/web/app/helpers/get-product-id.ts
@@ -5,12 +5,12 @@ export interface GetProductIDSignature {
   Args: {
     Positional: [string | undefined];
   };
-  Return: string | null;
+  Return: string | undefined;
 }
 
 const getProductIDHelper = helper<GetProductIDSignature>(([productName]) => {
   if (!productName) {
-    return null;
+    return;
   }
   return getProductId(productName);
 });

--- a/web/app/utils/get-product-id.ts
+++ b/web/app/utils/get-product-id.ts
@@ -1,8 +1,6 @@
-export default function getProductId(
-  productName: string | null
-): string | null {
+export default function getProductId(productName?: string) {
   if (!productName) {
-    return null;
+    return;
   }
   let product = productName.toLowerCase();
 
@@ -19,6 +17,6 @@ export default function getProductId(
     case "cloud platform":
       return "hcp";
     default:
-      return null;
+      return;
   }
 }


### PR DESCRIPTION
Changes the `get-product-id` files to return `undefined` instead of `null` as a fallback. This better matches (and thus passes more Glint checks for) receiving component types, which tend to be more efficient as `value?: string` rather than `value?: string | null` 