### PR TITLE
Fix UserMenuDropdown z-index bug

### DIFF
--- a/web/app/components/header.hbs
+++ b/web/app/components/header.hbs
@@ -1,3 +1,5 @@
-<header class="mb-7 border-b border-b-color-border-faint bg-color-page-faint">
+<header
+  class="z-20 mb-7 border-b border-b-color-border-faint bg-color-page-faint"
+>
   <Header::Nav />
 </header>

--- a/web/app/templates/application.hbs
+++ b/web/app/templates/application.hbs
@@ -4,7 +4,7 @@
 
 <Notification />
 
-<div class="flex flex-col min-h-screen">
+<div class="flex min-h-screen flex-col">
   {{outlet}}
 </div>
 
@@ -15,5 +15,5 @@
 </div>
 
 {{#if this.animatedToolsAreShown}}
-  <AnimatedTools />
+  <AnimatedTools class="!z-20" />
 {{/if}}


### PR DESCRIPTION
Fixes a z-index bug introduced in #418 causing the user menu dropdown to appear below table headers.

This is a temporary solution: Normally we'd isolate the z-index concerns to the popover itself rather than its parent (notice how we have to change the z-index of an unrelated element) but this isn't possible in `HdsDropdown`. I'll soon switch this to XDropdownList to give us better control.