### PR TITLE
Replace test strings with shared variables

### DIFF
--- a/web/app/utils/mirage-utils.ts
+++ b/web/app/utils/mirage-utils.ts
@@ -5,6 +5,12 @@ export const TEST_USER_NAME = "Test user";
 export const TEST_USER_EMAIL = "testuser@hashicorp.com";
 export const TEST_USER_GIVEN_NAME = "Test";
 
+export const TEST_USER_2_NAME = "Foo Bar";
+export const TEST_USER_2_EMAIL = "foo@hashicorp.com";
+export const TEST_USER_2_GIVEN_NAME = "Foo";
+
+export const TEST_USER_3_EMAIL = "bar@hashicorp.com";
+
 export function authenticateTestUser(mirageContext: MirageTestContext) {
   const authenticatedUserService = mirageContext.owner.lookup(
     "service:authenticated-user",

--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -12,6 +12,12 @@ import {
   TEST_SHORT_LINK_BASE_URL,
 } from "hermes/utils/hermes-urls";
 
+import {
+  TEST_USER_EMAIL,
+  TEST_USER_NAME,
+  TEST_USER_GIVEN_NAME,
+} from "hermes/utils/mirage-utils";
+
 export default function (mirageConfig) {
   let finalConfig = {
     ...mirageConfig,
@@ -99,12 +105,12 @@ export default function (mirageConfig) {
               return new Response(200, {}, { hits: docMatches });
             } else if (filters) {
               const requestIsForDocsAwaitingReview =
-                filters.includes("approvers:'testuser@example.com'") &&
+                filters.includes(`approvers:'${TEST_USER_EMAIL}'`) &&
                 requestBody.filters.includes("AND status:In-Review");
               if (requestIsForDocsAwaitingReview) {
                 docMatches = schema.document.all().models.filter((doc) => {
                   return (
-                    doc.attrs.approvers.includes("testuser@example.com") &&
+                    doc.attrs.approvers.includes(TEST_USER_EMAIL) &&
                     doc.attrs.status.toLowerCase().includes("review")
                   );
                 });
@@ -291,7 +297,7 @@ export default function (mirageConfig) {
 
         document.update({
           objectID: document.id,
-          owners: ["testuser@example.com"],
+          owners: [TEST_USER_EMAIL],
         });
 
         return new Response(200, {}, document.attrs);
@@ -414,9 +420,9 @@ export default function (mirageConfig) {
           // Otherwise, create and return a new user.
           return schema.mes.create({
             id: "1",
-            name: "Test User",
-            email: "testuser@example.com",
-            given_name: "Test",
+            name: TEST_USER_NAME,
+            email: TEST_USER_EMAIL,
+            given_name: TEST_USER_GIVEN_NAME,
             picture: "",
             subscriptions: [],
             isLoggedIn: true,
@@ -430,7 +436,7 @@ export default function (mirageConfig) {
        */
       this.get("/people", (schema, request) => {
         // This allows the test user to view docs they're an approver on.
-        if (request.queryParams.emails === "testuser@example.com") {
+        if (request.queryParams.emails === TEST_USER_EMAIL) {
           return new Response(200, {}, []);
         }
 

--- a/web/mirage/factories/document.ts
+++ b/web/mirage/factories/document.ts
@@ -1,4 +1,5 @@
 import { Factory } from "miragejs";
+import { TEST_USER_EMAIL } from "hermes/utils/mirage-utils";
 
 export function getTestDocNumber(product: string) {
   let abbreviation = "";
@@ -41,5 +42,5 @@ export default Factory.extend({
     },
   },
   approvers: [],
-  owners: ["testuser@example.com"],
+  owners: [TEST_USER_EMAIL],
 });

--- a/web/mirage/factories/me.ts
+++ b/web/mirage/factories/me.ts
@@ -1,10 +1,15 @@
 import { Factory } from "miragejs";
+import {
+  TEST_USER_EMAIL,
+  TEST_USER_NAME,
+  TEST_USER_GIVEN_NAME,
+} from "hermes/utils/mirage-utils";
 
 export default Factory.extend({
   id: "123456789",
-  email: "user@example.com",
-  name: "User",
-  given_name: "User",
+  email: TEST_USER_EMAIL,
+  name: TEST_USER_NAME,
+  given_name: TEST_USER_GIVEN_NAME,
   picture: "",
   subscriptions: [],
   isLoggedIn: true,

--- a/web/mirage/factories/project.ts
+++ b/web/mirage/factories/project.ts
@@ -1,12 +1,13 @@
 import { Factory, ModelInstance, Server } from "miragejs";
 import { HermesProject } from "hermes/types/project";
+import { TEST_USER_EMAIL } from "hermes/utils/mirage-utils";
 
 export default Factory.extend({
   id: (i: number) => i,
   title: (i: number) => `Test Project ${i}`,
   createdTime: 1,
   modifiedTime: 1,
-  creator: "testuser@example.com",
+  creator: TEST_USER_EMAIL,
   status: "active",
 
   // @ts-ignore - Bug https://github.com/miragejs/miragejs/issues/1052

--- a/web/mirage/factories/related-hermes-document.ts
+++ b/web/mirage/factories/related-hermes-document.ts
@@ -1,4 +1,5 @@
 import { Factory } from "miragejs";
+import { TEST_USER_EMAIL } from "hermes/utils/mirage-utils";
 
 // TODO: Improve how this generates IDs.
 // We should be able to use the `i` argument to generate IDs,
@@ -19,6 +20,6 @@ export default Factory.extend({
   },
   status: "In review",
   product: "Labs",
-  owners: ["testuser@example.com"],
+  owners: [TEST_USER_EMAIL],
   ownerPhotos: ["https://placehold.co/100x100"],
 });

--- a/web/tests/acceptance/authenticated/document-test.ts
+++ b/web/tests/acceptance/authenticated/document-test.ts
@@ -25,6 +25,11 @@ import window from "ember-window-mock";
 import { TEST_SHORT_LINK_BASE_URL } from "hermes/utils/hermes-urls";
 import RouterService from "@ember/routing/router-service";
 import { wait } from "ember-animated/.";
+import {
+  TEST_USER_2_EMAIL,
+  TEST_USER_3_EMAIL,
+  TEST_USER_EMAIL,
+} from "hermes/utils/mirage-utils";
 
 const ADD_RELATED_RESOURCE_BUTTON_SELECTOR =
   "[data-test-section-header-button-for='Related resources']";
@@ -414,8 +419,8 @@ module("Acceptance | authenticated/document", function (hooks) {
     this.server.create("document", {
       objectID: 1,
       isDraft: true,
-      owners: ["foo@example.com"],
-      collaborators: ["testuser@example.com"],
+      owners: [TEST_USER_2_EMAIL],
+      collaborators: [TEST_USER_EMAIL],
     });
 
     await visit("/document/1?draft=true");
@@ -428,8 +433,8 @@ module("Acceptance | authenticated/document", function (hooks) {
       objectID: 1,
       isDraft: false,
       status: "In review",
-      owners: ["foo@example.com"],
-      collaborators: ["testuser@example.com"],
+      owners: [TEST_USER_2_EMAIL],
+      collaborators: [TEST_USER_EMAIL],
     });
 
     await visit("/document/1");
@@ -442,8 +447,8 @@ module("Acceptance | authenticated/document", function (hooks) {
       objectID: 1,
       isDraft: false,
       status: "In review",
-      owners: ["foo@example.com"],
-      approvers: ["testuser@example.com"],
+      owners: [TEST_USER_2_EMAIL],
+      approvers: [TEST_USER_EMAIL],
     });
 
     await visit("/document/1");
@@ -455,7 +460,7 @@ module("Acceptance | authenticated/document", function (hooks) {
     this.server.create("document", {
       objectID: 1,
       isDraft: true,
-      owners: ["foo@example.com"],
+      owners: [TEST_USER_2_EMAIL],
       isShareable: true,
     });
 
@@ -628,7 +633,7 @@ module("Acceptance | authenticated/document", function (hooks) {
   test("the contributors attribute saves", async function (this: AuthenticatedDocumentRouteTestContext, assert) {
     this.server.create("document", {
       objectID: 1,
-      contributors: ["foo@example.com"],
+      contributors: [TEST_USER_2_EMAIL],
       isDraft: true,
     });
 
@@ -646,7 +651,7 @@ module("Acceptance | authenticated/document", function (hooks) {
   test("the approvers attribute saves", async function (this: AuthenticatedDocumentRouteTestContext, assert) {
     this.server.create("document", {
       objectID: 1,
-      approvers: ["foo@example.com"],
+      approvers: [TEST_USER_2_EMAIL],
       isDraft: true,
     });
 
@@ -727,7 +732,7 @@ module("Acceptance | authenticated/document", function (hooks) {
           type: "PEOPLE",
         },
       },
-      foo: ["foo@example.com"],
+      foo: [TEST_USER_2_EMAIL],
       isDraft: true,
     });
 
@@ -745,8 +750,8 @@ module("Acceptance | authenticated/document", function (hooks) {
   test("approvers who have approved a document are badged with a checkmark", async function (this: AuthenticatedDocumentRouteTestContext, assert) {
     this.server.create("document", {
       objectID: 1,
-      approvers: ["foo@example.com", "bar@example.com"],
-      approvedBy: ["foo@example.com"],
+      approvers: [TEST_USER_2_EMAIL, TEST_USER_3_EMAIL],
+      approvedBy: [TEST_USER_2_EMAIL],
     });
 
     await visit("/document/1");

--- a/web/tests/integration/components/dashboard/docs-awaiting-review-test.ts
+++ b/web/tests/integration/components/dashboard/docs-awaiting-review-test.ts
@@ -4,6 +4,7 @@ import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { click, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { HermesDocument } from "hermes/types/document";
+import { TEST_USER_EMAIL } from "hermes/utils/mirage-utils";
 
 const DOCS_AWAITING_REVIEW_COUNT_SELECTOR =
   "[data-test-docs-awaiting-review-count]";
@@ -29,19 +30,19 @@ module(
       this.server.create("document", {
         title: "Foo",
         status: "In Review",
-        approvers: ["testuser@example.com"],
+        approvers: [TEST_USER_EMAIL],
       });
 
       this.server.create("document", {
         title: "Bar",
         status: "In Review",
-        approvers: ["testuser@example.com"],
+        approvers: [TEST_USER_EMAIL],
       });
 
       this.set("docs", this.server.schema.document.all().models);
 
       await render<DashboardDocsAwaitingReviewTestContext>(
-        hbs`<Dashboard::DocsAwaitingReview @docs={{this.docs}} />`
+        hbs`<Dashboard::DocsAwaitingReview @docs={{this.docs}} />`,
       );
 
       assert.dom(DOCS_AWAITING_REVIEW_COUNT_SELECTOR).containsText("2");
@@ -64,14 +65,14 @@ module(
         this.server.create("document", {
           title,
           status: "In Review",
-          approvers: ["testuser@example.com"],
+          approvers: [TEST_USER_EMAIL],
         });
       });
 
       this.set("docs", this.server.schema.document.all().models);
 
       await render<DashboardDocsAwaitingReviewTestContext>(
-        hbs`<Dashboard::DocsAwaitingReview @docs={{this.docs}} />`
+        hbs`<Dashboard::DocsAwaitingReview @docs={{this.docs}} />`,
       );
 
       assert.dom(DOCS_AWAITING_REVIEW_COUNT_SELECTOR).containsText("5");
@@ -100,5 +101,5 @@ module(
         .dom(TOGGLE_SELECTOR)
         .doesNotExist("toggle not shown when there's fewer than 4 docs");
     });
-  }
+  },
 );

--- a/web/tests/integration/components/dashboard/docs-awaiting-review/doc-test.ts
+++ b/web/tests/integration/components/dashboard/docs-awaiting-review/doc-test.ts
@@ -4,6 +4,7 @@ import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { find, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { HermesDocument } from "hermes/types/document";
+import { TEST_USER_2_EMAIL, TEST_USER_EMAIL } from "hermes/utils/mirage-utils";
 
 const DOC_AWAITING_REVIEW_LINK_SELECTOR =
   "[data-test-doc-awaiting-review-link]";
@@ -37,8 +38,8 @@ module(
         product: "Cloud Platform",
         status: "In Review",
         docType: "PRFAQ",
-        owners: ["foo@example.com"],
-        approvers: ["testuser@example.com"],
+        owners: [TEST_USER_2_EMAIL],
+        approvers: [TEST_USER_EMAIL],
       });
 
       this.set("doc", this.server.schema.document.first());
@@ -57,34 +58,34 @@ module(
       assert
         .dom(
           find(
-            `${DOC_AWAITING_REVIEW_LINK_SELECTOR} ${DOC_AWAITING_REVIEW_NUMBER_AND_TITLE_SELECTOR}`
-          )
+            `${DOC_AWAITING_REVIEW_LINK_SELECTOR} ${DOC_AWAITING_REVIEW_NUMBER_AND_TITLE_SELECTOR}`,
+          ),
         )
         .hasText("HCP-001 Foo", "Shows the doc number and title");
 
       assert
         .dom(
           find(
-            `${DOC_AWAITING_REVIEW_LINK_SELECTOR} ${DOC_AWAITING_REVIEW_OWNER_SELECTOR}`
-          )
+            `${DOC_AWAITING_REVIEW_LINK_SELECTOR} ${DOC_AWAITING_REVIEW_OWNER_SELECTOR}`,
+          ),
         )
-        .hasText("foo@example.com", "Shows the doc owner");
+        .hasText(TEST_USER_2_EMAIL, "Shows the doc owner");
 
       assert
         .dom(
           find(
-            `${DOC_AWAITING_REVIEW_LINK_SELECTOR} ${DOC_AWAITING_REVIEW_PRODUCT_BADGE_SELECTOR}`
-          )
+            `${DOC_AWAITING_REVIEW_LINK_SELECTOR} ${DOC_AWAITING_REVIEW_PRODUCT_BADGE_SELECTOR}`,
+          ),
         )
         .hasText("Cloud Platform", "Shows the product name");
 
       assert
         .dom(
           find(
-            `${DOC_AWAITING_REVIEW_LINK_SELECTOR} ${DOC_AWAITING_REVIEW_DOCTYPE_BADGE_SELECTOR}`
-          )
+            `${DOC_AWAITING_REVIEW_LINK_SELECTOR} ${DOC_AWAITING_REVIEW_DOCTYPE_BADGE_SELECTOR}`,
+          ),
         )
         .hasText("PRFAQ", "Shows the doc type");
     });
-  }
+  },
 );

--- a/web/tests/integration/components/document/sidebar-test.ts
+++ b/web/tests/integration/components/document/sidebar-test.ts
@@ -9,6 +9,7 @@ import AuthenticatedUserService, {
 } from "hermes/services/authenticated-user";
 import { HermesDocument } from "hermes/types/document";
 import { HermesDocumentType } from "hermes/types/document-type";
+import { TEST_USER_2_EMAIL, TEST_USER_EMAIL } from "hermes/utils/mirage-utils";
 
 const SUMMARY_CONTAINER = "[data-test-document-summary]";
 const SUMMARY_EMPTY_STATE = `${SUMMARY_CONTAINER} .empty-state-text`;
@@ -37,7 +38,7 @@ module("Integration | Component | document/sidebar", function (hooks) {
 
     this.set("profile", authenticatedUser.info);
     this.server.create("document", {
-      owners: ["testuser@example.com"],
+      owners: [TEST_USER_EMAIL],
       isDraft: false,
     });
 
@@ -66,7 +67,7 @@ module("Integration | Component | document/sidebar", function (hooks) {
     this.set(
       "document",
       this.server.schema.document.first().update({
-        owners: ["foo@bar.com"],
+        owners: [TEST_USER_2_EMAIL],
       }),
     );
 

--- a/web/tests/integration/components/header/nav-test.ts
+++ b/web/tests/integration/components/header/nav-test.ts
@@ -8,6 +8,11 @@ import { setupMirage } from "ember-cli-mirage/test-support";
 import window from "ember-window-mock";
 import { HERMES_GITHUB_REPO_URL } from "hermes/utils/hermes-urls";
 import ConfigService from "hermes/services/config";
+import {
+  TEST_USER_2_EMAIL,
+  TEST_USER_2_GIVEN_NAME,
+  TEST_USER_2_NAME,
+} from "hermes/utils/mirage-utils";
 
 const SUPPORT_URL = "https://example.com/support";
 const USER_MENU_TOGGLE_SELECTOR = "[data-test-user-menu-toggle]";
@@ -24,9 +29,9 @@ module("Integration | Component | header/nav", function (hooks) {
     ) as AuthenticatedUserService;
 
     authenticatedUserSvc._info = {
-      email: "foo@example.com",
-      given_name: "Foo",
-      name: "Foo Bar",
+      email: TEST_USER_2_EMAIL,
+      given_name: TEST_USER_2_GIVEN_NAME,
+      name: TEST_USER_2_NAME,
       picture: "",
       subscriptions: [],
     };
@@ -48,8 +53,8 @@ module("Integration | Component | header/nav", function (hooks) {
 
     await click(USER_MENU_TOGGLE_SELECTOR);
 
-    assert.dom("[data-test-user-menu-title]").hasText("Foo Bar");
-    assert.dom("[data-test-user-menu-email]").hasText("foo@example.com");
+    assert.dom("[data-test-user-menu-title]").hasText(TEST_USER_2_NAME);
+    assert.dom("[data-test-user-menu-email]").hasText(TEST_USER_2_EMAIL);
     assert
       .dom("[data-test-user-menu-github]")
       .hasText("GitHub")

--- a/web/tests/integration/helpers/has-approved-doc-test.ts
+++ b/web/tests/integration/helpers/has-approved-doc-test.ts
@@ -2,6 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
+import { TEST_USER_EMAIL } from "hermes/utils/mirage-utils";
 
 module("Integration | Helper | has-approved-doc", function (hooks) {
   setupRenderingTest(hooks);
@@ -11,7 +12,7 @@ module("Integration | Helper | has-approved-doc", function (hooks) {
       approvedBy: [],
     });
 
-    const email = "person@example.com";
+    const email = TEST_USER_EMAIL;
     this.set("email", email);
 
     await render(hbs`


### PR DESCRIPTION
- Replaces instances of `test@example.com` (the default Mirage user) with a shared variable `TEST_USER_EMAIL`
- Does the same for a few other common test attributes