### PR TITLE
Add 'operator migrate-algolia-to-postgresql' command

### DIFF
--- a/internal/api/v2/approvals.go
+++ b/internal/api/v2/approvals.go
@@ -297,7 +297,7 @@ func ApprovalsHandler(srv server.Server) http.Handler {
 					)
 					return
 				}
-				if err := compareAlgoliaAndDatabaseDocument(
+				if err := CompareAlgoliaAndDatabaseDocument(
 					algoDoc, dbDoc, reviews, srv.Config.DocumentTypes.DocumentType,
 				); err != nil {
 					srv.Logger.Warn(
@@ -593,7 +593,7 @@ func ApprovalsHandler(srv server.Server) http.Handler {
 					)
 					return
 				}
-				if err := compareAlgoliaAndDatabaseDocument(
+				if err := CompareAlgoliaAndDatabaseDocument(
 					algoDoc, dbDoc, reviews, srv.Config.DocumentTypes.DocumentType,
 				); err != nil {
 					srv.Logger.Warn(

--- a/internal/api/v2/documents.go
+++ b/internal/api/v2/documents.go
@@ -276,7 +276,7 @@ func DocumentHandler(srv server.Server) http.Handler {
 					)
 					return
 				}
-				if err := compareAlgoliaAndDatabaseDocument(
+				if err := CompareAlgoliaAndDatabaseDocument(
 					algoDoc, dbDoc, reviews, srv.Config.DocumentTypes.DocumentType,
 				); err != nil {
 					srv.Logger.Warn(
@@ -834,7 +834,7 @@ Hermes
 					)
 					return
 				}
-				if err := compareAlgoliaAndDatabaseDocument(
+				if err := CompareAlgoliaAndDatabaseDocument(
 					algoDoc, dbDoc, reviews, srv.Config.DocumentTypes.DocumentType,
 				); err != nil {
 					srv.Logger.Warn(

--- a/internal/api/v2/drafts.go
+++ b/internal/api/v2/drafts.go
@@ -401,7 +401,7 @@ func DraftsHandler(srv server.Server) http.Handler {
 					)
 					return
 				}
-				if err := compareAlgoliaAndDatabaseDocument(
+				if err := CompareAlgoliaAndDatabaseDocument(
 					algoDoc, dbDoc, reviews, srv.Config.DocumentTypes.DocumentType,
 				); err != nil {
 					srv.Logger.Warn(
@@ -777,7 +777,7 @@ func DraftsDocumentHandler(srv server.Server) http.Handler {
 					)
 					return
 				}
-				if err := compareAlgoliaAndDatabaseDocument(
+				if err := CompareAlgoliaAndDatabaseDocument(
 					algoDoc, dbDoc, reviews, srv.Config.DocumentTypes.DocumentType,
 				); err != nil {
 					srv.Logger.Warn(
@@ -1365,7 +1365,7 @@ func DraftsDocumentHandler(srv server.Server) http.Handler {
 					)
 					return
 				}
-				if err := compareAlgoliaAndDatabaseDocument(
+				if err := CompareAlgoliaAndDatabaseDocument(
 					algoDoc, dbDoc, reviews, srv.Config.DocumentTypes.DocumentType,
 				); err != nil {
 					srv.Logger.Warn(

--- a/internal/api/v2/helpers.go
+++ b/internal/api/v2/helpers.go
@@ -122,10 +122,10 @@ type fakeT struct{}
 
 func (t fakeT) Errorf(string, ...interface{}) {}
 
-// compareAlgoliaAndDatabaseDocument compares data for a document stored in
+// CompareAlgoliaAndDatabaseDocument compares data for a document stored in
 // Algolia and the database to determine any inconsistencies, which are returned
 // back as a (multierror) error.
-func compareAlgoliaAndDatabaseDocument(
+func CompareAlgoliaAndDatabaseDocument(
 	algoDoc map[string]any,
 	dbDoc models.Document,
 	dbDocReviews models.DocumentReviews,

--- a/internal/api/v2/helpers.go
+++ b/internal/api/v2/helpers.go
@@ -174,7 +174,7 @@ func CompareAlgoliaAndDatabaseDocument(
 			result = multierror.Append(result,
 				fmt.Errorf(
 					"docType not equal, algolia=%v, db=%v",
-					algoTitle, dbDocType),
+					algoDocType, dbDocType),
 			)
 		}
 	}

--- a/internal/api/v2/helpers_test.go
+++ b/internal/api/v2/helpers_test.go
@@ -111,6 +111,8 @@ func TestCompareAlgoliaAndDatabaseDocument(t *testing.T) {
 
 		shouldErr   bool
 		errContains string
+		// Use multiErrContains if there are multiple errors expected.
+		multiErrContains []string
 	}{
 		"good": {
 			algoDoc: map[string]any{
@@ -528,6 +530,39 @@ func TestCompareAlgoliaAndDatabaseDocument(t *testing.T) {
 			errContains: "docType not equal",
 		},
 
+		"bad doc number": {
+			algoDoc: map[string]any{
+				"appCreated": true,
+				"docNumber":  "ABC-123",
+				"docType":    "RFC",
+				"createdTime": float64(time.Date(
+					2023, time.April, 5, 1, 0, 0, 0, time.UTC).Unix()),
+				"modifiedTime": float64(time.Date(
+					2023, time.April, 5, 23, 0, 0, 0, time.UTC).Unix()),
+				"owners":  []any{"owner1@hashicorp.com"},
+				"product": "Product1",
+			},
+			dbDoc: models.Document{
+				DocumentNumber: 321,
+				DocumentType: models.DocumentType{
+					Name: "RFC",
+				},
+				Product: models.Product{
+					Name:         "Product1",
+					Abbreviation: "ABC",
+				},
+				DocumentCreatedAt: time.Date(
+					2023, time.April, 5, 1, 0, 0, 0, time.UTC),
+				DocumentModifiedAt: time.Date(
+					2023, time.April, 5, 23, 0, 0, 0, time.UTC),
+				Owner: &models.User{
+					EmailAddress: "owner1@hashicorp.com",
+				},
+			},
+			shouldErr:   true,
+			errContains: "docNumber not equal",
+		},
+
 		"bad appCreated": {
 			algoDoc: map[string]any{
 				"appCreated": false,
@@ -613,6 +648,78 @@ func TestCompareAlgoliaAndDatabaseDocument(t *testing.T) {
 					"approver2@hashicorp.com",
 				},
 				"docNumber": "ABC-123",
+				"createdTime": float64(time.Date(
+					2023, time.April, 5, 1, 0, 0, 0, time.UTC).Unix()),
+				"modifiedTime": float64(time.Date(
+					2023, time.April, 5, 23, 0, 0, 0, time.UTC).Unix()),
+				"owners":  []any{"owner1@hashicorp.com"},
+				"product": "Product1",
+			},
+			dbDoc: models.Document{
+				Title:          "BadTitle",
+				DocumentNumber: 123,
+				Product: models.Product{
+					Name:         "Product1",
+					Abbreviation: "ABC",
+				},
+				DocumentCreatedAt: time.Date(
+					2023, time.April, 5, 1, 0, 0, 0, time.UTC),
+				DocumentModifiedAt: time.Date(
+					2023, time.April, 5, 23, 0, 0, 0, time.UTC),
+				Owner: &models.User{
+					EmailAddress: "owner1@hashicorp.com",
+				},
+				Approvers: []*models.User{
+					{
+						EmailAddress: "badapprover1@hashicorp.com",
+					},
+					{
+						EmailAddress: "badapprover2@hashicorp.com",
+					},
+				},
+			},
+			shouldErr:   true,
+			errContains: "approvers not equal",
+		},
+
+		"approvers exist only in Algolia object": {
+			algoDoc: map[string]any{
+				"appCreated": true,
+				"approvers": []any{
+					"approver1@hashicorp.com",
+					"approver2@hashicorp.com",
+				},
+				"docNumber": "ABC-123",
+				"createdTime": float64(time.Date(
+					2023, time.April, 5, 1, 0, 0, 0, time.UTC).Unix()),
+				"modifiedTime": float64(time.Date(
+					2023, time.April, 5, 23, 0, 0, 0, time.UTC).Unix()),
+				"owners":  []any{"owner1@hashicorp.com"},
+				"product": "Product1",
+			},
+			dbDoc: models.Document{
+				Title:          "BadTitle",
+				DocumentNumber: 123,
+				Product: models.Product{
+					Name:         "Product1",
+					Abbreviation: "ABC",
+				},
+				DocumentCreatedAt: time.Date(
+					2023, time.April, 5, 1, 0, 0, 0, time.UTC),
+				DocumentModifiedAt: time.Date(
+					2023, time.April, 5, 23, 0, 0, 0, time.UTC),
+				Owner: &models.User{
+					EmailAddress: "owner1@hashicorp.com",
+				},
+			},
+			shouldErr:   true,
+			errContains: "approvers not equal",
+		},
+
+		"approvers exist only in database record": {
+			algoDoc: map[string]any{
+				"appCreated": true,
+				"docNumber":  "ABC-123",
 				"createdTime": float64(time.Date(
 					2023, time.April, 5, 1, 0, 0, 0, time.UTC).Unix()),
 				"modifiedTime": float64(time.Date(
@@ -811,6 +918,55 @@ func TestCompareAlgoliaAndDatabaseDocument(t *testing.T) {
 			errContains: "custom field currentVersion not equal",
 		},
 
+		"bad mismatched string custom fields currentVersion and prd": {
+			algoDoc: map[string]any{
+				"appCreated": true,
+				"docNumber":  "ABC-123",
+				"createdTime": float64(time.Date(
+					2023, time.April, 5, 1, 0, 0, 0, time.UTC).Unix()),
+				"currentVersion": "1",
+				"docType":        "RFC",
+				"modifiedTime": float64(time.Date(
+					2023, time.April, 5, 23, 0, 0, 0, time.UTC).Unix()),
+				"owners":  []any{"owner1@hashicorp.com"},
+				"product": "Product1",
+				"prd":     "PRD1",
+			},
+			dbDoc: models.Document{
+				DocumentType: models.DocumentType{
+					Name: "RFC",
+				},
+				DocumentNumber: 123,
+				Product: models.Product{
+					Name:         "Product1",
+					Abbreviation: "ABC",
+				},
+				CustomFields: []*models.DocumentCustomField{
+					{
+						DocumentTypeCustomField: models.DocumentTypeCustomField{
+							Name: "Current Version",
+							DocumentType: models.DocumentType{
+								Name: "RFC",
+							},
+						},
+						Value: "PRD1",
+					},
+				},
+				DocumentCreatedAt: time.Date(
+					2023, time.April, 5, 1, 0, 0, 0, time.UTC),
+				DocumentModifiedAt: time.Date(
+					2023, time.April, 5, 23, 0, 0, 0, time.UTC),
+				Owner: &models.User{
+					EmailAddress: "owner1@hashicorp.com",
+				},
+			},
+			shouldErr: true,
+			multiErrContains: []string{
+				"custom field currentVersion not equal",
+				"custom field prd not equal",
+			},
+		},
+
 		"bad people custom field stakeholders": {
 			algoDoc: map[string]any{
 				"appCreated": true,
@@ -826,6 +982,86 @@ func TestCompareAlgoliaAndDatabaseDocument(t *testing.T) {
 					"stakeholder1@hashicorp.com",
 					"stakeholder2@hashicorp.com",
 				},
+			},
+			dbDoc: models.Document{
+				DocumentType: models.DocumentType{
+					Name: "RFC",
+				},
+				DocumentNumber: 123,
+				Product: models.Product{
+					Name:         "Product1",
+					Abbreviation: "ABC",
+				},
+				CustomFields: []*models.DocumentCustomField{
+					{
+						DocumentTypeCustomField: models.DocumentTypeCustomField{
+							Name: "Stakeholders",
+							DocumentType: models.DocumentType{
+								Name: "RFC",
+							},
+						},
+						Value: `["stakeholder1@hashicorp.com","badstakeholder2@hashicorp.com"]`,
+					},
+				},
+				DocumentCreatedAt: time.Date(
+					2023, time.April, 5, 1, 0, 0, 0, time.UTC),
+				DocumentModifiedAt: time.Date(
+					2023, time.April, 5, 23, 0, 0, 0, time.UTC),
+				Owner: &models.User{
+					EmailAddress: "owner1@hashicorp.com",
+				},
+			},
+			shouldErr:   true,
+			errContains: "custom field stakeholders not equal",
+		},
+
+		"bad people custom field stakeholders only exists in Algolia": {
+			algoDoc: map[string]any{
+				"appCreated": true,
+				"docNumber":  "ABC-123",
+				"createdTime": float64(time.Date(
+					2023, time.April, 5, 1, 0, 0, 0, time.UTC).Unix()),
+				"docType": "RFC",
+				"modifiedTime": float64(time.Date(
+					2023, time.April, 5, 23, 0, 0, 0, time.UTC).Unix()),
+				"owners":  []any{"owner1@hashicorp.com"},
+				"product": "Product1",
+				"stakeholders": []any{
+					"stakeholder1@hashicorp.com",
+				},
+			},
+			dbDoc: models.Document{
+				DocumentType: models.DocumentType{
+					Name: "RFC",
+				},
+				DocumentNumber: 123,
+				Product: models.Product{
+					Name:         "Product1",
+					Abbreviation: "ABC",
+				},
+				DocumentCreatedAt: time.Date(
+					2023, time.April, 5, 1, 0, 0, 0, time.UTC),
+				DocumentModifiedAt: time.Date(
+					2023, time.April, 5, 23, 0, 0, 0, time.UTC),
+				Owner: &models.User{
+					EmailAddress: "owner1@hashicorp.com",
+				},
+			},
+			shouldErr:   true,
+			errContains: "custom field stakeholders not equal",
+		},
+
+		"bad people custom field stakeholders only exists in database": {
+			algoDoc: map[string]any{
+				"appCreated": true,
+				"docNumber":  "ABC-123",
+				"createdTime": float64(time.Date(
+					2023, time.April, 5, 1, 0, 0, 0, time.UTC).Unix()),
+				"docType": "RFC",
+				"modifiedTime": float64(time.Date(
+					2023, time.April, 5, 23, 0, 0, 0, time.UTC).Unix()),
+				"owners":  []any{"owner1@hashicorp.com"},
+				"product": "Product1",
 			},
 			dbDoc: models.Document{
 				DocumentType: models.DocumentType{
@@ -1023,6 +1259,10 @@ func TestCompareAlgoliaAndDatabaseDocument(t *testing.T) {
 							Type: "string",
 						},
 						{
+							Name: "PRD",
+							Type: "string",
+						},
+						{
 							Name: "Stakeholders",
 							Type: "people",
 						},
@@ -1030,15 +1270,21 @@ func TestCompareAlgoliaAndDatabaseDocument(t *testing.T) {
 				},
 			}
 
-			if err := compareAlgoliaAndDatabaseDocument(
+			err := CompareAlgoliaAndDatabaseDocument(
 				c.algoDoc, c.dbDoc, c.dbDocReviews, docTypes,
-			); err != nil {
-				if c.shouldErr {
-					require.Error(err)
+			)
+			if c.shouldErr {
+				if len(c.multiErrContains) > 0 {
+					for _, m := range c.multiErrContains {
+						assert.ErrorContains(err, m)
+					}
+				} else if c.errContains != "" {
 					assert.ErrorContains(err, c.errContains)
 				} else {
-					require.NoError(err)
+					require.Error(err)
 				}
+			} else {
+				require.NoError(err)
 			}
 		})
 	}

--- a/internal/api/v2/helpers_test.go
+++ b/internal/api/v2/helpers_test.go
@@ -284,6 +284,37 @@ func TestCompareAlgoliaAndDatabaseDocument(t *testing.T) {
 			},
 		},
 
+		"good legacy doc number without three digit padding": {
+			algoDoc: map[string]any{
+				"appCreated": true,
+				"docNumber":  "ABC-23",
+				"docType":    "RFC",
+				"createdTime": float64(time.Date(
+					2023, time.April, 5, 1, 0, 0, 0, time.UTC).Unix()),
+				"modifiedTime": float64(time.Date(
+					2023, time.April, 5, 23, 0, 0, 0, time.UTC).Unix()),
+				"owners":  []any{"owner1@hashicorp.com"},
+				"product": "Product1",
+			},
+			dbDoc: models.Document{
+				DocumentNumber: 23,
+				DocumentType: models.DocumentType{
+					Name: "RFC",
+				},
+				Product: models.Product{
+					Name:         "Product1",
+					Abbreviation: "ABC",
+				},
+				DocumentCreatedAt: time.Date(
+					2023, time.April, 5, 1, 0, 0, 0, time.UTC),
+				DocumentModifiedAt: time.Date(
+					2023, time.April, 5, 23, 0, 0, 0, time.UTC),
+				Owner: &models.User{
+					EmailAddress: "owner1@hashicorp.com",
+				},
+			},
+		},
+
 		"good with different order of slice and map fields": {
 			algoDoc: map[string]any{
 				"appCreated": true,

--- a/internal/api/v2/reviews.go
+++ b/internal/api/v2/reviews.go
@@ -724,7 +724,7 @@ func ReviewsHandler(srv server.Server) http.Handler {
 					)
 					return
 				}
-				if err := compareAlgoliaAndDatabaseDocument(
+				if err := CompareAlgoliaAndDatabaseDocument(
 					algoDoc, dbDoc, reviews, srv.Config.DocumentTypes.DocumentType,
 				); err != nil {
 					srv.Logger.Warn(

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp-forge/hermes/internal/cmd/base"
 	"github.com/hashicorp-forge/hermes/internal/cmd/commands/indexer"
+	"github.com/hashicorp-forge/hermes/internal/cmd/commands/operator"
 	"github.com/hashicorp-forge/hermes/internal/cmd/commands/server"
 	"github.com/hashicorp-forge/hermes/internal/cmd/commands/version"
 )
@@ -19,6 +20,16 @@ func initCommands(log hclog.Logger, ui cli.Ui) {
 	Commands = map[string]cli.CommandFactory{
 		"indexer": func() (cli.Command, error) {
 			return &indexer.Command{
+				Command: b,
+			}, nil
+		},
+		"operator": func() (cli.Command, error) {
+			return &operator.Command{
+				Command: b,
+			}, nil
+		},
+		"operator migrate-algolia-to-postgresql": func() (cli.Command, error) {
+			return &operator.MigrateAlgoliaToPostgreSQLCommand{
 				Command: b,
 			}, nil
 		},

--- a/internal/cmd/commands/operator/migrate_algolia_to_postgresql.go
+++ b/internal/cmd/commands/operator/migrate_algolia_to_postgresql.go
@@ -1,0 +1,436 @@
+package operator
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	apiv2 "github.com/hashicorp-forge/hermes/internal/api/v2"
+	"github.com/hashicorp-forge/hermes/internal/cmd/base"
+	"github.com/hashicorp-forge/hermes/internal/config"
+	"github.com/hashicorp-forge/hermes/internal/db"
+	"github.com/hashicorp-forge/hermes/pkg/algolia"
+	"github.com/hashicorp-forge/hermes/pkg/document"
+	"github.com/hashicorp-forge/hermes/pkg/models"
+	"github.com/hashicorp/go-hclog"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+type MigrateAlgoliaToPostgreSQLCommand struct {
+	*base.Command
+
+	flagAutoApprove bool
+	flagConfig      string
+	flagDryRun      bool
+	flagVerbose     bool
+}
+
+// migrator contains the migrator configuration.
+type migrator struct {
+	Config         *config.Config
+	Database       *gorm.DB
+	DocsCreated    *int
+	DocsUpdated    *int
+	DocsWithErrors *[]string
+	DryRun         bool
+	Logger         hclog.Logger
+	Verbose        bool
+}
+
+func (c *MigrateAlgoliaToPostgreSQLCommand) Synopsis() string {
+	return "Migrate Algolia data to PostgreSQL"
+}
+
+func (c *MigrateAlgoliaToPostgreSQLCommand) Help() string {
+	return `Usage: hermes operator migrate-algolia-to-postgresql
+
+  This command migrates document data from Algolia to PostgreSQL.` +
+		c.Flags().Help()
+}
+
+func (c *MigrateAlgoliaToPostgreSQLCommand) Flags() *base.FlagSet {
+	f := base.NewFlagSet(
+		flag.NewFlagSet("migrate-algolia-to-postgresql", flag.ExitOnError))
+
+	f.BoolVar(
+		&c.flagAutoApprove, "auto-approve", false,
+		"Skip interactive approval for updating documents.",
+	)
+	f.StringVar(
+		&c.flagConfig, "config", "", "(Required) Path to Hermes config file",
+	)
+	f.BoolVar(
+		&c.flagDryRun, "dry-run", false,
+		"Only print the changes to PostgreSQL data instead of updating the data.",
+	)
+	f.BoolVar(
+		&c.flagVerbose, "verbose", false,
+		"Print extra information.",
+	)
+
+	return f
+}
+
+func (c *MigrateAlgoliaToPostgreSQLCommand) Run(args []string) int {
+	logger, ui := c.Log, c.UI
+
+	// Parse flags.
+	flags := c.Flags()
+	if err := flags.Parse(args); err != nil {
+		ui.Error(fmt.Sprintf("error parsing flags: %v", err))
+		return 1
+	}
+
+	// Validate flags.
+	if c.flagConfig == "" {
+		ui.Error("config flag is required")
+		return 1
+	}
+
+	// Parse configuration.
+	cfg, err := config.NewConfig(c.flagConfig)
+	if err != nil {
+		ui.Error(fmt.Sprintf("error parsing config file: %v", err))
+		return 1
+	}
+
+	// Validate configuration.
+	if err := validation.ValidateStruct(cfg,
+		validation.Field(&cfg.Algolia, validation.Required),
+	); err != nil {
+		ui.Error(fmt.Sprintf("error validating configuration: %v", err))
+		return 1
+	}
+	if err := validation.ValidateStruct(cfg.Algolia,
+		validation.Field(&cfg.Algolia.ApplicationID, validation.Required),
+		validation.Field(&cfg.Algolia.DocsIndexName, validation.Required),
+		validation.Field(&cfg.Algolia.DraftsIndexName, validation.Required),
+		validation.Field(&cfg.Algolia.WriteAPIKey, validation.Required),
+	); err != nil {
+		ui.Error(fmt.Sprintf("error validating configuration: %v", err))
+		return 1
+	}
+
+	// Initialize Algolia client.
+	// Note: Algolia requires a write API key to browse objects for...reasons.
+	algo, err := algolia.New(cfg.Algolia)
+	if err != nil {
+		ui.Error(fmt.Sprintf("error initializing Algolia search client: %v", err))
+		return 1
+	}
+
+	// Initialize database.
+	if val, ok := os.LookupEnv("HERMES_SERVER_POSTGRES_PASSWORD"); ok {
+		cfg.Postgres.Password = val
+	}
+	db, err := db.NewDB(*cfg.Postgres)
+	if err != nil {
+		ui.Error(fmt.Sprintf("error initializing database: %v", err))
+		return 1
+	}
+	// Create GORM-compatible logger.
+	stdLogger := logger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	})
+	// Ignore "record not found" errors.
+	db = db.Session(&gorm.Session{Logger: gormlogger.New(
+		stdLogger,
+		gormlogger.Config{IgnoreRecordNotFoundError: true},
+	)})
+
+	// If dry run is false, get confirmation that it is okay to update data in
+	// PostgreSQL.
+	if !c.flagDryRun && !c.flagAutoApprove {
+		ui.Info("This will update records for all documents in PostgreSQL if they" +
+			" differ from the data in Algolia.")
+		ask, err := ui.Ask("Do you want to continue? (only \"yes\" will continue)")
+		if err != nil || ask != "yes" {
+			ui.Info("No \"yes\" confirmation, so exiting...")
+			return 0
+		}
+	}
+
+	// Create variables used to print results at the end.
+	docsCreated := new(int)
+	docsUpdated := new(int)
+	docsWithErrors := &[]string{}
+
+	// Create migrator.
+	migrator := &migrator{
+		Config:         cfg,
+		Database:       db,
+		DocsCreated:    docsCreated,
+		DocsUpdated:    docsUpdated,
+		DocsWithErrors: docsWithErrors,
+		DryRun:         c.flagDryRun,
+		Logger:         logger,
+		Verbose:        c.flagVerbose,
+	}
+
+	start := time.Now()
+
+	// Migrate docs index.
+	docsIterator, err := algo.Docs.BrowseObjects()
+	if err != nil {
+		logger.Error("error getting docs Algolia object iterator",
+			"error", err,
+		)
+		return 1
+	}
+	migrateIndex(migrator, docsIterator)
+
+	// Migrate drafts index.
+	draftsIterator, err := algo.Drafts.BrowseObjects()
+	if err != nil {
+		logger.Error("error getting drafts Algolia object iterator",
+			"error", err,
+		)
+		return 1
+	}
+	migrateIndex(migrator, draftsIterator)
+
+	// Print results.
+	duration := time.Since(start)
+	if !c.flagDryRun {
+		fmt.Println("\nResults:")
+	} else {
+		fmt.Println("\nResults (dry run):")
+	}
+	fmt.Printf("  %d documents created\n", *docsCreated)
+	fmt.Printf("  %d documents updated\n", *docsUpdated)
+	fmt.Printf("  %d documents with errors\n", len(*docsWithErrors))
+	fmt.Printf("\n\nCompleted in: %s\n", duration)
+	fmt.Printf("\n\nDocuments with errors:\n%v\n", *docsWithErrors)
+
+	return 0
+}
+
+// migrateIndex migrates all documents in an Algolia docs or drafts index.
+func migrateIndex(
+	m *migrator,
+	it *search.ObjectIterator,
+) {
+	for {
+		// Get base document object from Algolia.
+		obj := map[string]interface{}{}
+		_, err := it.Next(&obj)
+		if err != nil {
+			if err == io.EOF {
+				break
+			} else {
+				m.Logger.Error("error decoding next object",
+					"error", err,
+				)
+				os.Exit(1)
+			}
+		}
+
+		// Convert Algolia object to a document.
+		doc, err := document.NewFromAlgoliaObject(
+			obj, m.Config.DocumentTypes.DocumentType)
+		if err != nil {
+			m.Logger.Error("error converting Algolia object to a document",
+				"error", err,
+				"document_id", obj["objectID"],
+			)
+			*m.DocsWithErrors = append(*m.DocsWithErrors, doc.ObjectID)
+			continue
+		}
+
+		// Convert document to a document database model.
+		dbDoc, reviews, err := doc.ToDatabaseModels(
+			m.Config.DocumentTypes.DocumentType, m.Config.Products.Product)
+		if err != nil {
+			m.Logger.Error("error converting document to database models",
+				"error", err,
+				"document_id", doc.ObjectID,
+			)
+			*m.DocsWithErrors = append(*m.DocsWithErrors, doc.ObjectID)
+			continue
+		}
+
+		// Check if document already exists in the database.
+		existingDoc := models.Document{
+			GoogleFileID: dbDoc.GoogleFileID,
+		}
+		err = existingDoc.Get(m.Database)
+		if err != nil {
+			// If the document doesn't exist, create it.
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				// Only save document if the -dry-run flag is not true.
+				if !m.DryRun {
+					// Save the document in a transaction so we rollback on any errors.
+					if err := m.Database.Transaction(func(tx *gorm.DB) error {
+						if err = dbDoc.Create(tx); err != nil {
+							return fmt.Errorf("error creating document in database: %w", err)
+						}
+
+						// Create reviews.
+						for _, dr := range reviews {
+							if err := dr.Update(tx); err != nil {
+								return fmt.Errorf("error upserting document review: %w", err)
+							}
+						}
+
+						return nil
+					}); err != nil {
+						m.Logger.Error("error creating document",
+							"error", err,
+						)
+						*m.DocsWithErrors = append(*m.DocsWithErrors, dbDoc.GoogleFileID)
+						continue
+					}
+
+					*m.DocsCreated += 1
+					m.Logger.Info("document created",
+						"document_id", doc.ObjectID,
+					)
+				} else {
+					*m.DocsCreated += 1
+
+					logArgs := []any{"document_id", dbDoc.GoogleFileID}
+					// Log additional document information if the verbose flag is true.
+					if m.Verbose {
+						if err == nil {
+							logArgs = append(logArgs,
+								"title", doc.Title,
+								"summary", doc.Summary,
+								"owners", doc.Owners,
+								"status", doc.Status,
+								"product", doc.Product,
+							)
+						}
+					}
+					m.Logger.Info("would have created document",
+						logArgs...,
+					)
+				}
+			} else {
+				// We received an error getting the document.
+				m.Logger.Error("error getting document in database",
+					"error", err,
+					"document_id", doc.ObjectID,
+				)
+				*m.DocsWithErrors = append(*m.DocsWithErrors, dbDoc.GoogleFileID)
+				continue
+			}
+		} else {
+			// There was no error getting the document so it already exists.
+
+			// If the document modified time is later in the database, replace the
+			// Algolia object with that so we effectively ignore it.
+			if existingDoc.DocumentModifiedAt.After(time.Unix(doc.ModifiedTime, 0)) {
+				// Algolia infers these values as float64 for some reason.
+				obj["modifiedTime"] = float64(existingDoc.DocumentModifiedAt.Unix())
+
+				// Also make sure that we don't replace it in the database.
+				dbDoc.DocumentModifiedAt = existingDoc.DocumentModifiedAt
+			}
+
+			// Get all reviews for the document.
+			var cmpReviews models.DocumentReviews
+			if err := cmpReviews.Find(m.Database, models.DocumentReview{
+				Document: models.Document{
+					GoogleFileID: doc.ObjectID,
+				},
+			}); err != nil {
+				m.Logger.Error(
+					"error getting reviews for document for data comparison",
+					"error", err,
+					"document_id", doc.ObjectID,
+				)
+				*m.DocsWithErrors = append(*m.DocsWithErrors, dbDoc.GoogleFileID)
+				continue
+			}
+
+			// Compare documents.
+			docsDiffErr := apiv2.CompareAlgoliaAndDatabaseDocument(
+				obj, existingDoc, cmpReviews, m.Config.DocumentTypes.DocumentType,
+			)
+
+			if docsDiffErr != nil {
+				// Only actually save document if the -dry-run flag is not true.
+				if !m.DryRun {
+					// Save the document in a transaction so we rollback on any errors.
+					if err := m.Database.Transaction(func(tx *gorm.DB) error {
+						// Upsert document.
+						if err = dbDoc.Upsert(tx); err != nil {
+							return fmt.Errorf("error upserting document: %w", err)
+						}
+
+						// Find all file revisions for the document.
+						var dbFileRevs models.DocumentFileRevisions
+						if err := dbFileRevs.Find(
+							tx, models.Document{GoogleFileID: doc.ObjectID},
+						); err != nil {
+							return fmt.Errorf("error finding all file revisions: %w", err)
+						}
+
+						// Create file revisions for any that don't exist.
+						for revID, revName := range doc.FileRevisions {
+							frExists := false
+							for _, fr := range dbFileRevs {
+								if fr.GoogleDriveFileRevisionID == revID && fr.Name == revName {
+									frExists = true
+									break
+								}
+							}
+							if !frExists {
+								fr := models.DocumentFileRevision{
+									Document: models.Document{
+										GoogleFileID: doc.ObjectID,
+									},
+									GoogleDriveFileRevisionID: revID,
+									Name:                      revName,
+								}
+								if err := fr.Create(tx); err != nil {
+									return fmt.Errorf("error creating new file revision: %w", err)
+								}
+							}
+						}
+
+						// Upsert document reviews.
+						for _, dr := range reviews {
+							if err := dr.Update(tx); err != nil {
+								return fmt.Errorf("error upserting document review: %w", err)
+							}
+						}
+
+						return nil
+					}); err != nil {
+						m.Logger.Error("error saving document",
+							"error", err,
+							"document_id", doc.ObjectID,
+						)
+						*m.DocsWithErrors = append(*m.DocsWithErrors, dbDoc.GoogleFileID)
+						continue
+					}
+
+					*m.DocsUpdated += 1
+					m.Logger.Info("document updated",
+						"document_id", doc.ObjectID,
+						"differences", docsDiffErr,
+					)
+				} else {
+					*m.DocsUpdated += 1
+					m.Logger.Info("would have updated document",
+						"document_id", doc.ObjectID,
+						"differences", docsDiffErr,
+					)
+				}
+			} else {
+				if m.Verbose {
+					m.Logger.Info("document contains the same data",
+						"document_id", doc.ObjectID,
+					)
+				}
+			}
+		}
+	}
+}

--- a/internal/cmd/commands/operator/operator.go
+++ b/internal/cmd/commands/operator/operator.go
@@ -1,0 +1,24 @@
+package operator
+
+import (
+	"github.com/hashicorp-forge/hermes/internal/cmd/base"
+	"github.com/mitchellh/cli"
+)
+
+type Command struct {
+	*base.Command
+}
+
+func (c *Command) Synopsis() string {
+	return "Perform operator-specific tasks"
+}
+
+func (c *Command) Help() string {
+	return `Usage: hermes operator <subcommand> [options] [args]
+
+  This command groups subcommands for operators interacting with Hermes.`
+}
+
+func (c *Command) Run(args []string) int {
+	return cli.RunResultHelp
+}

--- a/pkg/models/document.go
+++ b/pkg/models/document.go
@@ -493,6 +493,14 @@ func (d *Document) createAssocations(db *gorm.DB) error {
 	}
 	d.Contributors = contributors
 
+	// Get document type if DocumentTypeID is not set.
+	if d.DocumentTypeID == 0 && d.DocumentType.Name != "" {
+		if err := d.DocumentType.Get(db); err != nil {
+			return fmt.Errorf("error getting document type: %w", err)
+		}
+		d.DocumentTypeID = d.DocumentType.ID
+	}
+
 	// Find or create owner.
 	if d.Owner != nil && d.Owner.EmailAddress != "" {
 		if err := d.Owner.FirstOrCreate(db); err != nil {


### PR DESCRIPTION
This PR adds a new `hermes operator migrate-algolia-to-postgresql` command that migrates all data from Algolia to PostgreSQL. In v1 of the API, Algolia was used as the source of truth, but this will change to PostgreSQL for all non-search data in v2 of the API (which is currently behind a feature flag) — this command enables a migration path for v1 to v2.

### New commands:

```
$ hermes operator -help
Usage: hermes operator <subcommand> [options] [args]

  This command groups subcommands for operators interacting with Hermes.

Subcommands:
    migrate-algolia-to-postgresql    Migrate Algolia data to PostgreSQL
```

```
$ hermes operator migrate-algolia-to-postgresql -help
Usage: hermes operator migrate-algolia-to-postgresql

  This command migrates document data from Algolia to PostgreSQL.

Command Options:
  -auto-approve
    	Skip interactive approval for updating documents.
  -config string
    	(Required) Path to Hermes config file
  -dry-run
    	Only print the changes to PostgreSQL data instead of updating the data.
  -verbose
    	Print extra information.
```