### PR TITLE
Add projects API

### DIFF
--- a/internal/api/v2/projects.go
+++ b/internal/api/v2/projects.go
@@ -281,7 +281,7 @@ func ProjectHandler(srv server.Server) http.Handler {
 								"error", err,
 							}, logArgs...)...)
 						http.Error(
-							w, "Error processing requst", http.StatusInternalServerError)
+							w, "Error processing request", http.StatusInternalServerError)
 						return
 					}
 				}

--- a/internal/api/v2/projects.go
+++ b/internal/api/v2/projects.go
@@ -1,0 +1,359 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp-forge/hermes/internal/server"
+	"github.com/hashicorp-forge/hermes/pkg/models"
+	"gorm.io/gorm"
+)
+
+type ProjectGetResponse struct {
+	*project
+}
+
+type ProjectPatchRequest struct {
+	Description *string `json:"description"`
+	JiraIssueID *string `json:"jiraIssueID"`
+	Status      string  `json:"status"`
+	Title       string  `json:"title"`
+}
+
+type ProjectsPostRequest struct {
+	Description *string `json:"description"`
+	JiraIssueID *string `json:"jiraIssueID"`
+	Title       string  `json:"title"`
+}
+
+type ProjectsGetResponse []project
+
+type ProjectsPostResponse struct {
+	ID int `json:"id"`
+}
+
+type project struct {
+	CreatedTime  int64  `json:"createdTime,omitempty"`
+	Creator      string `json:"creator,omitempty"`
+	Description  string `json:"description,omitempty"`
+	ID           uint   `json:"id"`
+	JiraIssueID  string `json:"jiraIssueID,omitempty"`
+	ModifiedTime int64  `json:"modifiedTime,omitempty"`
+	Status       string `json:"status"`
+	Title        string `json:"title"`
+}
+
+func ProjectsHandler(srv server.Server) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logArgs := []any{
+			"path", r.URL.Path,
+		}
+
+		// Authorize request.
+		userEmail := r.Context().Value("userEmail").(string)
+		if userEmail == "" {
+			srv.Logger.Error("user email not found in request context", logArgs...)
+			http.Error(
+				w, "No authorization information for request", http.StatusUnauthorized)
+			return
+		}
+
+		switch r.Method {
+		case "GET":
+			logArgs = append(logArgs, "method", r.Method)
+
+			// Get all projects from database.
+			projs := []models.Project{}
+			if err := srv.DB.Find(&projs).Error; err != nil &&
+				!errors.Is(err, gorm.ErrRecordNotFound) {
+				srv.Logger.Error("error getting projects",
+					append([]interface{}{
+						"error", err,
+					}, logArgs...)...)
+				http.Error(
+					w, "Error processing request", http.StatusInternalServerError)
+				return
+			}
+
+			// Build response.
+			resp := []project{}
+			for _, p := range projs {
+				resp = append(resp, project{
+					CreatedTime:  p.ProjectCreatedAt.Unix(),
+					Creator:      p.Creator.EmailAddress,
+					Description:  p.Description,
+					ID:           p.ID,
+					JiraIssueID:  p.JiraIssueID,
+					ModifiedTime: p.ProjectModifiedAt.Unix(),
+					Status:       p.Status.ToString(),
+					Title:        p.Title,
+				})
+			}
+
+			// Write response.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			enc := json.NewEncoder(w)
+			if err := enc.Encode(resp); err != nil {
+				srv.Logger.Error("error encoding response",
+					append([]interface{}{
+						"error", err,
+					}, logArgs...)...,
+				)
+				http.Error(
+					w, "Error processing request", http.StatusInternalServerError)
+				return
+			}
+
+		case "POST":
+			logArgs = append(logArgs, "method", r.Method)
+
+			// Decode request.
+			var req ProjectsPostRequest
+			if err := decodeRequest(r, &req); err != nil {
+				srv.Logger.Error("error decoding request",
+					append([]interface{}{
+						"error", err,
+					}, logArgs...)...)
+				http.Error(
+					w, "Bad request", http.StatusBadRequest)
+				return
+			}
+
+			// Validate request.
+			if req.Title == "" {
+				http.Error(w, "Bad request: title is required", http.StatusBadRequest)
+				return
+			}
+
+			// Build project for database.
+			proj := models.Project{
+				Creator: models.User{
+					EmailAddress: userEmail,
+				},
+				Title: req.Title,
+			}
+			if req.Description != nil {
+				proj.Description = *req.Description
+			}
+			if req.JiraIssueID != nil {
+				proj.JiraIssueID = *req.JiraIssueID
+			}
+
+			// Create project.
+			if err := proj.Create(srv.DB); err != nil {
+				srv.Logger.Error("error creating project",
+					append([]interface{}{
+						"error", err,
+					}, logArgs...)...)
+				http.Error(w, "Error creating project", http.StatusInternalServerError)
+				return
+			}
+			logArgs = append(logArgs, "project_id", proj.ID)
+
+			// Write response.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			resp := &ProjectsPostResponse{
+				ID: int(proj.ID),
+			}
+
+			enc := json.NewEncoder(w)
+			if err := enc.Encode(resp); err != nil {
+				srv.Logger.Error("error encoding response",
+					append([]interface{}{
+						"error", err,
+					}, logArgs...)...,
+				)
+				http.Error(w, "Error creating project",
+					http.StatusInternalServerError)
+				return
+			}
+
+			srv.Logger.Info("created project", logArgs...)
+
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+	})
+}
+
+func ProjectHandler(srv server.Server) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logArgs := []any{
+			"path", r.URL.Path,
+		}
+
+		// Authorize request.
+		userEmail := r.Context().Value("userEmail").(string)
+		if userEmail == "" {
+			srv.Logger.Error("user email not found in request context", logArgs...)
+			http.Error(
+				w, "No authorization information for request", http.StatusUnauthorized)
+			return
+		}
+
+		// Parse project ID and subpath.
+		projectRegex := regexp.MustCompile(
+			`^\/api\/v2\/projects\/([0-9A-Za-z_\-]+)$`)
+		projectRelatedResourcesRegex := regexp.MustCompile(
+			`^\/api\/v2\/projects\/([0-9A-Za-z_\-]+)\/related-resources$`)
+		switch {
+		case projectRelatedResourcesRegex.MatchString(r.URL.Path):
+			projectID, err := getProjectIDFromPath(
+				r.URL.Path, projectRelatedResourcesRegex)
+			if err != nil {
+				srv.Logger.Warn("error getting project ID from path",
+					append([]interface{}{
+						"error", err,
+					}, logArgs...)...)
+				http.Error(w, "Project not found", http.StatusNotFound)
+				return
+			}
+
+			projectsResourceRelatedResourcesHandler(srv, w, r, projectID)
+			return
+
+		case projectRegex.MatchString(r.URL.Path):
+			projectID, err := getProjectIDFromPath(r.URL.Path, projectRegex)
+			if err != nil {
+				srv.Logger.Warn("error getting project ID from path",
+					append([]interface{}{
+						"error", err,
+					}, logArgs...)...)
+				http.Error(w, "Project not found", http.StatusNotFound)
+				return
+			}
+			logArgs = append(logArgs, "project_id", projectID)
+
+			switch r.Method {
+			case "PATCH":
+				logArgs = append(logArgs, "method", r.Method)
+
+				// Decode request.
+				var req ProjectPatchRequest
+				if err := decodeRequest(r, &req); err != nil {
+					srv.Logger.Error("error decoding request",
+						append([]interface{}{
+							"error", err,
+						}, logArgs...)...)
+					http.Error(
+						w, "Bad request", http.StatusBadRequest)
+					return
+				}
+
+				// Validate request.
+				if req.Status != "" {
+					switch strings.ToLower(req.Status) {
+					case "active":
+					case "archived":
+					case "complete":
+					default:
+						http.Error(w,
+							"Bad request: invalid status"+
+								` (valid values are "active", "archived", "complete")`,
+							http.StatusBadRequest)
+						return
+					}
+				}
+				if req.Title == "" {
+					http.Error(
+						w, "Bad request: title cannot be empty", http.StatusBadRequest)
+					return
+				}
+
+				// Get project.
+				proj := models.Project{}
+				if err := proj.Get(srv.DB, projectID); err != nil {
+					if errors.Is(err, gorm.ErrRecordNotFound) {
+						srv.Logger.Warn("project not found", logArgs...)
+						http.Error(w, "Project not found", http.StatusNotFound)
+						return
+					} else {
+						srv.Logger.Error("error getting project from database",
+							append([]interface{}{
+								"error", err,
+							}, logArgs...)...)
+						http.Error(
+							w, "Error processing requst", http.StatusInternalServerError)
+						return
+					}
+				}
+
+				// Build project patch.
+				patch := models.Project{
+					Model: gorm.Model{
+						ID: uint(projectID),
+					},
+				}
+				if req.Description != nil {
+					patch.Description = *req.Description
+				}
+				if req.JiraIssueID != nil {
+					patch.JiraIssueID = *req.JiraIssueID
+				}
+				if req.Status != "" {
+					switch strings.ToLower(req.Status) {
+					case "active":
+						patch.Status = models.ActiveProjectStatus
+					case "archived":
+						patch.Status = models.ArchivedProjectStatus
+					case "complete":
+						patch.Status = models.CompletedProjectStatus
+					}
+				}
+				patch.Title = req.Title
+
+				// Update project in the database.
+				if err := patch.Update(srv.DB); err != nil {
+					srv.Logger.Error("error updating project",
+						append([]interface{}{
+							"error", err,
+						}, logArgs...)...)
+					http.Error(
+						w, "Error updating project", http.StatusInternalServerError)
+					return
+				}
+
+				srv.Logger.Info("updated project", logArgs...)
+
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+
+		default:
+			srv.Logger.Warn("path not found", logArgs...)
+			http.Error(w, "Not found", http.StatusNotFound)
+			return
+		}
+	})
+}
+
+// getProjectIDFromPath returns the project ID from a request path and
+// corresponding regular expression.
+func getProjectIDFromPath(path string, re *regexp.Regexp) (uint, error) {
+	matches := re.FindStringSubmatch(path)
+	if len(matches) != 2 {
+		return 0,
+			fmt.Errorf(
+				"wrong number of string submatches for resource URL path: %d",
+				len(matches),
+			)
+	}
+	projectIDStr := matches[1]
+
+	projectID, err := strconv.Atoi(projectIDStr)
+	if err != nil {
+		return 0,
+			fmt.Errorf("error convering project ID to integer: %w", err)
+	}
+
+	return uint(projectID), nil
+}

