### PR TITLE
Fix panic when document has no owners

### DIFF
--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -346,7 +346,11 @@ func NewFromDatabaseModel(
 	doc.ModifiedTime = model.DocumentModifiedAt.Unix()
 
 	// Owners.
-	doc.Owners = []string{model.Owner.EmailAddress}
+	if model.Owner != nil {
+		doc.Owners = []string{model.Owner.EmailAddress}
+	} else {
+		doc.Owners = []string{}
+	}
 
 	// Note: OwnerPhotos is not stored in the database.
 


### PR DESCRIPTION
This PR fixes a panic in v2 of the API for documents that do not have an owner.