### PR TITLE
Fix recently viewed docs

### DIFF
--- a/internal/api/documents.go
+++ b/internal/api/documents.go
@@ -211,15 +211,12 @@ func DocumentHandler(
 				if err := updateRecentlyViewedDocs(email, docID, db, now); err != nil {
 					// If we get an error, log it but don't return an error response
 					// because this would degrade UX.
-					// TODO: change this log back to an error when this handles incomplete
-					// data in the database.
-					l.Warn("error updating recently viewed docs",
+					l.Error("error updating recently viewed docs",
 						"error", err,
 						"doc_id", docID,
 						"method", r.Method,
 						"path", r.URL.Path,
 					)
-					return
 				}
 			}
 

--- a/internal/api/documents.go
+++ b/internal/api/documents.go
@@ -851,6 +851,9 @@ func updateRecentlyViewedDocs(
 			},
 		}
 		if err := dd.Get(db); err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				continue
+			}
 			return fmt.Errorf("error getting document: %w", err)
 		}
 		docs = append(docs, dd)

--- a/internal/api/drafts.go
+++ b/internal/api/drafts.go
@@ -623,15 +623,12 @@ func DraftsDocumentHandler(
 				if err := updateRecentlyViewedDocs(userEmail, docId, db, now); err != nil {
 					// If we get an error, log it but don't return an error response because
 					// this would degrade UX.
-					// TODO: change this log back to an error when this handles incomplete
-					// data in the database.
-					l.Warn("error updating recently viewed docs",
+					l.Error("error updating recently viewed docs",
 						"error", err,
 						"path", r.URL.Path,
 						"method", r.Method,
 						"doc_id", docId,
 					)
-					return
 				}
 			}
 

--- a/internal/api/me_recently_viewed_docs.go
+++ b/internal/api/me_recently_viewed_docs.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/hashicorp-forge/hermes/internal/config"
@@ -83,14 +84,14 @@ func MeRecentlyViewedDocsHandler(
 				if err := doc.Get(db); err != nil {
 					// If we get an error, log it but don't return an error response
 					// because this would degrade UX.
-					// TODO: change this log back to an error when this handles incomplete
-					// data in the database.
-					l.Warn("error getting document in database",
-						"error", err,
-						"method", r.Method,
-						"path", r.URL.Path,
-						"document_db_id", d.DocumentID,
-					)
+					if !errors.Is(err, gorm.ErrRecordNotFound) {
+						l.Error("error getting document in database",
+							"error", err,
+							"method", r.Method,
+							"path", r.URL.Path,
+							"document_db_id", d.DocumentID,
+						)
+					}
 					continue
 				}
 

--- a/internal/api/v2/documents.go
+++ b/internal/api/v2/documents.go
@@ -226,15 +226,12 @@ func DocumentHandler(srv server.Server) http.Handler {
 				); err != nil {
 					// If we get an error, log it but don't return an error response
 					// because this would degrade UX.
-					// TODO: change this log back to an error when this handles incomplete
-					// data in the database.
-					srv.Logger.Warn("error updating recently viewed docs",
+					srv.Logger.Error("error updating recently viewed docs",
 						"error", err,
 						"doc_id", docID,
 						"method", r.Method,
 						"path", r.URL.Path,
 					)
-					return
 				}
 			}
 

--- a/internal/api/v2/documents.go
+++ b/internal/api/v2/documents.go
@@ -916,6 +916,9 @@ func updateRecentlyViewedDocs(
 			},
 		}
 		if err := dd.Get(db); err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				continue
+			}
 			return fmt.Errorf("error getting document: %w", err)
 		}
 		docs = append(docs, dd)

--- a/internal/api/v2/drafts.go
+++ b/internal/api/v2/drafts.go
@@ -716,15 +716,12 @@ func DraftsDocumentHandler(srv server.Server) http.Handler {
 				); err != nil {
 					// If we get an error, log it but don't return an error response
 					// because this would degrade UX.
-					// TODO: change this log back to an error when this handles incomplete
-					// data in the database.
-					srv.Logger.Warn("error updating recently viewed docs",
+					srv.Logger.Error("error updating recently viewed docs",
 						"error", err,
 						"path", r.URL.Path,
 						"method", r.Method,
 						"doc_id", docID,
 					)
-					return
 				}
 			}
 

--- a/internal/api/v2/me_recently_viewed_docs.go
+++ b/internal/api/v2/me_recently_viewed_docs.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/hashicorp-forge/hermes/internal/server"
@@ -78,14 +79,14 @@ func MeRecentlyViewedDocsHandler(srv server.Server) http.Handler {
 				if err := doc.Get(srv.DB); err != nil {
 					// If we get an error, log it but don't return an error response
 					// because this would degrade UX.
-					// TODO: change this log back to an error when this handles incomplete
-					// data in the database.
-					srv.Logger.Warn("error getting document in database",
-						"error", err,
-						"method", r.Method,
-						"path", r.URL.Path,
-						"document_db_id", d.DocumentID,
-					)
+					if !errors.Is(err, gorm.ErrRecordNotFound) {
+						srv.Logger.Error("error getting document in database",
+							"error", err,
+							"method", r.Method,
+							"path", r.URL.Path,
+							"document_db_id", d.DocumentID,
+						)
+					}
 					continue
 				}
 


### PR DESCRIPTION
Deleted drafts in the database can currently cause updating recently viewed documents to fail because we weren't checking for (and only failing on) non-"record not found" errors. This PR fixes that, as well as logs errors instead of warnings now that data in PostgreSQL is cleaned up.