### PR TITLE
Change `product-link` routing

### DIFF
--- a/web/app/components/product-link.hbs
+++ b/web/app/components/product-link.hbs
@@ -1,5 +1,5 @@
 <LinkTo
-  @route={{this.route}}
+  @route="authenticated.documents"
   @query={{this.query}}
   class="product-link"
   ...attributes

--- a/web/app/components/product-link.ts
+++ b/web/app/components/product-link.ts
@@ -1,5 +1,3 @@
-import RouterService from "@ember/routing/router-service";
-import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
 import getProductLabel from "hermes/utils/get-product-label";
 
@@ -14,8 +12,6 @@ interface ProductLinkComponentSignature {
 }
 
 export default class ProductLinkComponent extends Component<ProductLinkComponentSignature> {
-  @service declare router: RouterService;
-
   protected get productAreaName(): string | undefined {
     return getProductLabel(this.args.product);
   }
@@ -32,23 +28,6 @@ export default class ProductLinkComponent extends Component<ProductLinkComponent
       };
     } else {
       return {};
-    }
-  }
-
-  /**
-   * The route the badge should link to.
-   * If on the /drafts or /my screen, stay there.
-   * In all other cases, link to the /all screen.
-   */
-  protected get route() {
-    const { currentRouteName } = this.router;
-
-    switch (currentRouteName) {
-      case "authenticated.drafts":
-      case "authenticated.my":
-        return currentRouteName;
-      default:
-        return "authenticated.documents";
     }
   }
 }

--- a/web/tests/acceptance/authenticated/all/documents-test.ts
+++ b/web/tests/acceptance/authenticated/all/documents-test.ts
@@ -23,18 +23,6 @@ module("Acceptance | authenticated/documents", function (hooks) {
     assert.equal(getPageTitle(), "All Docs | Hermes");
   });
 
-  test("product badges have the correct hrefs", async function (this: AuthenticatedDocumentsRouteTestContext, assert) {
-    this.server.create("document", {
-      product: "Labs",
-    });
-
-    await visit("/documents");
-
-    assert
-      .dom(PRODUCT_LINK_SELECTOR)
-      .hasAttribute("href", "/documents?product=%5B%22Labs%22%5D");
-  });
-
   test("documents can be sorted by created date", async function (this: AuthenticatedDocumentsRouteTestContext, assert) {
     this.server.createList("document", 2);
 

--- a/web/tests/acceptance/authenticated/drafts-test.ts
+++ b/web/tests/acceptance/authenticated/drafts-test.ts
@@ -48,16 +48,4 @@ module("Acceptance | authenticated/drafts", function (hooks) {
       .dom(`${TABLE_HEADER_CREATED_SELECTOR} .flight-icon`)
       .hasAttribute("data-test-icon", "arrow-up");
   });
-
-  test("product links have the correct hrefs", async function (this: AuthenticatedDraftRouteTestContext, assert) {
-    this.server.create("document", {
-      product: "Security",
-    });
-
-    await visit("/drafts");
-
-    assert
-      .dom(".product-link")
-      .hasAttribute("href", "/drafts?product=%5B%22Security%22%5D");
-  });
 });

--- a/web/tests/acceptance/authenticated/my-test.ts
+++ b/web/tests/acceptance/authenticated/my-test.ts
@@ -49,16 +49,4 @@ module("Acceptance | authenticated/my", function (hooks) {
       .dom(`${TABLE_HEADER_CREATED_SELECTOR} .flight-icon`)
       .hasAttribute("data-test-icon", "arrow-up");
   });
-
-  test("product badges have the correct hrefs", async function (this: AuthenticatedMyRouteTestContext, assert) {
-    this.server.create("document", {
-      product: "Terraform",
-    });
-
-    await visit("/my");
-
-    assert
-      .dom(PRODUCT_LINK_SELECTOR)
-      .hasAttribute("href", "/my?product=%5B%22Terraform%22%5D");
-  });
 });

--- a/web/tests/acceptance/authenticated/results-test.ts
+++ b/web/tests/acceptance/authenticated/results-test.ts
@@ -19,14 +19,4 @@ module("Acceptance | authenticated/results", function (hooks) {
     await visit("/results");
     assert.equal(getPageTitle(), "Search Results | Hermes");
   });
-
-  test("product badges have the correct hrefs", async function (this: AuthenticatedResultsRouteTestContext, assert) {
-    this.server.createList("document", 10);
-
-    await visit("/results");
-
-    assert
-      .dom(".product-link")
-      .hasAttribute("href", "/documents?product=%5B%22Vault%22%5D");
-  });
 });


### PR DESCRIPTION
Simplifies the `ProductLink` to always route to `authenticated.documents` rather than conditionally pointing to `my` or `drafts`. Now all links function the same regardless of context, as they will when we introduce product landing screens.