### PR TITLE
Backport API helper changes from v2 to v1

### DIFF
--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -174,7 +174,7 @@ func compareAlgoliaAndDatabaseDocument(
 			result = multierror.Append(result,
 				fmt.Errorf(
 					"docType not equal, algolia=%v, db=%v",
-					algoTitle, dbDocType),
+					algoDocType, dbDocType),
 			)
 		}
 	}
@@ -190,16 +190,28 @@ func compareAlgoliaAndDatabaseDocument(
 		re := regexp.MustCompile(`-\?\?\?$`)
 		algoDocNumber = re.ReplaceAllString(algoDocNumber, "-000")
 
-		// Note that we pad the database document number to three digits here like
-		// we do when assigning a document number when a doc review is requested.
-		dbDocNumber := fmt.Sprintf(
-			"%s-%03d", dbDoc.Product.Abbreviation, dbDoc.DocumentNumber)
+		var dbDocNumber string
+		// If document number in Algolia isn't empty, build the database document
+		// number. If it is empty, we expect the database document number to be
+		// empty too.
+		if algoDocNumber != "" {
+			// Note that we pad the database document number to three digits here like
+			// we do when assigning a document number when a doc review is requested.
+			dbDocNumber = fmt.Sprintf(
+				"%s-%03d", dbDoc.Product.Abbreviation, dbDoc.DocumentNumber)
+		}
 		if algoDocNumber != dbDocNumber {
-			result = multierror.Append(result,
-				fmt.Errorf(
-					"docNumber not equal, algolia=%v, db=%v",
-					algoDocNumber, dbDocNumber),
-			)
+			// Some legacy documents may not have the three digit number padding so
+			// check that too.
+			dbDocNumberNoPadding := fmt.Sprintf(
+				"%s-%d", dbDoc.Product.Abbreviation, dbDoc.DocumentNumber)
+			if algoDocNumber != dbDocNumberNoPadding {
+				result = multierror.Append(result,
+					fmt.Errorf(
+						"docNumber not equal, algolia=%v, db=%v",
+						algoDocNumber, dbDocNumber),
+				)
+			}
 		}
 	}
 
@@ -270,7 +282,9 @@ func compareAlgoliaAndDatabaseDocument(
 			dbChangesRequestedBy = append(dbChangesRequestedBy, r.User.EmailAddress)
 		}
 	}
-	if !assert.ElementsMatch(fakeT{}, algoChangesRequestedBy, dbChangesRequestedBy) {
+	if !assert.ElementsMatch(
+		fakeT{}, algoChangesRequestedBy, dbChangesRequestedBy,
+	) {
 		result = multierror.Append(result,
 			fmt.Errorf(
 				"changesRequestedBy not equal, algolia=%v, db=%v",
@@ -328,17 +342,19 @@ func compareAlgoliaAndDatabaseDocument(
 							result, fmt.Errorf(
 								"error getting custom field (%s) value: %w", algoCFName, err))
 					} else {
+						var dbCFVal string
 						for _, c := range dbDoc.CustomFields {
 							if c.DocumentTypeCustomField.Name == cf.Name {
-								if algoCFVal != c.Value {
-									result = multierror.Append(result,
-										fmt.Errorf(
-											"custom field %s not equal, algolia=%v, db=%v",
-											algoCFName, algoCFVal, c.Value),
-									)
-								}
+								dbCFVal = c.Value
 								break
 							}
+						}
+						if algoCFVal != dbCFVal {
+							result = multierror.Append(result,
+								fmt.Errorf(
+									"custom field %s not equal, algolia=%v, db=%v",
+									algoCFName, algoCFVal, dbCFVal),
+							)
 						}
 					}
 				case "people":
@@ -348,11 +364,13 @@ func compareAlgoliaAndDatabaseDocument(
 							result, fmt.Errorf(
 								"error getting custom field (%s) value: %w", algoCFName, err))
 					} else {
+						var dbCFVal []string
 						for _, c := range dbDoc.CustomFields {
 							if c.DocumentTypeCustomField.Name == cf.Name {
 								// Unmarshal person custom field value to string slice.
-								var dbCFVal []string
-								if err := json.Unmarshal([]byte(c.Value), &dbCFVal); err != nil {
+								if err := json.Unmarshal(
+									[]byte(c.Value), &dbCFVal,
+								); err != nil {
 									result = multierror.Append(result,
 										fmt.Errorf(
 											"error unmarshaling custom field %s to string slice",
@@ -360,15 +378,15 @@ func compareAlgoliaAndDatabaseDocument(
 									)
 								}
 
-								if !assert.ElementsMatch(fakeT{}, algoCFVal, dbCFVal) {
-									result = multierror.Append(result,
-										fmt.Errorf(
-											"custom field %s not equal, algolia=%v, db=%v",
-											algoCFName, algoCFVal, dbCFVal),
-									)
-								}
 								break
 							}
+						}
+						if !assert.ElementsMatch(fakeT{}, algoCFVal, dbCFVal) {
+							result = multierror.Append(result,
+								fmt.Errorf(
+									"custom field %s not equal, algolia=%v, db=%v",
+									algoCFName, algoCFVal, dbCFVal),
+							)
 						}
 					}
 				default:
@@ -429,21 +447,19 @@ func compareAlgoliaAndDatabaseDocument(
 		result = multierror.Append(
 			result, fmt.Errorf("error getting owners value: %w", err))
 	} else {
-		var dbOwner string
+		var algoOwner, dbOwner string
 		if dbDoc.Owner != nil {
 			dbOwner = dbDoc.Owner.EmailAddress
 		}
 		if len(algoOwners) > 0 {
-			if algoOwners[0] != dbOwner {
-				result = multierror.Append(result,
-					fmt.Errorf(
-						"owners not equal, algolia=%#v, db=%#v",
-						algoOwners, dbOwner),
-				)
-			}
-		} else {
-			result = multierror.Append(
-				result, fmt.Errorf("owners in Algolia was length %d", len(algoOwners)))
+			algoOwner = algoOwners[0]
+		}
+		if algoOwner != dbOwner {
+			result = multierror.Append(result,
+				fmt.Errorf(
+					"owners not equal, algolia=%#v, db=%#v",
+					algoOwner, dbOwner),
+			)
 		}
 	}
 
@@ -480,6 +496,12 @@ func compareAlgoliaAndDatabaseDocument(
 		case models.ObsoleteDocumentStatus:
 			dbStatus = "Obsolete"
 		}
+
+		// Standardize on "In-Review" Algolia status for the sake of comparison.
+		if algoStatus == "In Review" {
+			algoStatus = "In-Review"
+		}
+
 		if algoStatus != dbStatus {
 			result = multierror.Append(result,
 				fmt.Errorf(


### PR DESCRIPTION
This PR backports updates to API helpers in #400 from v2 to v1. In particular this fixes some bugs around comparing data between Algolia and PostgreSQL.