### PR TITLE
Add `checkmarkPosition` argument to `CheckableItem`

### DIFF
--- a/web/app/components/x/dropdown-list/checkable-item.hbs
+++ b/web/app/components/x/dropdown-list/checkable-item.hbs
@@ -1,17 +1,33 @@
-<FlightIcon
-  data-test-x-dropdown-list-checkable-item-check
-  data-test-is-checked={{@isSelected}}
-  @name="check"
-  class="check mr-2.5 {{if @isSelected 'visible' 'invisible'}}"
-/>
-<div class="x-dropdown-list-item-value">
-  {{@value}}
-</div>
-{{#if @count}}
-  <Hds::BadgeCount
-    data-test-x-dropdown-list-checkable-item-count
-    @text="{{@count}}"
-    @size="small"
-    class="x-dropdown-list-item-count"
+<div
+  data-test-checkable-item
+  class="checkable-item checkmark-position--{{or @checkmarkPosition 'leading'}}
+    flex w-full items-center gap-2.5"
+  ...attributes
+>
+
+  <FlightIcon
+    data-test-x-dropdown-list-checkable-item-check
+    data-test-is-checked={{@isSelected}}
+    @name="check"
+    class="check {{if @isSelected 'visible' 'invisible'}}"
   />
-{{/if}}
+
+  <div data-test-checkable-item-content class="checkable-item-content w-full">
+    {{#if (has-block "default")}}
+      {{yield}}
+    {{else}}
+      <div class="x-dropdown-list-item-value">
+        {{@value}}
+      </div>
+    {{/if}}
+  </div>
+
+  {{#if @count}}
+    <Hds::BadgeCount
+      data-test-x-dropdown-list-checkable-item-count
+      @text="{{@count}}"
+      @size="small"
+      class="x-dropdown-list-item-count checkable-item-count"
+    />
+  {{/if}}
+</div>

--- a/web/app/components/x/dropdown-list/checkable-item.ts
+++ b/web/app/components/x/dropdown-list/checkable-item.ts
@@ -1,10 +1,15 @@
 import Component from "@glimmer/component";
 
+export enum CheckmarkPosition {
+  Leading = "leading",
+  Trailing = "trailing",
+}
+
 export interface XDropdownListCheckableItemComponentArgs {
   value?: string;
   isSelected?: boolean;
   count?: number;
-  checkmarkPosition?: "trailing" | "leading";
+  checkmarkPosition?: `${CheckmarkPosition}`;
 }
 
 interface XDropdownListCheckableItemComponentSignature {

--- a/web/app/components/x/dropdown-list/checkable-item.ts
+++ b/web/app/components/x/dropdown-list/checkable-item.ts
@@ -1,13 +1,18 @@
 import Component from "@glimmer/component";
 
 export interface XDropdownListCheckableItemComponentArgs {
-  value: string;
+  value?: string;
   isSelected?: boolean;
   count?: number;
+  checkmarkPosition?: "trailing" | "leading";
 }
 
 interface XDropdownListCheckableItemComponentSignature {
+  Element: HTMLDivElement;
   Args: XDropdownListCheckableItemComponentArgs;
+  Blocks: {
+    default: [];
+  };
 }
 
 export default class XDropdownListCheckableItemComponent extends Component<XDropdownListCheckableItemComponentSignature> {}

--- a/web/app/styles/components/x/dropdown/list-item.scss
+++ b/web/app/styles/components/x/dropdown/list-item.scss
@@ -3,7 +3,7 @@
 }
 
 .x-dropdown-list-item-link {
-  @apply no-underline flex text-body-200 items-center py-[7px] pl-2.5 pr-8 w-full text-color-foreground-primary;
+  @apply flex w-full items-center py-[7px] pl-2.5 pr-8 text-body-200 text-color-foreground-primary no-underline;
 
   &.is-aria-selected {
     @apply bg-color-foreground-action text-color-foreground-high-contrast outline-none;
@@ -38,4 +38,20 @@
 
 .x-dropdown-list-item-count {
   @apply ml-8 shrink-0;
+}
+
+.checkable-item {
+  &.checkmark-position--trailing {
+    .checkable-item-content {
+      @apply order-1;
+    }
+
+    .checkable-item-count {
+      @apply order-2;
+    }
+
+    .check {
+      @apply order-3;
+    }
+  }
 }

--- a/web/tests/integration/components/x/dropdown-list/checkable-item-test.ts
+++ b/web/tests/integration/components/x/dropdown-list/checkable-item-test.ts
@@ -48,7 +48,8 @@ module("Integration | Component | x/dropdown-list", function (hooks) {
     await render<XDropdownListCheckableItemTestContext>(hbs`
       <X::DropdownList::CheckableItem
         @checkmarkPosition={{this.checkmarkPosition}}
-        @isSelected={{false}}
+        @isSelected={{true}}
+        @count={{1}}
         @value="foo"
       />
     `);
@@ -69,8 +70,8 @@ module("Integration | Component | x/dropdown-list", function (hooks) {
         "can render checkmark in trailing position",
       );
 
-    assert.dom(CONTENT).hasClass("order-1");
-    assert.dom(COUNT).hasClass("order-2");
-    assert.dom(CHECK).hasClass("order-3");
+    assert.dom(CONTENT).hasStyle({ order: "1" });
+    assert.dom(COUNT).hasStyle({ order: "2" });
+    assert.dom(CHECK).hasStyle({ order: "3" });
   });
 });

--- a/web/tests/integration/components/x/dropdown-list/checkable-item-test.ts
+++ b/web/tests/integration/components/x/dropdown-list/checkable-item-test.ts
@@ -2,6 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
 import { TestContext, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
+import { CheckmarkPosition } from "hermes/components/x/dropdown-list/checkable-item";
 
 const ITEM = "[data-test-checkable-item]";
 const CONTENT = "[data-test-checkable-item-content]";
@@ -11,7 +12,7 @@ const COUNT = "[data-test-x-dropdown-list-checkable-item-count]";
 interface XDropdownListCheckableItemTestContext extends TestContext {
   isSelected: boolean;
   count?: number;
-  checkmarkPosition?: "trailing" | "leading";
+  checkmarkPosition?: `${CheckmarkPosition}`;
 }
 
 module("Integration | Component | x/dropdown-list", function (hooks) {

--- a/web/tests/integration/components/x/dropdown-list/checkable-item-test.ts
+++ b/web/tests/integration/components/x/dropdown-list/checkable-item-test.ts
@@ -1,19 +1,27 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
-import { render } from "@ember/test-helpers";
+import { TestContext, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 
-const CHECK_SELECTOR = "[data-test-x-dropdown-list-checkable-item-check]";
-const COUNT_SELECTOR = "[data-test-x-dropdown-list-checkable-item-count]";
+const ITEM = "[data-test-checkable-item]";
+const CONTENT = "[data-test-checkable-item-content]";
+const CHECK = "[data-test-x-dropdown-list-checkable-item-check]";
+const COUNT = "[data-test-x-dropdown-list-checkable-item-count]";
+
+interface XDropdownListCheckableItemTestContext extends TestContext {
+  isSelected: boolean;
+  count?: number;
+  checkmarkPosition?: "trailing" | "leading";
+}
 
 module("Integration | Component | x/dropdown-list", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("it renders as expected", async function (assert) {
+  test("it renders as expected", async function (this: XDropdownListCheckableItemTestContext, assert) {
     this.set("isSelected", false);
-    this.set("count", null);
+    this.set("count", undefined);
 
-    await render(hbs`
+    await render<XDropdownListCheckableItemTestContext>(hbs`
       <X::DropdownList::CheckableItem
         @isSelected={{this.isSelected}}
         @value="foo"
@@ -21,15 +29,47 @@ module("Integration | Component | x/dropdown-list", function (hooks) {
       />
     `);
 
-    assert.dom(CHECK_SELECTOR).hasClass("invisible");
+    assert.dom(CHECK).hasClass("invisible");
     assert.dom(".x-dropdown-list-item-value").hasText("foo");
-    assert.dom(COUNT_SELECTOR).doesNotExist();
+    assert.dom(COUNT).doesNotExist();
 
     this.set("isSelected", true);
 
-    assert.dom(CHECK_SELECTOR).hasClass("visible");
+    assert.dom(CHECK).hasClass("visible");
 
     this.set("count", 1);
-    assert.dom(COUNT_SELECTOR).hasText("1");
+    assert.dom(COUNT).hasText("1");
+  });
+
+  test("it can render the checkmark in a leading or trailing position", async function (this: XDropdownListCheckableItemTestContext, assert) {
+    this.set("checkmarkPosition", undefined);
+
+    await render<XDropdownListCheckableItemTestContext>(hbs`
+      <X::DropdownList::CheckableItem
+        @checkmarkPosition={{this.checkmarkPosition}}
+        @isSelected={{false}}
+        @value="foo"
+      />
+    `);
+
+    assert
+      .dom(ITEM)
+      .hasClass(
+        "checkmark-position--leading",
+        "default checkmark position is leading",
+      );
+
+    this.set("checkmarkPosition", "trailing");
+
+    assert
+      .dom(ITEM)
+      .hasClass(
+        "checkmark-position--trailing",
+        "can render checkmark in trailing position",
+      );
+
+    assert.dom(CONTENT).hasClass("order-1");
+    assert.dom(COUNT).hasClass("order-2");
+    assert.dom(CHECK).hasClass("order-3");
   });
 });


### PR DESCRIPTION
Adds a `checkmarkPosition` argument to the `CheckableItem` component.

Currently the check is hard-coded to the `leading` position.