### PR TITLE
Make sure document_number is not NULL when getting latest product doc…

### DIFF
--- a/pkg/models/document.go
+++ b/pkg/models/document.go
@@ -260,6 +260,7 @@ func GetLatestProductNumber(db *gorm.DB,
 			DocumentTypeID: dt.ID,
 			ProductID:      p.ID,
 		}).
+		Where("document_number IS NOT NULL").
 		Order("document_number desc").
 		First(&d).
 		Error; err != nil {


### PR DESCRIPTION
…ument number

This PR fixes a bug where NULL values for `document_number` will always cause new published documents for a product to get a document number of `001`.