### PR TITLE
Bugfix: Add `?draft=true` to draft links

### DIFF
--- a/web/app/components/table/row.hbs
+++ b/web/app/components/table/row.hbs
@@ -1,9 +1,10 @@
 <tr>
   <td class="name">
     <LinkTo
+      data-test-document-link
       @route="authenticated.document"
       @model="{{@doc.objectID}}"
-      @query={{hash draft=(eq @doc.status "wip")}}
+      @query={{hash draft=this.isDraft}}
       class="inner flex h-full w-full items-start gap-3.5 focus:outline-none"
     >
       <Doc::Thumbnail @product={{@doc.product}} @status={{@doc.status}} />

--- a/web/app/components/table/row.ts
+++ b/web/app/components/table/row.ts
@@ -13,6 +13,14 @@ interface TableRowComponentSignature {
 export default class TableRowComponent extends Component<TableRowComponentSignature> {
   @service declare authenticatedUser: AuthenticatedUserService;
 
+  protected get isDraft() {
+    if (this.args.doc.isDraft) {
+      return true;
+    }
+
+    return this.args.doc.status === "WIP";
+  }
+
   protected get ownerIsAuthenticatedUser() {
     const docOwner = this.args.doc.owners?.[0];
 

--- a/web/mirage/factories/document.ts
+++ b/web/mirage/factories/document.ts
@@ -23,7 +23,7 @@ export function getTestDocNumber(product: string) {
 export default Factory.extend({
   objectID: (i: number) => `doc-${i}`,
   title: (i: number) => `Test Document ${i}`,
-  status: "Draft",
+  status: "WIP",
   product: "Vault",
   docType: "RFC",
   modifiedTime: 1,

--- a/web/tests/acceptance/authenticated/drafts-test.ts
+++ b/web/tests/acceptance/authenticated/drafts-test.ts
@@ -7,6 +7,7 @@ import { getPageTitle } from "ember-page-title/test-support";
 
 const TABLE_HEADER_CREATED_SELECTOR =
   "[data-test-sortable-table-header][data-test-attribute=createdTime]";
+const DOCUMENT_LINK = "[data-test-document-link]";
 
 interface AuthenticatedDraftRouteTestContext extends MirageTestContext {}
 
@@ -59,5 +60,19 @@ module("Acceptance | authenticated/drafts", function (hooks) {
     assert
       .dom(".product-link")
       .hasAttribute("href", "/drafts?product=%5B%22Security%22%5D");
+  });
+
+  test("document links have the correct query params", async function (this: AuthenticatedDraftRouteTestContext, assert) {
+    this.server.create("document");
+
+    await visit("/drafts");
+
+    assert
+      .dom(DOCUMENT_LINK)
+      .hasAttribute(
+        "href",
+        "/document/doc-0?draft=true",
+        "correctly has the draft param",
+      );
   });
 });


### PR DESCRIPTION
Fixes (and now tests for) the `draft` queryParam on `/draft` document links. 

Bug was introduced #418 by not capitalizing "WIP."