--- a/internal/api/v2/projects_related_resources.go
+++ b/internal/api/v2/projects_related_resources.go
@@ -1,0 +1,271 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/hashicorp-forge/hermes/internal/server"
+	"github.com/hashicorp-forge/hermes/pkg/document"
+	"github.com/hashicorp-forge/hermes/pkg/models"
+	"gorm.io/gorm"
+)
+
+type ProjectRelatedResourcesGetResponse struct {
+	ExternalLinks   []ProjectRelatedResourcesGetResponseExternalLink   `json:"externalLinks,omitempty"`
+	HermesDocuments []ProjectRelatedResourcesGetResponseHermesDocument `json:"hermesDocuments,omitempty"`
+}
+
+type ProjectRelatedResourcesGetResponseExternalLink struct {
+	Name      string `json:"name"`
+	URL       string `json:"url"`
+	SortOrder int    `json:"sortOrder"`
+}
+
+type ProjectRelatedResourcesGetResponseHermesDocument struct {
+	GoogleFileID   string `json:"googleFileID"`
+	Title          string `json:"title"`
+	DocumentType   string `json:"documentType"`
+	DocumentNumber string `json:"documentNumber"`
+	SortOrder      int    `json:"sortOrder"`
+}
+
+type ProjectRelatedResourcesPutRequest struct {
+	ExternalLinks   []ProjectRelatedResourcesPutRequestExternalLink   `json:"externalLinks,omitempty"`
+	HermesDocuments []ProjectRelatedResourcesPutRequestHermesDocument `json:"hermesDocuments,omitempty"`
+}
+
+type ProjectRelatedResourcesPutRequestExternalLink struct {
+	Name      string `json:"name"`
+	URL       string `json:"url"`
+	SortOrder int    `json:"sortOrder"`
+}
+
+type ProjectRelatedResourcesPutRequestHermesDocument struct {
+	GoogleFileID string `json:"googleFileID"`
+	SortOrder    int    `json:"sortOrder"`
+}
+
+func projectsResourceRelatedResourcesHandler(
+	srv server.Server,
+	w http.ResponseWriter,
+	r *http.Request,
+	projectID uint,
+) {
+	logArgs := []any{
+		"path", r.URL.Path,
+		"project_id", projectID,
+	}
+
+	switch r.Method {
+	case "GET":
+		logArgs = append(logArgs, "method", r.Method)
+
+		// Get project.
+		proj := models.Project{}
+		if err := proj.Get(srv.DB, projectID); err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				srv.Logger.Warn("project not found", logArgs...)
+				http.Error(w, "Project not found", http.StatusNotFound)
+				return
+			} else {
+				srv.Logger.Error("error getting project from database",
+					append([]interface{}{
+						"error", err,
+					}, logArgs...)...)
+				http.Error(
+					w, "Error processing requst", http.StatusInternalServerError)
+				return
+			}
+		}
+
+		// Get typed related resources.
+		elrrs, hdrrs, err := proj.GetRelatedResources(srv.DB)
+		if err != nil {
+			srv.Logger.Error("error getting related resources",
+				append([]interface{}{
+					"error", err,
+				}, logArgs...)...)
+			http.Error(
+				w, "Error processing requst", http.StatusInternalServerError)
+			return
+		}
+
+		// Build response.
+		resp := ProjectRelatedResourcesGetResponse{
+			ExternalLinks:   []ProjectRelatedResourcesGetResponseExternalLink{},
+			HermesDocuments: []ProjectRelatedResourcesGetResponseHermesDocument{},
+		}
+		// Add external link related resources.
+		for _, elrr := range elrrs {
+			if err := elrr.Get(srv.DB); err != nil {
+				srv.Logger.Error(
+					"error getting external link related resource from database",
+					append([]interface{}{
+						"error", err,
+					}, logArgs...)...)
+				http.Error(
+					w, "Error processing requst", http.StatusInternalServerError)
+				return
+			}
+
+			resp.ExternalLinks = append(resp.ExternalLinks,
+				ProjectRelatedResourcesGetResponseExternalLink{
+					Name:      elrr.Name,
+					URL:       elrr.URL,
+					SortOrder: elrr.RelatedResource.SortOrder,
+				})
+		}
+		// Add Hermes document related resources.
+		for _, hdrr := range hdrrs {
+			logArgs = append(logArgs, "document_id", hdrr.Document.GoogleFileID)
+
+			// Get document from database.
+			model := models.Document{
+				GoogleFileID: hdrr.Document.GoogleFileID,
+			}
+			if err := model.Get(srv.DB); err != nil {
+				srv.Logger.Error("error getting document from database",
+					append([]interface{}{
+						"error", err,
+					}, logArgs...)...)
+				http.Error(
+					w, "Error processing requst", http.StatusInternalServerError)
+				return
+			}
+
+			// Get reviews for the document.
+			var reviews models.DocumentReviews
+			if err := reviews.Find(srv.DB, models.DocumentReview{
+				Document: models.Document{
+					GoogleFileID: hdrr.Document.GoogleFileID,
+				},
+			}); err != nil {
+				srv.Logger.Error("error getting reviews for document",
+					append([]interface{}{
+						"error", err,
+					}, logArgs...)...)
+				http.Error(
+					w, "Error processing requst", http.StatusInternalServerError)
+				return
+			}
+
+			// Convert database model to a document.
+			doc, err := document.NewFromDatabaseModel(
+				model, reviews)
+			if err != nil {
+				srv.Logger.Error("error converting database model to document type",
+					append([]interface{}{
+						"error", err,
+					}, logArgs...)...)
+				http.Error(
+					w, "Error processing requst", http.StatusInternalServerError)
+				return
+			}
+
+			resp.HermesDocuments = append(
+				resp.HermesDocuments,
+				ProjectRelatedResourcesGetResponseHermesDocument{
+					GoogleFileID:   hdrr.Document.GoogleFileID,
+					Title:          doc.Title,
+					DocumentType:   doc.DocType,
+					DocumentNumber: doc.DocNumber,
+					SortOrder:      hdrr.RelatedResource.SortOrder,
+				})
+		}
+
+		// Write response.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		enc := json.NewEncoder(w)
+		err = enc.Encode(resp)
+		if err != nil {
+			srv.Logger.Error("error encoding response",
+				append([]interface{}{
+					"error", err,
+				}, logArgs...)...)
+			http.Error(
+				w, "Error processing requst", http.StatusInternalServerError)
+			return
+		}
+
+	case "POST":
+		fallthrough
+	case "PUT":
+		logArgs = append(logArgs, "method", r.Method)
+
+		// Decode request.
+		var req ProjectRelatedResourcesPutRequest
+		if err := decodeRequest(r, &req); err != nil {
+			srv.Logger.Error("error decoding request",
+				append([]interface{}{
+					"error", err,
+				}, logArgs...)...)
+			http.Error(
+				w, "Bad request", http.StatusBadRequest)
+			return
+		}
+
+		// Get project.
+		proj := models.Project{}
+		if err := proj.Get(srv.DB, projectID); err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				srv.Logger.Warn("project not found", logArgs...)
+				http.Error(w, "Project not found", http.StatusNotFound)
+				return
+			} else {
+				srv.Logger.Error("error getting project from database",
+					append([]interface{}{
+						"error", err,
+					}, logArgs...)...)
+				http.Error(
+					w, "Error processing requst", http.StatusInternalServerError)
+				return
+			}
+		}
+
+		// Build external link related resources for database model.
+		elrrs := []models.ProjectRelatedResourceExternalLink{}
+		for _, elrr := range req.ExternalLinks {
+			elrrs = append(elrrs, models.ProjectRelatedResourceExternalLink{
+				RelatedResource: models.ProjectRelatedResource{
+					ProjectID: uint(projectID),
+					SortOrder: elrr.SortOrder,
+				},
+				Name: elrr.Name,
+				URL:  elrr.URL,
+			})
+		}
+
+		// Build Hermes document related resources for database model.
+		hdrrs := []models.ProjectRelatedResourceHermesDocument{}
+		for _, hdrr := range req.HermesDocuments {
+			hdrrs = append(hdrrs, models.ProjectRelatedResourceHermesDocument{
+				RelatedResource: models.ProjectRelatedResource{
+					ProjectID: projectID,
+					SortOrder: hdrr.SortOrder,
+				},
+				Document: models.Document{
+					GoogleFileID: hdrr.GoogleFileID,
+				},
+			})
+		}
+
+		// Replace related resources for project.
+		if err := proj.ReplaceRelatedResources(srv.DB, elrrs, hdrrs); err != nil {
+			srv.Logger.Error("error replacing related resources for document",
+				append([]interface{}{
+					"error", err,
+				}, logArgs...)...)
+			http.Error(
+				w, "Error processing requst", http.StatusInternalServerError)
+			return
+		}
+
+		srv.Logger.Info("replaced related resources for project", logArgs...)
+
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+}

