### PR TITLE
Add flag for the "start a project" button

### DIFF
--- a/web/app/components/new/document-template-list.hbs
+++ b/web/app/components/new/document-template-list.hbs
@@ -1,18 +1,19 @@
 <div class="flex items-center gap-3.5">
   <h1>Choose a template</h1>
-  {{!
-  <div class="hermes-h4 mt-[5px] mr-0.5">
-    or
-  </div>
-  <Hds::Button
-    @text="Start a project"
-    @icon="chevron-right"
-    @iconPosition="trailing"
-    @route="authenticated.new.project"
-    @color="secondary"
-    class="mt-[4px]"
-  />
-  }}
+  {{#if this.flags.projects}}
+    <div class="hermes-h4 mt-[5px] mr-0.5">
+      or
+    </div>
+    <Hds::Button
+      data-test-start-a-project-button
+      @text="Start a project"
+      @icon="chevron-right"
+      @iconPosition="trailing"
+      @route="authenticated.new.project"
+      @color="secondary"
+      class="mt-[4px]"
+    />
+  {{/if}}
 </div>
 
 <ol class="mt-8 grid auto-rows-fr grid-cols-2 gap-2">

--- a/web/app/components/new/document-template-list.ts
+++ b/web/app/components/new/document-template-list.ts
@@ -1,4 +1,6 @@
+import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
+import FlagsService from "hermes/services/flags";
 import { HermesDocumentType } from "hermes/types/document-type";
 
 interface NewDocumentTemplateListComponentSignature {
@@ -8,6 +10,12 @@ interface NewDocumentTemplateListComponentSignature {
 }
 
 export default class NewDocumentTemplateListComponent extends Component<NewDocumentTemplateListComponentSignature> {
+  /**
+   * Used in the template to decide whether to show
+   * the "Start a project" button.
+   */
+  @service declare flags: FlagsService;
+
   protected get moreInfoLinksAreShown(): boolean {
     return this.args.docTypes.some((docType) => docType.moreInfoLink);
   }

--- a/web/tests/acceptance/authenticated/new-test.ts
+++ b/web/tests/acceptance/authenticated/new-test.ts
@@ -4,6 +4,7 @@ import { module, test } from "qunit";
 import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
+import { Response } from "miragejs";
 
 const TEMPLATE_OPTION = "[data-test-template-option]";
 const ICON = `${TEMPLATE_OPTION} [data-test-icon]`;
@@ -11,6 +12,7 @@ const LONG_NAME = `${TEMPLATE_OPTION} [data-test-long-name]`;
 const NAME = `${TEMPLATE_OPTION} [data-test-name]`;
 const DESCRIPTION = `${TEMPLATE_OPTION} [data-test-description]`;
 const MORE_INFO_LINK = `[data-test-more-info-link]`;
+const START_A_PROJECT_BUTTON = "[data-test-start-a-project-button]";
 
 interface AuthenticatedNewRouteTestContext extends MirageTestContext {}
 
@@ -135,5 +137,30 @@ module("Acceptance | authenticated/new", function (hooks) {
     await visit("/new");
 
     assert.dom(MORE_INFO_LINK).doesNotExist();
+  });
+
+  test(`the "start a project" button is visible if the projects flag is true`, async function (this: AuthenticatedNewRouteTestContext, assert) {
+    await visit("/new");
+
+    // Projects are enabled by default
+    assert.dom(START_A_PROJECT_BUTTON).exists();
+  });
+
+  test(`the "start a project" button is hidden if the projects flag is false`, async function (this: AuthenticatedNewRouteTestContext, assert) {
+    this.server.get("/web/config", () => {
+      return new Response(
+        200,
+        {},
+        {
+          feature_flags: {
+            projects: false,
+          },
+        },
+      );
+    });
+
+    await visit("/new");
+
+    assert.dom(START_A_PROJECT_BUTTON).doesNotExist();
   });
 });


### PR DESCRIPTION
Adds the "Start a project" button to the "Chosoe a template" screen if the projects flag is enabled.