### PR TITLE
Standardize `FlashMessage` properties

### DIFF
--- a/web/app/components/copy-u-r-l-button.ts
+++ b/web/app/components/copy-u-r-l-button.ts
@@ -1,12 +1,12 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import Ember from "ember";
-import FlashMessageService from "ember-cli-flash/services/flash-messages";
 import { restartableTask, timeout } from "ember-concurrency";
 import { inject as service } from "@ember/service";
 import { Placement } from "@floating-ui/dom";
 import { action } from "@ember/object";
 import { assert } from "@ember/debug";
+import HermesFlashMessagesService from "hermes/services/flash-messages";
 
 interface CopyURLButtonComponentSignature {
   Element: HTMLButtonElement;
@@ -21,7 +21,7 @@ interface CopyURLButtonComponentSignature {
 }
 
 export default class CopyURLButtonComponent extends Component<CopyURLButtonComponentSignature> {
-  @service declare flashMessages: FlashMessageService;
+  @service declare flashMessages: HermesFlashMessagesService;
 
   /**
    * Whether the URL was recently copied to the clipboard.
@@ -119,12 +119,8 @@ export default class CopyURLButtonComponent extends Component<CopyURLButtonCompo
         }
       }
     } catch (e) {
-      this.flashMessages.add({
+      this.flashMessages.critical((e as any).message, {
         title: "Error copying link",
-        message: e as string,
-        type: "critical",
-        timeout: 5000,
-        extendedTimeout: 1000,
       });
     }
   });

--- a/web/app/components/document/index.ts
+++ b/web/app/components/document/index.ts
@@ -6,11 +6,11 @@ import { AuthenticatedUser } from "hermes/services/authenticated-user";
 import ConfigService from "hermes/services/config";
 import FetchService from "hermes/services/fetch";
 import RouterService from "@ember/routing/router-service";
-import FlashMessageService from "ember-cli-flash/services/flash-messages";
 import RecentlyViewedDocsService from "hermes/services/recently-viewed-docs";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { HermesDocumentType } from "hermes/types/document-type";
+import HermesFlashMessagesService from "hermes/services/flash-messages";
 
 interface DocumentIndexComponentSignature {
   Args: {
@@ -25,7 +25,7 @@ export default class DocumentIndexComponent extends Component<DocumentIndexCompo
   @service("config") declare configSvc: ConfigService;
   @service("fetch") declare fetchSvc: FetchService;
   @service declare router: RouterService;
-  @service declare flashMessages: FlashMessageService;
+  @service declare flashMessages: HermesFlashMessagesService;
   @service("recently-viewed-docs")
   declare recentDocs: RecentlyViewedDocsService;
 
@@ -53,9 +53,6 @@ export default class DocumentIndexComponent extends Component<DocumentIndexCompo
         this.flashMessages.add({
           message: "Document draft deleted",
           title: "Done!",
-          type: "success",
-          timeout: 6000,
-          extendedTimeout: 1000,
         });
 
         this.router.transitionTo("authenticated.drafts");
@@ -67,12 +64,8 @@ export default class DocumentIndexComponent extends Component<DocumentIndexCompo
   });
 
   protected showError(e?: unknown) {
-    this.flashMessages.add({
+    this.flashMessages.critical((e as any).message, {
       title: "Error deleting draft",
-      message: e as string,
-      type: "critical",
-      timeout: 6000,
-      extendedTimeout: 1000,
     });
   }
 }

--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -15,7 +15,6 @@ import { debounce } from "@ember/runloop";
 import FetchService from "hermes/services/fetch";
 import RouterService from "@ember/routing/router-service";
 import SessionService from "hermes/services/session";
-import FlashMessageService from "ember-cli-flash/services/flash-messages";
 import { AuthenticatedUser } from "hermes/services/authenticated-user";
 import {
   CustomEditableField,
@@ -29,6 +28,7 @@ import htmlElement from "hermes/utils/html-element";
 import ConfigService from "hermes/services/config";
 import isValidURL from "hermes/utils/is-valid-u-r-l";
 import { HermesDocumentType } from "hermes/types/document-type";
+import HermesFlashMessagesService from "hermes/services/flash-messages";
 
 interface DocumentSidebarComponentSignature {
   Args: {
@@ -64,7 +64,7 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
   @service("fetch") declare fetchSvc: FetchService;
   @service declare router: RouterService;
   @service declare session: SessionService;
-  @service declare flashMessages: FlashMessageService;
+  @service declare flashMessages: HermesFlashMessagesService;
 
   @tracked archiveModalIsShown = false;
   @tracked deleteModalIsShown = false;
@@ -495,12 +495,8 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
   }
 
   showFlashError(error: Error, title: string) {
-    this.flashMessages.add({
+    this.flashMessages.critical(error.message, {
       title,
-      message: error.message,
-      type: "critical",
-      timeout: 6000,
-      extendedTimeout: 1000,
       preventDuplicates: true,
     });
   }
@@ -509,9 +505,6 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
     this.flashMessages.add({
       message,
       title,
-      type: "success",
-      timeout: 6000,
-      extendedTimeout: 1000,
     });
   }
 

--- a/web/app/components/document/sidebar/related-resources.ts
+++ b/web/app/components/document/sidebar/related-resources.ts
@@ -9,7 +9,6 @@ import { restartableTask, task, timeout } from "ember-concurrency";
 import { next, schedule } from "@ember/runloop";
 import htmlElement from "hermes/utils/html-element";
 import Ember from "ember";
-import FlashMessageService from "ember-cli-flash/services/flash-messages";
 import maybeScrollIntoView from "hermes/utils/maybe-scroll-into-view";
 import {
   RelatedExternalLink,
@@ -18,6 +17,7 @@ import {
   RelatedResourceSelector,
 } from "hermes/components/related-resources";
 import { assert } from "@ember/debug";
+import HermesFlashMessagesService from "hermes/services/flash-messages";
 
 export interface DocumentSidebarRelatedResourcesComponentArgs {
   productArea?: string;
@@ -41,7 +41,7 @@ export default class DocumentSidebarRelatedResourcesComponent extends Component<
   @service("config") declare configSvc: ConfigService;
   @service("fetch") declare fetchSvc: FetchService;
   @service declare algolia: AlgoliaService;
-  @service declare flashMessages: FlashMessageService;
+  @service declare flashMessages: HermesFlashMessagesService;
 
   @tracked relatedLinks: RelatedExternalLink[] = [];
   @tracked relatedDocuments: RelatedHermesDocument[] = [];
@@ -322,16 +322,13 @@ export default class DocumentSidebarRelatedResourcesComponent extends Component<
             },
           },
         );
-      } catch (e: unknown) {
+      } catch (e) {
         this.relatedLinks = cachedLinks;
         this.relatedDocuments = cachedDocuments;
 
-        this.flashMessages.add({
+        this.flashMessages.critical((e as any).message, {
           title: "Unable to save resource",
-          message: (e as any).message,
-          type: "critical",
-          sticky: true,
-          extendedTimeout: 1000,
+          timeout: 10000,
         });
       }
     },

--- a/web/app/components/document/sidebar/related-resources.ts
+++ b/web/app/components/document/sidebar/related-resources.ts
@@ -18,6 +18,7 @@ import {
 } from "hermes/components/related-resources";
 import { assert } from "@ember/debug";
 import HermesFlashMessagesService from "hermes/services/flash-messages";
+import { FLASH_MESSAGES_LONG_TIMEOUT } from "hermes/utils/ember-cli-flash/timeouts";
 
 export interface DocumentSidebarRelatedResourcesComponentArgs {
   productArea?: string;
@@ -328,7 +329,7 @@ export default class DocumentSidebarRelatedResourcesComponent extends Component<
 
         this.flashMessages.critical((e as any).message, {
           title: "Unable to save resource",
-          timeout: 10000,
+          timeout: FLASH_MESSAGES_LONG_TIMEOUT,
         });
       }
     },

--- a/web/app/components/new/doc-form.ts
+++ b/web/app/components/new/doc-form.ts
@@ -10,11 +10,11 @@ import AuthenticatedUserService from "hermes/services/authenticated-user";
 import RouterService from "@ember/routing/router-service";
 import ModalAlertsService from "hermes/services/modal-alerts";
 import { HermesUser } from "hermes/types/document";
-import FlashService from "ember-cli-flash/services/flash-messages";
 import { assert } from "@ember/debug";
 import cleanString from "hermes/utils/clean-string";
 import { ProductArea } from "hermes/services/product-areas";
 import { next } from "@ember/runloop";
+import HermesFlashMessagesService from "hermes/services/flash-messages";
 
 interface DocFormErrors {
   title: string | null;
@@ -34,7 +34,7 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
   @service("config") declare configSvc: ConfigService;
   @service("fetch") declare fetchSvc: FetchService;
   @service declare authenticatedUser: AuthenticatedUserService;
-  @service declare flashMessages: FlashService;
+  @service declare flashMessages: HermesFlashMessagesService;
   @service declare modalAlerts: ModalAlertsService;
   @service declare router: RouterService;
 
@@ -225,15 +225,11 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
       this.router.transitionTo("authenticated.document", doc.id, {
         queryParams: { draft: true },
       });
-    } catch (err: unknown) {
+    } catch (e) {
       this.docIsBeingCreated = false;
 
-      this.flashMessages.add({
+      this.flashMessages.critical((e as any).message, {
         title: "Error creating document draft",
-        message: `${err}`,
-        type: "critical",
-        timeout: 6000,
-        extendedTimeout: 1000,
       });
     }
   });

--- a/web/app/components/new/project-form.ts
+++ b/web/app/components/new/project-form.ts
@@ -4,10 +4,10 @@ import { next } from "@ember/runloop";
 import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import FlashMessageService from "ember-cli-flash/services/flash-messages";
 import { task } from "ember-concurrency";
 import ConfigService from "hermes/services/config";
 import FetchService from "hermes/services/fetch";
+import HermesFlashMessagesService from "hermes/services/flash-messages";
 import { ProjectStatus } from "hermes/types/project-status";
 import cleanString from "hermes/utils/clean-string";
 
@@ -17,7 +17,7 @@ export default class NewProjectFormComponent extends Component<NewProjectFormCom
   @service("fetch") declare fetchSvc: FetchService;
   @service("config") declare configSvc: ConfigService;
   @service declare router: RouterService;
-  @service declare flashMessages: FlashMessageService;
+  @service declare flashMessages: HermesFlashMessagesService;
 
   /**
    * Whether the project is being created, or in the process of
@@ -86,14 +86,9 @@ export default class NewProjectFormComponent extends Component<NewProjectFormCom
         })
         .then((response) => response?.json());
       this.router.transitionTo("authenticated.projects.project", project.id);
-    } catch (error: unknown) {
-      const typedError = error as Error;
-      this.flashMessages.add({
+    } catch (e) {
+      this.flashMessages.critical((e as any).message, {
         title: "Error creating project",
-        message: typedError.message,
-        type: "critical",
-        timeout: 6000,
-        extendedTimeout: 1000,
       });
       this.projectIsBeingCreated = false;
     }

--- a/web/app/components/notification.ts
+++ b/web/app/components/notification.ts
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
-import FlashMessageService from "ember-cli-flash/services/flash-messages";
+import HermesFlashMessagesService from "hermes/services/flash-messages";
 
 export default class Notification extends Component {
-  @service declare flashMessages: FlashMessageService;
+  @service declare flashMessages: HermesFlashMessagesService;
 }

--- a/web/app/components/project/index.ts
+++ b/web/app/components/project/index.ts
@@ -16,8 +16,8 @@ import {
   projectStatusObjects,
 } from "hermes/types/project-status";
 import { assert } from "@ember/debug";
-import FlashMessageService from "ember-cli-flash/services/flash-messages";
 import ConfigService from "hermes/services/config";
+import HermesFlashMessagesService from "hermes/services/flash-messages";
 
 interface ProjectIndexComponentSignature {
   Args: {
@@ -28,7 +28,7 @@ interface ProjectIndexComponentSignature {
 export default class ProjectIndexComponent extends Component<ProjectIndexComponentSignature> {
   @service("fetch") declare fetchSvc: FetchService;
   @service("config") declare configSvc: ConfigService;
-  @service declare flashMessages: FlashMessageService;
+  @service declare flashMessages: HermesFlashMessagesService;
 
   /**
    * The array of possible project statuses.
@@ -313,13 +313,10 @@ export default class ProjectIndexComponent extends Component<ProjectIndexCompone
           method: "PATCH",
           body: JSON.stringify(valueToSave),
         });
-      } catch (e: unknown) {
-        this.flashMessages.add({
+      } catch (e) {
+        this.flashMessages.critical((e as any).message, {
           title: "Unable to save",
-          message: (e as any).message,
-          type: "critical",
           timeout: 10000,
-          extendedTimeout: 1000,
         });
       }
     },
@@ -351,16 +348,13 @@ export default class ProjectIndexComponent extends Component<ProjectIndexCompone
             },
           },
         );
-      } catch (e: unknown) {
+      } catch (e) {
         this.externalLinks = cachedLinks;
         this.hermesDocuments = cachedDocuments;
 
-        this.flashMessages.add({
+        this.flashMessages.critical((e as any).message, {
           title: "Unable to save resource",
-          message: (e as any).message,
-          type: "critical",
-          sticky: true,
-          extendedTimeout: 1000,
+          timeout: 10000,
         });
       }
     },

--- a/web/app/components/project/index.ts
+++ b/web/app/components/project/index.ts
@@ -18,6 +18,7 @@ import {
 import { assert } from "@ember/debug";
 import ConfigService from "hermes/services/config";
 import HermesFlashMessagesService from "hermes/services/flash-messages";
+import { FLASH_MESSAGES_LONG_TIMEOUT } from "hermes/utils/ember-cli-flash/timeouts";
 
 interface ProjectIndexComponentSignature {
   Args: {
@@ -316,7 +317,7 @@ export default class ProjectIndexComponent extends Component<ProjectIndexCompone
       } catch (e) {
         this.flashMessages.critical((e as any).message, {
           title: "Unable to save",
-          timeout: 10000,
+          timeout: FLASH_MESSAGES_LONG_TIMEOUT,
         });
       }
     },
@@ -354,7 +355,7 @@ export default class ProjectIndexComponent extends Component<ProjectIndexCompone
 
         this.flashMessages.critical((e as any).message, {
           title: "Unable to save resource",
-          timeout: 10000,
+          timeout: FLASH_MESSAGES_LONG_TIMEOUT,
         });
       }
     },

--- a/web/app/components/related-resources/add.ts
+++ b/web/app/components/related-resources/add.ts
@@ -7,7 +7,6 @@ import { assert } from "@ember/debug";
 import { restartableTask } from "ember-concurrency";
 import ConfigService from "hermes/services/config";
 import { inject as service } from "@ember/service";
-import FlashMessageService from "ember-cli-flash/services/flash-messages";
 import {
   RelatedExternalLink,
   RelatedHermesDocument,
@@ -19,6 +18,7 @@ import { XDropdownListAnchorAPI } from "hermes/components/x/dropdown-list";
 import { SearchOptions } from "instantsearch.js";
 import { RelatedResourcesScope } from "../related-resources";
 import { guidFor } from "@ember/object/internals";
+import HermesFlashMessagesService from "hermes/services/flash-messages";
 
 interface RelatedResourcesAddComponentSignature {
   Element: null;
@@ -79,7 +79,7 @@ enum FirstPartyURLFormat {
 export default class RelatedResourcesAddComponent extends Component<RelatedResourcesAddComponentSignature> {
   @service("config") declare configSvc: ConfigService;
   @service("fetch") declare fetchSvc: FetchService;
-  @service declare flashMessages: FlashMessageService;
+  @service declare flashMessages: HermesFlashMessagesService;
 
   private scopeIsExternalLinks =
     this.args.scope === RelatedResourcesScope.ExternalLinks;

--- a/web/app/routes/authenticated/document.ts
+++ b/web/app/routes/authenticated/document.ts
@@ -13,6 +13,7 @@ import RecentlyViewedDocsService from "hermes/services/recently-viewed-docs";
 import { assert } from "@ember/debug";
 import { GoogleUser } from "hermes/components/inputs/people-select";
 import HermesFlashMessagesService from "hermes/services/flash-messages";
+import { FLASH_MESSAGES_LONG_TIMEOUT } from "hermes/utils/ember-cli-flash/timeouts";
 
 const serializePeople = (people: GoogleUser[]): HermesUser[] => {
   return people.map((p) => ({
@@ -53,7 +54,7 @@ export default class AuthenticatedDocumentRoute extends Route {
   showErrorMessage(err: Error) {
     this.flashMessages.critical(err.message, {
       title: "Error fetching document",
-      timeout: 10000,
+      timeout: FLASH_MESSAGES_LONG_TIMEOUT,
     });
   }
 

--- a/web/app/routes/authenticated/document.ts
+++ b/web/app/routes/authenticated/document.ts
@@ -4,7 +4,6 @@ import htmlElement from "hermes/utils/html-element";
 import { schedule } from "@ember/runloop";
 import ConfigService from "hermes/services/config";
 import FetchService from "hermes/services/fetch";
-import FlashMessageService from "ember-cli-flash/services/flash-messages";
 import RouterService from "@ember/routing/router-service";
 import { HermesDocument, HermesUser } from "hermes/types/document";
 import Transition from "@ember/routing/transition";
@@ -13,6 +12,7 @@ import AuthenticatedDocumentController from "hermes/controllers/authenticated/do
 import RecentlyViewedDocsService from "hermes/services/recently-viewed-docs";
 import { assert } from "@ember/debug";
 import { GoogleUser } from "hermes/components/inputs/people-select";
+import HermesFlashMessagesService from "hermes/services/flash-messages";
 
 const serializePeople = (people: GoogleUser[]): HermesUser[] => {
   return people.map((p) => ({
@@ -36,7 +36,7 @@ export default class AuthenticatedDocumentRoute extends Route {
   @service("fetch") declare fetchSvc: FetchService;
   @service("recently-viewed-docs")
   declare recentDocs: RecentlyViewedDocsService;
-  @service declare flashMessages: FlashMessageService;
+  @service declare flashMessages: HermesFlashMessagesService;
   @service declare router: RouterService;
 
   declare controller: AuthenticatedDocumentController;
@@ -51,12 +51,9 @@ export default class AuthenticatedDocumentRoute extends Route {
   // };
 
   showErrorMessage(err: Error) {
-    this.flashMessages.add({
+    this.flashMessages.critical(err.message, {
       title: "Error fetching document",
-      message: err.message,
-      type: "critical",
-      sticky: true,
-      extendedTimeout: 1000,
+      timeout: 10000,
     });
   }
 

--- a/web/app/services/_session.ts
+++ b/web/app/services/_session.ts
@@ -3,7 +3,6 @@ import RouterService from "@ember/routing/router-service";
 import EmberSimpleAuthSessionService from "ember-simple-auth/services/session";
 import window from "ember-window-mock";
 import { dropTask, keepLatestTask, timeout } from "ember-concurrency";
-import FlashMessageService from "ember-cli-flash/services/flash-messages";
 import Ember from "ember";
 import { tracked } from "@glimmer/tracking";
 import simpleTimeout from "hermes/utils/simple-timeout";
@@ -12,6 +11,7 @@ import FetchService from "./fetch";
 import AuthenticatedUserService from "./authenticated-user";
 import { capitalize } from "@ember/string";
 import FlashObject from "ember-cli-flash/flash/object";
+import HermesFlashMessagesService from "./flash-messages";
 
 export const REDIRECT_STORAGE_KEY = "hermes.redirectTarget";
 
@@ -29,7 +29,7 @@ export default class SessionService extends EmberSimpleAuthSessionService {
   @service declare router: RouterService;
   @service declare fetch: FetchService;
   @service declare session: SessionService;
-  @service declare flashMessages: FlashMessageService;
+  @service declare flashMessages: HermesFlashMessagesService;
   @service declare authenticatedUser: AuthenticatedUserService;
 
   /**
@@ -176,9 +176,6 @@ export default class SessionService extends EmberSimpleAuthSessionService {
             ? `, ${this.authenticatedUser.info.given_name}`
             : ""
         }!`,
-        type: "success",
-        timeout: 1500,
-        extendedTimeout: 1000,
         destroyOnClick: true,
       });
 

--- a/web/app/services/flash-messages.d.ts
+++ b/web/app/services/flash-messages.d.ts
@@ -1,0 +1,9 @@
+import FlashMessageService, {
+  FlashFunction,
+  MessageOptions,
+} from "ember-cli-flash/services/flash-messages";
+
+export default class HermesFlashMessagesService extends FlashMessageService {
+  critical: FlashFunction;
+  success: FlashFunction;
+}

--- a/web/app/utils/ember-cli-flash/timeouts.ts
+++ b/web/app/utils/ember-cli-flash/timeouts.ts
@@ -1,0 +1,3 @@
+import Ember from "ember";
+
+export const FLASH_MESSAGES_LONG_TIMEOUT = Ember.testing ? 0 : 10000;

--- a/web/config/environment.js
+++ b/web/config/environment.js
@@ -5,7 +5,7 @@ const getEnv = (key, defaultValue) => {
   const value = process.env[fullKey];
   if (value == null) {
     console.warn(
-      `env var ${fullKey} was not set! Proceeding with default value "${defaultValue}"`
+      `env var ${fullKey} was not set! Proceeding with default value "${defaultValue}"`,
     );
   }
   return value != null ? value : defaultValue;
@@ -47,6 +47,13 @@ module.exports = function (environment) {
       draftsIndexName: getEnv("ALGOLIA_DRAFTS_INDEX_NAME", "drafts"),
       internalIndexName: getEnv("ALGOLIA_INTERNAL_INDEX_NAME", "internal"),
       apiKey: getEnv("ALGOLIA_SEARCH_API_KEY"),
+    },
+
+    flashMessageDefaults: {
+      timeout: 5000,
+      extendedTimeout: 1000,
+      type: "success",
+      types: ["critical", "success"],
     },
 
     google: {


### PR DESCRIPTION
Adds default configurations for the FlashMessage service as well as `critical()` and `success()` helper methods. Standardizes the duration of long timeouts. We'll now import from an extended service (`HermesFlashMessagesService`) which includes types for the new utility methods.