### PR TITLE
Fix owner photo bug for v2 drafts API

### DIFF
--- a/internal/api/v2/documents.go
+++ b/internal/api/v2/documents.go
@@ -151,18 +151,19 @@ func DocumentHandler(srv server.Server) http.Handler {
 
 			// Get owner photo by searching Google Workspace directory.
 			if len(doc.Owners) > 0 {
-				people, err := srv.GWService.SearchPeople(doc.Owners[0], "photos")
+				ppl, err := srv.GWService.SearchPeople(doc.Owners[0], "photos")
 				if err != nil {
-					srv.Logger.Error("error searching directory for person",
+					srv.Logger.Error("error searching directory for owner",
 						"error", err,
 						"method", r.Method,
 						"path", r.URL.Path,
+						"doc_id", docID,
 						"person", doc.Owners[0],
 					)
 				}
-				if len(people) > 0 {
-					if len(people[0].Photos) > 0 {
-						doc.OwnerPhotos = []string{people[0].Photos[0].Url}
+				if len(ppl) > 0 {
+					if len(ppl[0].Photos) > 0 {
+						doc.OwnerPhotos = []string{ppl[0].Photos[0].Url}
 					}
 				}
 			}

--- a/internal/api/v2/documents.go
+++ b/internal/api/v2/documents.go
@@ -99,6 +99,20 @@ func DocumentHandler(srv server.Server) http.Handler {
 			return
 		}
 
+		// If the document was created through Hermes and has a status of "WIP", it
+		// is a document draft and should be instead accessed through the drafts
+		// API. We return a 404 to be consistent with v1 of the API, and will
+		// improve this UX in the future when these APIs are combined.
+		if doc.AppCreated && doc.Status == "WIP" {
+			srv.Logger.Warn("attempted to access document draft via documents API",
+				"method", r.Method,
+				"path", r.URL.Path,
+				"doc_id", docID,
+			)
+			http.Error(w, "Document not found", http.StatusNotFound)
+			return
+		}
+
 		// Pass request off to associated subcollection (part of the URL after the
 		// document ID) handler, if appropriate.
 		switch reqType {

--- a/internal/api/v2/drafts.go
+++ b/internal/api/v2/drafts.go
@@ -655,18 +655,22 @@ func DraftsDocumentHandler(srv server.Server) http.Handler {
 			doc.ModifiedTime = modifiedTime.Unix()
 
 			// Get owner photo by searching Google Workspace directory.
-			ppl, err := srv.GWService.SearchPeople(userEmail, "photos")
-			if err != nil {
-				srv.Logger.Error(
-					"error searching directory for owner",
-					"error", err,
-					"path", r.URL.Path,
-					"method", r.Method,
-					"doc_id", docID,
-				)
-			}
-			if len(ppl) > 0 && len(ppl[0].Photos) > 0 {
-				doc.OwnerPhotos = []string{ppl[0].Photos[0].Url}
+			if len(doc.Owners) > 0 {
+				ppl, err := srv.GWService.SearchPeople(doc.Owners[0], "photos")
+				if err != nil {
+					srv.Logger.Error("error searching directory for owner",
+						"error", err,
+						"method", r.Method,
+						"path", r.URL.Path,
+						"doc_id", docID,
+						"person", doc.Owners[0],
+					)
+				}
+				if len(ppl) > 0 {
+					if len(ppl[0].Photos) > 0 {
+						doc.OwnerPhotos = []string{ppl[0].Photos[0].Url}
+					}
+				}
 			}
 
 			// Convert document to Algolia object because this is how it is expected


### PR DESCRIPTION
This PR fixes a bug where the logged-in user's photo was always being shown as the owner of a document draft in v2 of the API. It also makes the logic for attempting to GET a document draft via the v2 `documents` API consistent with v1 of the API, which returns a 404 response.