--- a/internal/api/v2/projects_related_resources.go
+++ b/internal/api/v2/projects_related_resources.go
@@ -87,7 +87,7 @@ func projectsResourceRelatedResourcesHandler(
 					"error", err,
 				}, logArgs...)...)
 			http.Error(
-				w, "Error processing requst", http.StatusInternalServerError)
+				w, "Error processing request", http.StatusInternalServerError)
 			return
 		}
 
@@ -105,7 +105,7 @@ func projectsResourceRelatedResourcesHandler(
 						"error", err,
 					}, logArgs...)...)
 				http.Error(
-					w, "Error processing requst", http.StatusInternalServerError)
+					w, "Error processing request", http.StatusInternalServerError)
 				return
 			}
 
@@ -146,7 +146,7 @@ func projectsResourceRelatedResourcesHandler(
 						"error", err,
 					}, logArgs...)...)
 				http.Error(
-					w, "Error processing requst", http.StatusInternalServerError)
+					w, "Error processing request", http.StatusInternalServerError)
 				return
 			}
 
@@ -219,7 +219,7 @@ func projectsResourceRelatedResourcesHandler(
 						"error", err,
 					}, logArgs...)...)
 				http.Error(
-					w, "Error processing requst", http.StatusInternalServerError)
+					w, "Error processing request", http.StatusInternalServerError)
 				return
 			}
 		}
@@ -258,7 +258,7 @@ func projectsResourceRelatedResourcesHandler(
 					"error", err,
 				}, logArgs...)...)
 			http.Error(
-				w, "Error processing requst", http.StatusInternalServerError)
+				w, "Error processing request", http.StatusInternalServerError)
 			return
 		}
 

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -342,6 +342,8 @@ func (c *Command) Run(args []string) int {
 			api.MeSubscriptionsHandler(cfg, c.Log, goog, db)},
 		{"/api/v1/people", api.PeopleDataHandler(cfg, c.Log, goog)},
 		{"/api/v1/products", api.ProductsHandler(cfg, algoSearch, c.Log)},
+		{"/api/v1/products", apiv2.ProductsHandler(srv)},
+		{"/api/v1/projects", apiv2.ProjectsHandler(srv)},
 		{"/api/v1/reviews/",
 			api.ReviewHandler(cfg, c.Log, algoSearch, algoWrite, goog, db)},
 		{"/api/v1/web/analytics", api.AnalyticsHandler(c.Log)},
