### PR TITLE
Remove unused `Table` argument

### DIFF
--- a/web/app/components/documents/table.hbs
+++ b/web/app/components/documents/table.hbs
@@ -9,7 +9,6 @@
         <th class="owner">Owner</th>
         <th class="time">
           <Table::SortableHeader
-            @changeSort={{@changeSort}}
             @currentSort={{@currentSort}}
             @sortDirection={{@sortDirection}}
             @queryParam={{hash

--- a/web/app/components/documents/table.ts
+++ b/web/app/components/documents/table.ts
@@ -11,7 +11,6 @@ interface DocumentsTableComponentSignature {
     isDraft?: boolean;
     nbPages?: number;
     currentPage?: number;
-    changeSort?: (attribute: SortAttribute) => void;
     currentSort: `${SortAttribute}`;
     sortDirection: SortDirection;
   };

--- a/web/app/components/table/sortable-header.hbs
+++ b/web/app/components/table/sortable-header.hbs
@@ -1,30 +1,14 @@
-{{#if @changeSort}}
-  <Action
-    data-test-sortable-table-header
-    data-test-attribute={{@attribute}}
-    data-test-element="button"
-    class="sortable-table-header {{if this.isActive 'active'}}"
-    {{on "click" this.changeSort}}
-    ...attributes
-  >
-    <div class="sort-icon">
-      <FlightIcon @name={{this.iconName}} />
-    </div>
-    {{yield}}
-  </Action>
-{{else}}
-  <LinkTo
-    data-test-sortable-table-header
-    data-test-attribute={{@attribute}}
-    data-test-element="anchor"
-    ...attributes
-    @route={{this.currentRoute}}
-    @query={{@queryParam}}
-    class="sortable-table-header {{if this.isActive 'active'}}"
-  >
-    <div class="sort-icon">
-      <FlightIcon @name={{this.iconName}} />
-    </div>
-    {{yield}}
-  </LinkTo>
-{{/if}}
+<LinkTo
+  data-test-sortable-table-header
+  data-test-attribute={{@attribute}}
+  data-test-element="anchor"
+  ...attributes
+  @route={{this.currentRoute}}
+  @query={{@queryParam}}
+  class="sortable-table-header {{if this.isActive 'active'}}"
+>
+  <div class="sort-icon">
+    <FlightIcon @name={{this.iconName}} />
+  </div>
+  {{yield}}
+</LinkTo>

--- a/web/app/components/table/sortable-header.ts
+++ b/web/app/components/table/sortable-header.ts
@@ -24,10 +24,6 @@ interface TableSortableHeaderSignature {
     currentSort: `${SortAttribute}`;
     sortDirection: SortDirection;
     attribute: `${SortAttribute}`;
-    changeSort?: (
-      attribute: SortAttribute,
-      defaultSortDirection?: SortDirection
-    ) => void;
     defaultSortDirection?: `${SortDirection}`;
     queryParam?: Record<string, unknown>;
   };
@@ -55,32 +51,8 @@ export default class TableSortableHeader extends Component<TableSortableHeaderSi
     }
   }
 
-  private get sortDirection() {
-    if (!this.isActive) {
-      return (
-        (this.args.defaultSortDirection as SortDirection) ?? SortDirection.Asc
-      );
-    }
-  }
-
-  protected get isReadOnly() {
-    if (this.args.attribute === SortAttribute.CreatedTime) {
-      return false;
-    }
-
-    return true;
-  }
-
   protected get isActive() {
     return this.args.currentSort === this.args.attribute;
-  }
-
-  @action protected changeSort() {
-    assert("this.args.changeSort must exists", this.args.changeSort);
-    this.args.changeSort(
-      this.args.attribute as SortAttribute,
-      this.sortDirection
-    );
   }
 }
 


### PR DESCRIPTION
Removes the unused `changeSort` property and simplifies the `SortableHeader` to reflect that.