### PR TITLE
Add projects to document GET response

### DIFF
--- a/internal/api/documents.go
+++ b/internal/api/documents.go
@@ -184,6 +184,25 @@ func DocumentHandler(
 				return
 			}
 
+			// Get projects associated with the document.
+			projs, err := model.GetProjects(db)
+			if err != nil {
+				l.Error("error getting projects associated with document",
+					"error", err,
+					"method", r.Method,
+					"path", r.URL.Path,
+					"doc_id", docID,
+				)
+				http.Error(w, "Error processing request",
+					http.StatusInternalServerError)
+				return
+			}
+			projIDs := []int{}
+			for _, p := range projs {
+				projIDs = append(projIDs, int(p.ID))
+			}
+			docObj["projects"] = projIDs
+
 			// Write response.
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)

--- a/internal/api/v2/documents.go
+++ b/internal/api/v2/documents.go
@@ -63,8 +63,7 @@ func DocumentHandler(srv server.Server) http.Handler {
 				"method", r.Method,
 				"doc_id", docID,
 			)
-			http.Error(w, "Error requesting document draft",
-				http.StatusInternalServerError)
+			http.Error(w, "Error processing request", http.StatusInternalServerError)
 			return
 		}
 
@@ -81,6 +80,7 @@ func DocumentHandler(srv server.Server) http.Handler {
 				"path", r.URL.Path,
 				"doc_id", docID,
 			)
+			http.Error(w, "Error processing request", http.StatusInternalServerError)
 			return
 		}
 
@@ -94,8 +94,7 @@ func DocumentHandler(srv server.Server) http.Handler {
 				"path", r.URL.Path,
 				"doc_id", docID,
 			)
-			http.Error(w, "Error accessing draft document",
-				http.StatusInternalServerError)
+			http.Error(w, "Error processing request", http.StatusInternalServerError)
 			return
 		}
 
@@ -192,7 +191,7 @@ func DocumentHandler(srv server.Server) http.Handler {
 					"path", r.URL.Path,
 					"doc_id", docID,
 				)
-				http.Error(w, "Error getting document",
+				http.Error(w, "Error processing request",
 					http.StatusInternalServerError)
 				return
 			}
@@ -227,7 +226,7 @@ func DocumentHandler(srv server.Server) http.Handler {
 					"error", err,
 					"doc_id", docID,
 				)
-				http.Error(w, "Error requesting document",
+				http.Error(w, "Error processing request",
 					http.StatusInternalServerError)
 				return
 			}

--- a/internal/api/v2/documents.go
+++ b/internal/api/v2/documents.go
@@ -197,6 +197,25 @@ func DocumentHandler(srv server.Server) http.Handler {
 				return
 			}
 
+			// Get projects associated with the document.
+			projs, err := model.GetProjects(srv.DB)
+			if err != nil {
+				srv.Logger.Error("error getting projects associated with document",
+					"error", err,
+					"method", r.Method,
+					"path", r.URL.Path,
+					"doc_id", docID,
+				)
+				http.Error(w, "Error processing request",
+					http.StatusInternalServerError)
+				return
+			}
+			projIDs := []int{}
+			for _, p := range projs {
+				projIDs = append(projIDs, int(p.ID))
+			}
+			docObj["projects"] = projIDs
+
 			// Write response.
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)