@@ -357,6 +359,8 @@ func (c *Command) Run(args []string) int {
 		{"/api/v2/me/subscriptions", apiv2.MeSubscriptionsHandler(srv)},
 		{"/api/v2/people", apiv2.PeopleDataHandler(srv)},
 		{"/api/v2/products", apiv2.ProductsHandler(srv)},
+		{"/api/v2/projects", apiv2.ProjectsHandler(srv)},
+		{"/api/v2/projects/", apiv2.ProjectHandler(srv)},
 		{"/api/v2/reviews/", apiv2.ReviewsHandler(srv)},
 		{"/api/v2/web/analytics", apiv2.AnalyticsHandler(srv)},
 	}

--- a/pkg/models/gorm.go
+++ b/pkg/models/gorm.go
@@ -15,6 +15,10 @@ func ModelsToAutoMigrate() []interface{} {
 		&IndexerMetadata{},
 		&Product{},
 		&ProductLatestDocumentNumber{},
+		&Project{},
+		&ProjectRelatedResource{},
+		&ProjectRelatedResourceExternalLink{},
+		&ProjectRelatedResourceHermesDocument{},
 		&User{},
 	}
 }

--- a/pkg/models/project.go
+++ b/pkg/models/project.go
@@ -1,0 +1,292 @@
+package models
+
+import (
+	"fmt"
+	"time"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Project is a model for a project.
+type Project struct {
+	gorm.Model
+
+	// Creator is the user that created the project.
+	Creator   User
+	CreatorID uint `gorm:"default:null;not null"`
+
+	// Description is a description of the project.
+	// Description *string
+	Description string
+
+	// JiraIssueID is the ID of the Jira issue associated with the project.
+	// JiraIssueID *string
+	JiraIssueID string
+
+	// ProjectCreatedAt is the time of project creation.
+	ProjectCreatedAt time.Time `gorm:"default:null;not null"`
+
+	// ProjectModifiedAt is the time the project was last modified.
+	ProjectModifiedAt time.Time `gorm:"default:null;not null"`
+
+	// RelatedResources are the related resources for the project.
+	RelatedResources []*ProjectRelatedResource
+
+	// Status is the status of the document.
+	Status ProjectStatus `gorm:"default:null;not null"`
+	// Status *ProjectStatus
+
+	// Title is the title of the project.
+	Title string `gorm:"default:null;not null"`
+}
+
+// ProjectStatus is the status of the project.
+type ProjectStatus int
+
+const (
+	UnspecifiedProjectStatus ProjectStatus = iota
+	ActiveProjectStatus
+	CompletedProjectStatus
+	ArchivedProjectStatus
+)
+
+func (s *ProjectStatus) ToString() string {
+	switch *s {
+	case ActiveProjectStatus:
+		return "active"
+	case CompletedProjectStatus:
+		return "completed"
+	case ArchivedProjectStatus:
+		return "archived"
+	}
+
+	return ""
+}
+
+// Create creates a new project. The resulting project is saved back to the
+// receiver.
+func (p *Project) Create(db *gorm.DB) error {
+	// Validate required fields.
+	if err := validation.ValidateStruct(p,
+		validation.Field(&p.Title, validation.Required),
+	); err != nil {
+		return err
+	}
+	if err := validation.ValidateStruct(&p.Creator,
+		validation.Field(
+			&p.Creator.ID,
+			validation.When(p.Creator.EmailAddress == "",
+				validation.Required.Error("either ID or EmailAddress is required"),
+			),
+		),
+		validation.Field(
+			&p.Creator.EmailAddress,
+			validation.When(p.Creator.ID == 0,
+				validation.Required.Error("either ID or EmailAddress is required"),
+			),
+		),
+	); err != nil {
+		return err
+	}
+
+	// Preload associations.
+	if err := p.preloadAssocations(db); err != nil {
+		return fmt.Errorf("error preloading associations: %w", err)
+	}
+
+	now := time.Now()
+	p.ProjectCreatedAt = now.UTC()
+	p.ProjectModifiedAt = now.UTC()
+	p.Status = ActiveProjectStatus
+
+	return db.
+		Omit(clause.Associations).
+		Create(&p).
+		Error
+}
+
+// Get gets a project by ID.
+func (p *Project) Get(db *gorm.DB, id uint) error {
+	// Validate required fields.
+	if err := validation.Validate(id, validation.Required); err != nil {
+		return err
+	}
+
+	return db.
+		Preload(clause.Associations).
+		First(&p, id).
+		Error
+}
+
+// GetRelatedResources returns typed related resources for project p.
+func (p *Project) GetRelatedResources(db *gorm.DB) (
+	elrrs []ProjectRelatedResourceExternalLink,
+	hdrrs []ProjectRelatedResourceHermesDocument,
+	err error,
+) {
+	// Validate required fields.
+	if err := validation.Validate(p.ID, validation.Required); err != nil {
+		return nil, nil, err
+	}
+
+	// Get the project.
+	if err := p.Get(db, p.ID); err != nil {
+		return nil, nil, fmt.Errorf("error getting project: %w", err)
+	}
+
+	// Get related resources.
+	for _, rr := range p.RelatedResources {
+		switch rr.RelatedResourceType {
+		case "project_related_resource_external_links":
+			elrr := ProjectRelatedResourceExternalLink{}
+			if err := db.
+				Where("id = ?", rr.RelatedResourceID).
+				Preload(clause.Associations).
+				First(&elrr).Error; err != nil {
+				return nil,
+					nil,
+					fmt.Errorf("error getting external link related resource: %w", err)
+			}
+			elrrs = append(elrrs, elrr)
+		case "project_related_resource_hermes_documents":
+			hdrr := ProjectRelatedResourceHermesDocument{}
+			if err := db.
+				Where("id = ?", rr.RelatedResourceID).
+				Preload(clause.Associations).
+				First(&hdrr).Error; err != nil {
+				return nil,
+					nil,
+					fmt.Errorf(
+						"error getting document for Hermes document related resource: %w",
+						err)
+			}
+			hdrrs = append(hdrrs, hdrr)
+		default:
+			return nil,
+				nil,
+				fmt.Errorf("unknown related resource type: %s", rr.RelatedResourceType)
+		}
+	}
+
+	return
+}
+
+// ReplaceRelatedResources replaces related resources for project p.
+func (p *Project) ReplaceRelatedResources(
+	db *gorm.DB,
+	elrrs []ProjectRelatedResourceExternalLink,
+	hdrrs []ProjectRelatedResourceHermesDocument,
+) error {
+	// Validate required fields.
+	if err := validation.Validate(p.ID, validation.Required); err != nil {
+		return err
+	}
+
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		// Delete assocations of RelatedResources.
+		rrs := []ProjectRelatedResource{}
+		if err := tx.
+			Where("project_id = ?", p.ID).
+			Find(&rrs).Error; err != nil {
+			return fmt.Errorf("error finding existing related resources: %w", err)
+		}
+		for _, rr := range rrs {
+			if err := tx.
+				Exec(
+					fmt.Sprintf("DELETE FROM %q WHERE id = ?", rr.RelatedResourceType),
+					rr.RelatedResourceID,
+				).
+				Error; err != nil {
+				return fmt.Errorf(
+					"error deleting existing typed related resources: %w", err)
+			}
+		}
+
+		// Delete RelatedResources.
+		if err := tx.
+			Unscoped(). // Hard delete instead of soft delete.
+			Where("project_id = ?", p.ID).
+			Delete(&ProjectRelatedResource{}).Error; err != nil {
+			return fmt.Errorf("error deleting existing related resources: %w", err)
+		}
+
+		// Create all related resources.
+		for _, elrr := range elrrs {
+			if err := elrr.Create(tx); err != nil {
+				return fmt.Errorf(
+					"error creating external link related resource: %w", err)
+			}
+		}
+		for _, hdrr := range hdrrs {
+			if err := hdrr.Create(tx); err != nil {
+				return fmt.Errorf(
+					"error creating Hermes document related resource: %w", err)
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return fmt.Errorf("error replacing related resources: %w", err)
+	}
+
+	return nil
+}
+
+// Update updates a project. The resulting project is saved back to the
+// receiver.
+func (p *Project) Update(db *gorm.DB) error {
+	// Validate required fields.
+	if err := validation.ValidateStruct(p,
+		validation.Field(&p.ID, validation.Required),
+	); err != nil {
+		return err
+	}
+
+	now := time.Now()
+	p.ProjectModifiedAt = now.UTC()
+
+	// Build fields to omit during an update. Because we use `Select("*")` to
+	// allow removal of values for non-required fields, we need to do this
+	// manually.
+	omitFields := []string{
+		"Creator",
+		"CreatorID",
+		"ProjectCreatedAt",
+	}
+	if p.Status == UnspecifiedProjectStatus {
+		omitFields = append(omitFields, "Status")
+	}
+	if p.Title == "" {
+		omitFields = append(omitFields, "Title")
+	}
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.
+			Model(&p).
+			Select("*").
+			Omit(omitFields...).
+			Updates(p).
+			Error; err != nil {
+			return err
+		}
+
+		if err := p.Get(tx, p.ID); err != nil {
+			return fmt.Errorf("error getting the project after update: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// preloadAssocations preloads assocations for a project.
+func (p *Project) preloadAssocations(db *gorm.DB) error {
+	// Preload Creator.
+	if err := p.Creator.FirstOrCreate(db); err != nil {
+		return fmt.Errorf("error finding or creating Creator: %w", err)
+	}
+	p.CreatorID = p.Creator.ID
+
+	return nil
+}

--- a/pkg/models/project_related_resource.go
+++ b/pkg/models/project_related_resource.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"gorm.io/gorm"
+)
+
+// ProjectRelatedResource is a model for a project related resource.
+type ProjectRelatedResource struct {
+	gorm.Model
+
+	// Project is the project that the related resource is attached to.
+	Project   Project
+	ProjectID uint `gorm:"uniqueIndex:project_id_sort_order_unique"`
+
+	// RelatedResourceID is the foreign key of the related resource, set by a Gorm
+	// polymorphic relationship.
+	RelatedResourceID uint `gorm:"default:null;not null"`
+
+	// RelatedResourceType is the table for the related resource, set by a Gorm
+	// polymorphic relationship.
+	RelatedResourceType string `gorm:"default:null;not null"`
+
+	// SortOrder is the relative order of the related resource in comparison to
+	// all of the project's other related resources.
+	SortOrder int `gorm:"default:null;not null;uniqueIndex:project_id_sort_order_unique"`
+}

--- a/pkg/models/project_related_resource_external_link.go
+++ b/pkg/models/project_related_resource_external_link.go
@@ -1,0 +1,64 @@
+package models
+
+import (
+	"fmt"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type ProjectRelatedResourceExternalLink struct {
+	gorm.Model
+
+	RelatedResource ProjectRelatedResource `gorm:"polymorphic:RelatedResource"`
+
+	Name string `gorm:"default:null;not null"`
+
+	URL string `gorm:"default:null;not null"`
+}
+
+type ProjectRelatedResourceExternalLinks []ProjectRelatedResourceExternalLink
+
+func (rr *ProjectRelatedResourceExternalLink) Create(db *gorm.DB) error {
+	// Validate required fields.
+	if err := validation.ValidateStruct(&rr.RelatedResource,
+		validation.Field(&rr.RelatedResource.ProjectID,
+			validation.When(rr.RelatedResource.Project.ID == 0,
+				validation.Required.Error("Project ID is required"),
+			),
+		),
+	); err != nil {
+		return err
+	}
+	if err := validation.ValidateStruct(&rr.RelatedResource.Project,
+		validation.Field(&rr.RelatedResource.Project.ID,
+			validation.When(rr.RelatedResource.ProjectID == 0,
+				validation.Required.Error("Project ID is required"),
+			),
+		),
+	); err != nil {
+		return err
+	}
+
+	// Preload RelatedResource.Project.
+	if rr.RelatedResource.ProjectID == 0 {
+		proj := Project{}
+		if err := proj.Get(db, rr.RelatedResource.Project.ID); err != nil {
+			return fmt.Errorf("error preloading RelatedResource.Project: %w", err)
+		}
+		rr.RelatedResource.ProjectID = rr.RelatedResource.Project.ID
+	}
+
+	return db.
+		Omit("RelatedResource.Project").
+		Create(&rr).
+		Error
+}
+
+func (rr *ProjectRelatedResourceExternalLink) Get(db *gorm.DB) error {
+	return db.
+		Preload(clause.Associations).
+		Preload("RelatedResource.Project").
+		First(&rr).Error
+}

--- a/pkg/models/project_related_resource_hermes_document.go
+++ b/pkg/models/project_related_resource_hermes_document.go
@@ -1,0 +1,66 @@
+package models
+
+import (
+	"fmt"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"gorm.io/gorm"
+)
+
+type ProjectRelatedResourceHermesDocument struct {
+	gorm.Model
+
+	RelatedResource ProjectRelatedResource `gorm:"polymorphic:RelatedResource"`
+
+	// Document is the target related Hermes document.
+	Document   Document
+	DocumentID uint
+}
+
+func (rr *ProjectRelatedResourceHermesDocument) Create(db *gorm.DB) error {
+	// Validate required fields.
+	if err := validation.ValidateStruct(&rr.RelatedResource,
+		validation.Field(&rr.RelatedResource.ProjectID,
+			validation.When(rr.RelatedResource.Project.ID == 0,
+				validation.Required.Error("Project ID is required"),
+			),
+		),
+	); err != nil {
+		return err
+	}
+	if err := validation.ValidateStruct(&rr.RelatedResource.Project,
+		validation.Field(&rr.RelatedResource.Project.ID,
+			validation.When(rr.RelatedResource.ProjectID == 0,
+				validation.Required.Error("Project ID is required"),
+			),
+		),
+	); err != nil {
+		return err
+	}
+
+	// Preload Document.
+	if rr.DocumentID == 0 {
+		if err := db.
+			Where(Document{GoogleFileID: rr.Document.GoogleFileID}).
+			First(&rr.Document).
+			Error; err != nil {
+			return fmt.Errorf("error preloading RelatedResource.Document: %w", err)
+		}
+		rr.DocumentID = rr.Document.ID
+	}
+
+	// Preload RelatedResource.Project.
+	if rr.RelatedResource.ProjectID == 0 {
+		proj := Project{}
+		if err := proj.Get(db, rr.RelatedResource.Project.ID); err != nil {
+			return fmt.Errorf("error preloading RelatedResource.Project: %w", err)
+		}
+		rr.RelatedResource.ProjectID = rr.RelatedResource.Project.ID
+	}
+
+	return db.
+		Omit("Document").
+		Omit("RelatedResource.Project").
+		Create(&rr).
+		Error
+}

--- a/pkg/models/project_related_resource_test.go
+++ b/pkg/models/project_related_resource_test.go
@@ -1,0 +1,212 @@
+package models
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+func TestProjectRelatedResource(t *testing.T) {
+	dsn := os.Getenv("HERMES_TEST_POSTGRESQL_DSN")
+	if dsn == "" {
+		t.Skip("HERMES_TEST_POSTGRESQL_DSN environment variable isn't set")
+	}
+
+	t.Run("Get and Update", func(t *testing.T) {
+		db, tearDownTest := setupTest(t, dsn)
+		defer tearDownTest(t)
+
+		t.Run("Create a document type", func(t *testing.T) {
+			_, require := assert.New(t), require.New(t)
+			dt := DocumentType{
+				Name:     "DT1",
+				LongName: "DocumentType1",
+			}
+			err := dt.FirstOrCreate(db)
+			require.NoError(err)
+		})
+
+		t.Run("Create a product", func(t *testing.T) {
+			_, require := assert.New(t), require.New(t)
+			p := Product{
+				Name:         "Product1",
+				Abbreviation: "P1",
+			}
+			err := p.FirstOrCreate(db)
+			require.NoError(err)
+		})
+
+		t.Run("Create documents", func(t *testing.T) {
+			_, require := assert.New(t), require.New(t)
+			d := Document{
+				GoogleFileID: "GoogleFileID1",
+				DocumentType: DocumentType{
+					Name: "DT1",
+				},
+				Product: Product{
+					Name: "Product1",
+				},
+			}
+			err := d.Create(db)
+			require.NoError(err)
+
+			d = Document{
+				GoogleFileID: "GoogleFileID2",
+				DocumentType: DocumentType{
+					Name: "DT1",
+				},
+				Product: Product{
+					Name: "Product1",
+				},
+			}
+			err = d.Create(db)
+			require.NoError(err)
+
+			d = Document{
+				GoogleFileID: "GoogleFileID3",
+				DocumentType: DocumentType{
+					Name: "DT1",
+				},
+				Product: Product{
+					Name: "Product1",
+				},
+			}
+			err = d.Create(db)
+			require.NoError(err)
+		})
+
+		t.Run("Create a project", func(t *testing.T) {
+			_, require := assert.New(t), require.New(t)
+			p := Project{
+				Creator: User{
+					EmailAddress: "a@a.com",
+				},
+				Title: "Title1",
+			}
+			err := p.Create(db)
+			require.NoError(err)
+			require.EqualValues(1, p.ID)
+		})
+
+		t.Run(
+			"Try to add related resource without an associated typed related resource",
+			func(t *testing.T) {
+				_, require := assert.New(t), require.New(t)
+
+				rr := ProjectRelatedResource{
+					Project: Project{
+						Model: gorm.Model{
+							ID: 1,
+						},
+					},
+					SortOrder: 1,
+				}
+				err := db.
+					Omit(clause.Associations).
+					Create(&rr).
+					Error
+				require.Error(err)
+			})
+
+		t.Run("Add external link related resource", func(t *testing.T) {
+			_, require := assert.New(t), require.New(t)
+
+			rr := ProjectRelatedResourceExternalLink{
+				RelatedResource: ProjectRelatedResource{
+					Project: Project{
+						Model: gorm.Model{
+							ID: 1,
+						},
+					},
+					SortOrder: 1,
+				},
+				Name: "Name1",
+				URL:  "URL1",
+			}
+			err := rr.Create(db)
+			require.NoError(err)
+		})
+
+		t.Run("Add external link related resource with same SortOrder",
+			func(t *testing.T) {
+				_, require := assert.New(t), require.New(t)
+
+				rr := ProjectRelatedResourceExternalLink{
+					RelatedResource: ProjectRelatedResource{
+						Project: Project{
+							Model: gorm.Model{
+								ID: 1,
+							},
+						},
+						SortOrder: 1,
+					},
+					Name: "Name2",
+					URL:  "URL2",
+				}
+				err := rr.Create(db)
+				require.Error(err)
+			})
+
+		t.Run("Add another external link related resource using ProjectID",
+			func(t *testing.T) {
+				_, require := assert.New(t), require.New(t)
+
+				rr := ProjectRelatedResourceExternalLink{
+					RelatedResource: ProjectRelatedResource{
+						ProjectID: 1,
+						SortOrder: 2,
+					},
+					Name: "Name2",
+					URL:  "URL2",
+				}
+				err := rr.Create(db)
+				require.NoError(err)
+			})
+
+		t.Run("Add Hermes document related resource with same SortOrder",
+			func(t *testing.T) {
+				_, require := assert.New(t), require.New(t)
+
+				rr := ProjectRelatedResourceHermesDocument{
+					RelatedResource: ProjectRelatedResource{
+						Project: Project{
+							Model: gorm.Model{
+								ID: 1,
+							},
+						},
+						SortOrder: 2,
+					},
+					Document: Document{
+						GoogleFileID: "GoogleFileID1",
+					},
+				}
+				err := rr.Create(db)
+				require.Error(err)
+			})
+
+		t.Run("Add Hermes document related resource",
+			func(t *testing.T) {
+				_, require := assert.New(t), require.New(t)
+
+				rr := ProjectRelatedResourceHermesDocument{
+					RelatedResource: ProjectRelatedResource{
+						Project: Project{
+							Model: gorm.Model{
+								ID: 1,
+							},
+						},
+						SortOrder: 3,
+					},
+					Document: Document{
+						GoogleFileID: "GoogleFileID1",
+					},
+				}
+				err := rr.Create(db)
+				require.NoError(err)
+			})
+	})
+}

--- a/pkg/models/project_test.go
+++ b/pkg/models/project_test.go
@@ -1,0 +1,463 @@
+package models
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestProject(t *testing.T) {
+	dsn := os.Getenv("HERMES_TEST_POSTGRESQL_DSN")
+	if dsn == "" {
+		t.Skip("HERMES_TEST_POSTGRESQL_DSN environment variable isn't set")
+	}
+
+	t.Run("Create, Get, and Update", func(t *testing.T) {
+		db, tearDownTest := setupTest(t, dsn)
+		defer tearDownTest(t)
+
+		t.Run("Create a project without a Creator", func(t *testing.T) {
+			assert, _ := assert.New(t), require.New(t)
+			p := Project{
+				Title: "Title1",
+			}
+			err := p.Create(db)
+			assert.Error(err)
+			assert.Empty(p.ID)
+		})
+
+		t.Run("Create a project without a Title", func(t *testing.T) {
+			assert, _ := assert.New(t), require.New(t)
+			p := Project{
+				Creator: User{
+					EmailAddress: "a@a.com",
+				},
+			}
+			err := p.Create(db)
+			assert.Error(err)
+			assert.Empty(p.ID)
+		})
+
+		t.Run("Create a minimal project", func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			p := Project{
+				Creator: User{
+					EmailAddress: "a@a.com",
+				},
+				Title: "Title1",
+			}
+			err := p.Create(db)
+			require.NoError(err)
+			assert.Equal("a@a.com", p.Creator.EmailAddress)
+			assert.EqualValues(1, p.Creator.ID)
+			assert.EqualValues(1, p.CreatorID)
+			assert.EqualValues(1, p.ID)
+			assert.WithinDuration(time.Now(), p.ProjectCreatedAt, 1*time.Second)
+			assert.WithinDuration(time.Now(), p.ProjectModifiedAt, 1*time.Second)
+			assert.Equal(ActiveProjectStatus, p.Status)
+			// assert.Equal(ActiveProjectStatus, *p.Status)
+			assert.Equal("Title1", p.Title)
+		})
+
+		t.Run("Get the project", func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			p := Project{}
+
+			err := p.Get(db, 1)
+			require.NoError(err)
+			assert.Equal("a@a.com", p.Creator.EmailAddress)
+			assert.EqualValues(1, p.Creator.ID)
+			assert.EqualValues(1, p.CreatorID)
+			assert.EqualValues(1, p.ID)
+			assert.WithinDuration(time.Now(), p.ProjectCreatedAt, 1*time.Second)
+			assert.WithinDuration(time.Now(), p.ProjectModifiedAt, 1*time.Second)
+			assert.Equal(ActiveProjectStatus, p.Status)
+			// assert.Equal(ActiveProjectStatus, *p.Status)
+			assert.Equal("Title1", p.Title)
+		})
+
+		t.Run("Update the project", func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			p := Project{
+				Model: gorm.Model{
+					ID: 1,
+				},
+				Title: "UpdatedTitle1",
+			}
+
+			err := p.Update(db)
+			require.NoError(err)
+			assert.Equal("a@a.com", p.Creator.EmailAddress)
+			assert.EqualValues(1, p.Creator.ID)
+			assert.EqualValues(1, p.CreatorID)
+			assert.EqualValues(1, p.ID)
+			assert.WithinDuration(time.Now(), p.ProjectModifiedAt, 1*time.Second)
+			assert.NotEqualf(p.ProjectCreatedAt, p.ProjectModifiedAt,
+				"ProjectModifiedAt should not be equal to ProjectCreatedAt")
+			assert.Equal(ActiveProjectStatus, p.Status)
+			assert.Equal("UpdatedTitle1", p.Title)
+		})
+
+		t.Run("Get the project", func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			p := Project{}
+
+			err := p.Get(db, 1)
+			require.NoError(err)
+			assert.Equal("a@a.com", p.Creator.EmailAddress)
+			assert.EqualValues(1, p.Creator.ID)
+			assert.EqualValues(1, p.CreatorID)
+			assert.EqualValues(1, p.ID)
+			assert.WithinDuration(time.Now(), p.ProjectCreatedAt, 1*time.Second)
+			assert.WithinDuration(time.Now(), p.ProjectModifiedAt, 1*time.Second)
+			assert.Equal(ActiveProjectStatus, p.Status)
+			assert.Equal("UpdatedTitle1", p.Title)
+		})
+
+		t.Run("Update a project that doesn't exist", func(t *testing.T) {
+			_, require := assert.New(t), require.New(t)
+			p := Project{
+				Model: gorm.Model{
+					ID: 10,
+				},
+				Title: "UpdatedTitle1",
+			}
+
+			err := p.Update(db)
+			require.Error(err)
+		})
+
+		t.Run("Create a second project with all fields", func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			p := Project{
+				Creator: User{
+					EmailAddress: "b@b.com",
+				},
+				Description: "Description2",
+				JiraIssueID: "JiraIssueID2",
+				Title:       "Title2",
+			}
+			err := p.Create(db)
+			require.NoError(err)
+			assert.Equal("b@b.com", p.Creator.EmailAddress)
+			assert.EqualValues(2, p.Creator.ID)
+			assert.EqualValues(2, p.CreatorID)
+			assert.EqualValues(2, p.ID)
+			assert.Equal("Description2", p.Description)
+			assert.Equal("JiraIssueID2", p.JiraIssueID)
+			assert.WithinDuration(time.Now(), p.ProjectCreatedAt, 1*time.Second)
+			assert.WithinDuration(time.Now(), p.ProjectModifiedAt, 1*time.Second)
+			assert.Equal(ActiveProjectStatus, p.Status)
+			assert.Equal("Title2", p.Title)
+		})
+
+		t.Run("Get the second project", func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			p := Project{}
+
+			err := p.Get(db, 2)
+			require.NoError(err)
+			assert.Equal("b@b.com", p.Creator.EmailAddress)
+			assert.EqualValues(2, p.Creator.ID)
+			assert.EqualValues(2, p.CreatorID)
+			assert.EqualValues(2, p.ID)
+			assert.Equal("Description2", p.Description)
+			assert.Equal("JiraIssueID2", p.JiraIssueID)
+			assert.WithinDuration(time.Now(), p.ProjectCreatedAt, 1*time.Second)
+			assert.WithinDuration(time.Now(), p.ProjectModifiedAt, 1*time.Second)
+			assert.Equal(ActiveProjectStatus, p.Status)
+			assert.Equal("Title2", p.Title)
+		})
+
+		t.Run("Update the second project to remove optional fields",
+			func(t *testing.T) {
+				assert, require := assert.New(t), require.New(t)
+				p := Project{
+					Model: gorm.Model{
+						ID: 2,
+					},
+					Description: "",
+					JiraIssueID: "",
+				}
+
+				err := p.Update(db)
+				require.NoError(err)
+				assert.Equal("b@b.com", p.Creator.EmailAddress)
+				assert.EqualValues(2, p.Creator.ID)
+				assert.EqualValues(2, p.CreatorID)
+				assert.EqualValues(2, p.ID)
+				assert.Equal("", p.Description)
+				assert.Equal("", p.JiraIssueID)
+				assert.WithinDuration(time.Now(), p.ProjectCreatedAt, 1*time.Second)
+				assert.WithinDuration(time.Now(), p.ProjectModifiedAt, 1*time.Second)
+				assert.Equal(ActiveProjectStatus, p.Status)
+				assert.Equal("Title2", p.Title)
+			})
+
+		t.Run("Get the second project", func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			p := Project{}
+
+			err := p.Get(db, 2)
+			require.NoError(err)
+			assert.Equal("b@b.com", p.Creator.EmailAddress)
+			assert.EqualValues(2, p.Creator.ID)
+			assert.EqualValues(2, p.CreatorID)
+			assert.EqualValues(2, p.ID)
+			assert.Equal("", p.Description)
+			assert.Equal("", p.JiraIssueID)
+			assert.WithinDuration(time.Now(), p.ProjectCreatedAt, 1*time.Second)
+			assert.WithinDuration(time.Now(), p.ProjectModifiedAt, 1*time.Second)
+			assert.Equal(ActiveProjectStatus, p.Status)
+			assert.Equal("Title2", p.Title)
+		})
+
+		t.Run("Update the second project again", func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			p := Project{
+				Model: gorm.Model{
+					ID: 2,
+				},
+				Description: "UpdatedDescription2",
+				JiraIssueID: "UpdatedJiraIssueID2",
+				Title:       "UpdatedTitle2",
+			}
+
+			err := p.Update(db)
+			require.NoError(err)
+			assert.Equal("b@b.com", p.Creator.EmailAddress)
+			assert.EqualValues(2, p.Creator.ID)
+			assert.EqualValues(2, p.CreatorID)
+			assert.EqualValues(2, p.ID)
+			assert.Equal("UpdatedDescription2", p.Description)
+			assert.Equal("UpdatedJiraIssueID2", p.JiraIssueID)
+			assert.WithinDuration(time.Now(), p.ProjectCreatedAt, 1*time.Second)
+			assert.WithinDuration(time.Now(), p.ProjectModifiedAt, 1*time.Second)
+			assert.Equal(ActiveProjectStatus, p.Status)
+			assert.Equal("UpdatedTitle2", p.Title)
+		})
+
+		t.Run("Get the second project", func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			p := Project{}
+
+			err := p.Get(db, 2)
+			require.NoError(err)
+			assert.Equal("b@b.com", p.Creator.EmailAddress)
+			assert.EqualValues(2, p.Creator.ID)
+			assert.EqualValues(2, p.CreatorID)
+			assert.EqualValues(2, p.ID)
+			assert.Equal("UpdatedDescription2", p.Description)
+			assert.Equal("UpdatedJiraIssueID2", p.JiraIssueID)
+			assert.WithinDuration(time.Now(), p.ProjectCreatedAt, 1*time.Second)
+			assert.WithinDuration(time.Now(), p.ProjectModifiedAt, 1*time.Second)
+			assert.Equal(ActiveProjectStatus, p.Status)
+			assert.Equal("UpdatedTitle2", p.Title)
+		})
+	})
+}
+
+func TestProjectReplaceRelatedResources(t *testing.T) {
+	dsn := os.Getenv("HERMES_TEST_POSTGRESQL_DSN")
+	if dsn == "" {
+		t.Skip("HERMES_TEST_POSTGRESQL_DSN environment variable isn't set")
+	}
+
+	t.Run("Get and Replace", func(t *testing.T) {
+		db, tearDownTest := setupTest(t, dsn)
+		defer tearDownTest(t)
+
+		t.Run("Create a document type", func(t *testing.T) {
+			_, require := assert.New(t), require.New(t)
+			dt := DocumentType{
+				Name:     "DT1",
+				LongName: "DocumentType1",
+			}
+			err := dt.FirstOrCreate(db)
+			require.NoError(err)
+		})
+
+		t.Run("Create a product", func(t *testing.T) {
+			_, require := assert.New(t), require.New(t)
+			p := Product{
+				Name:         "Product1",
+				Abbreviation: "P1",
+			}
+			err := p.FirstOrCreate(db)
+			require.NoError(err)
+		})
+
+		t.Run("Create documents", func(t *testing.T) {
+			_, require := assert.New(t), require.New(t)
+			d := Document{
+				GoogleFileID: "GoogleFileID1",
+				DocumentType: DocumentType{
+					Name: "DT1",
+				},
+				Product: Product{
+					Name: "Product1",
+				},
+			}
+			err := d.Create(db)
+			require.NoError(err)
+
+			d = Document{
+				GoogleFileID: "GoogleFileID2",
+				DocumentType: DocumentType{
+					Name: "DT1",
+				},
+				Product: Product{
+					Name: "Product1",
+				},
+			}
+			err = d.Create(db)
+			require.NoError(err)
+
+			d = Document{
+				GoogleFileID: "GoogleFileID3",
+				DocumentType: DocumentType{
+					Name: "DT1",
+				},
+				Product: Product{
+					Name: "Product1",
+				},
+			}
+			err = d.Create(db)
+			require.NoError(err)
+		})
+
+		t.Run("Create a project", func(t *testing.T) {
+			_, require := assert.New(t), require.New(t)
+			p := Project{
+				Creator: User{
+					EmailAddress: "a@a.com",
+				},
+				Title: "Title1",
+			}
+			err := p.Create(db)
+			require.NoError(err)
+			require.EqualValues(1, p.ID)
+		})
+
+		t.Run("Add external link related resources", func(t *testing.T) {
+			_, require := assert.New(t), require.New(t)
+
+			rr := ProjectRelatedResourceExternalLink{
+				RelatedResource: ProjectRelatedResource{
+					ProjectID: 1,
+					SortOrder: 1,
+				},
+				Name: "Name1",
+				URL:  "URL1",
+			}
+			err := rr.Create(db)
+			require.NoError(err)
+
+			rr = ProjectRelatedResourceExternalLink{
+				RelatedResource: ProjectRelatedResource{
+					ProjectID: 1,
+					SortOrder: 2,
+				},
+				Name: "Name2",
+				URL:  "URL2",
+			}
+			err = rr.Create(db)
+			require.NoError(err)
+
+			rr = ProjectRelatedResourceExternalLink{
+				RelatedResource: ProjectRelatedResource{
+					ProjectID: 1,
+					SortOrder: 3,
+				},
+				Name: "Name3",
+				URL:  "URL3",
+			}
+			err = rr.Create(db)
+			require.NoError(err)
+		})
+
+		t.Run("Get the project", func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			p := Project{}
+
+			err := p.Get(db, 1)
+			require.NoError(err)
+			assert.Len(p.RelatedResources, 3)
+		})
+
+		t.Run("Replace related resources", func(t *testing.T) {
+			_, require := assert.New(t), require.New(t)
+			p := Project{
+				Model: gorm.Model{
+					ID: 1,
+				},
+			}
+			err := p.ReplaceRelatedResources(db,
+				[]ProjectRelatedResourceExternalLink{
+					{
+						RelatedResource: ProjectRelatedResource{
+							ProjectID: 1,
+							SortOrder: 1,
+						},
+						Name: "Name4",
+						URL:  "URL4",
+					},
+				},
+				[]ProjectRelatedResourceHermesDocument{
+					{
+						RelatedResource: ProjectRelatedResource{
+							ProjectID: 1,
+							SortOrder: 2,
+						},
+						Document: Document{
+							GoogleFileID: "GoogleFileID1",
+						},
+					},
+					{
+						RelatedResource: ProjectRelatedResource{
+							ProjectID: 1,
+							SortOrder: 3,
+						},
+						Document: Document{
+							GoogleFileID: "GoogleFileID3",
+						},
+					},
+				},
+			)
+			require.NoError(err)
+		})
+
+		t.Run("Get the project", func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			p := Project{}
+
+			err := p.Get(db, 1)
+			require.NoError(err)
+			assert.Len(p.RelatedResources, 3)
+		})
+
+		t.Run("Get typed related resources", func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			p := Project{
+				Model: gorm.Model{
+					ID: 1,
+				},
+			}
+			elrrs, hdrrs, err := p.GetRelatedResources(db)
+			require.NoError(err)
+			require.Len(elrrs, 1)
+			assert.Equal("Name4", elrrs[0].Name)
+			assert.Equal("URL4", elrrs[0].URL)
+			assert.Equal(1, elrrs[0].RelatedResource.SortOrder)
+			require.Len(hdrrs, 2)
+			assert.Equal("GoogleFileID1", hdrrs[0].Document.GoogleFileID)
+			assert.Equal(2, hdrrs[0].RelatedResource.SortOrder)
+			assert.Equal("GoogleFileID3", hdrrs[1].Document.GoogleFileID)
+			assert.Equal(3, hdrrs[1].RelatedResource.SortOrder)
+		})
+	})
+}


### PR DESCRIPTION
This PR adds APIs for creating and updating projects and their associated related resources (both API versions `v1` and `v2` are handled by the same code).

### New API Endpoints

- `/api/v1/projects`: `GET`, `POST`
- `/api/v1/projects/{project_id}`: `GET`, `PATCH`
- `/api/v1/projects/{project_id}/related-resources`: `GET`, `POST`, `PUT`
- `/api/v2/projects`: `GET`, `POST`
- `/api/v2/projects/{project_id}`: `GET`, `PATCH`
- `/api/v2/projects/{project_id}/related-resources`: `GET`, `POST`, `PUT`