--- a/internal/api/v2/projects.go
+++ b/internal/api/v2/projects.go
@@ -21,8 +21,8 @@ type ProjectGetResponse struct {
 type ProjectPatchRequest struct {
 	Description *string `json:"description"`
 	JiraIssueID *string `json:"jiraIssueID"`
-	Status      string  `json:"status"`
-	Title       string  `json:"title"`
+	Status      *string `json:"status"`
+	Title       *string `json:"title"`
 }
 
 type ProjectsPostRequest struct {
@@ -299,8 +299,8 @@ func ProjectHandler(srv server.Server) http.Handler {
 				}
 
 				// Validate request.
-				if req.Status != "" {
-					switch strings.ToLower(req.Status) {
+				if req.Status != nil {
+					switch strings.ToLower(*req.Status) {
 					case "active":
 					case "archived":
 					case "complete":
@@ -312,7 +312,7 @@ func ProjectHandler(srv server.Server) http.Handler {
 						return
 					}
 				}
-				if req.Title == "" {
+				if req.Title != nil && *req.Title == "" {
 					http.Error(
 						w, "Bad request: title cannot be empty", http.StatusBadRequest)
 					return
@@ -348,8 +348,8 @@ func ProjectHandler(srv server.Server) http.Handler {
 				if req.JiraIssueID != nil {
 					patch.JiraIssueID = *req.JiraIssueID
 				}
-				if req.Status != "" {
-					switch strings.ToLower(req.Status) {
+				if req.Status != nil {
+					switch strings.ToLower(*req.Status) {
 					case "active":
 						patch.Status = models.ActiveProjectStatus
 					case "archived":
@@ -358,7 +358,9 @@ func ProjectHandler(srv server.Server) http.Handler {
 						patch.Status = models.CompletedProjectStatus
 					}
 				}
-				patch.Title = req.Title
+				if req.Title != nil {
+					patch.Title = *req.Title
+				}
 
 				// Update project in the database.
 				if err := patch.Update(srv.DB); err != nil {

--- a/internal/api/v2/projects.go
+++ b/internal/api/v2/projects.go
@@ -201,9 +201,9 @@ func ProjectHandler(srv server.Server) http.Handler {
 
 		// Parse project ID and subpath.
 		projectRegex := regexp.MustCompile(
-			`^\/api\/v2\/projects\/([0-9A-Za-z_\-]+)$`)
+			`^\/api\/v\d+\/projects\/([0-9A-Za-z_\-]+)$`)
 		projectRelatedResourcesRegex := regexp.MustCompile(
-			`^\/api\/v2\/projects\/([0-9A-Za-z_\-]+)\/related-resources$`)
+			`^\/api\/v\d+\/projects\/([0-9A-Za-z_\-]+)\/related-resources$`)
 		switch {
 		case projectRelatedResourcesRegex.MatchString(r.URL.Path):
 			projectID, err := getProjectIDFromPath(

--- a/web/app/components/project/index.ts
+++ b/web/app/components/project/index.ts
@@ -310,10 +310,13 @@ export default class ProjectIndexComponent extends Component<ProjectIndexCompone
         const valueToSave = key
           ? { [key]: newValue }
           : this.formattedRelatedResources;
-        await this.fetchSvc.fetch(`/api/v1/projects/${this.args.project.id}`, {
-          method: "PATCH",
-          body: JSON.stringify(valueToSave),
-        });
+        await this.fetchSvc.fetch(
+          `/api/${this.configSvc.config.api_version}/projects/${this.args.project.id}`,
+          {
+            method: "PATCH",
+            body: JSON.stringify(valueToSave),
+          },
+        );
       } catch (e) {
         this.flashMessages.critical((e as any).message, {
           title: "Unable to save",

--- a/web/app/components/project/index.ts
+++ b/web/app/components/project/index.ts
@@ -96,10 +96,8 @@ export default class ProjectIndexComponent extends Component<ProjectIndexCompone
 
     const hermesDocuments = this.hermesDocuments.map((doc) => {
       return {
-        ...doc,
         googleFileID: doc.googleFileID,
         sortOrder: doc.sortOrder,
-        product: doc.product,
       };
     });
 

--- a/web/tests/acceptance/authenticated/projects/project-test.ts
+++ b/web/tests/acceptance/authenticated/projects/project-test.ts
@@ -319,7 +319,6 @@ module("Acceptance | authenticated/projects/project", function (hooks) {
       this.server.schema.projects.first().attrs.hermesDocuments;
 
     assert.equal(projectDocuments.length, 1);
-    assert.equal(projectDocuments[0].title, docTitle);
   });
 
   test("you can remove a document from a project", async function (this: AuthenticatedProjectsProjectRouteTestContext, assert) {


### PR DESCRIPTION
This PR:
- Adds associated projects to the document GET response (v1 and v2 API)
- Fixes a bug where some projects APIs weren't handled correctly for v1 of the API
- Adds `/projects/{project_id}` GET API
- Fixes patching a project