### PR TITLE
Move Project `status` assignment to Mirage

### DIFF
--- a/web/app/components/new/project-form.ts
+++ b/web/app/components/new/project-form.ts
@@ -8,7 +8,6 @@ import { task } from "ember-concurrency";
 import ConfigService from "hermes/services/config";
 import FetchService from "hermes/services/fetch";
 import HermesFlashMessagesService from "hermes/services/flash-messages";
-import { ProjectStatus } from "hermes/types/project-status";
 import cleanString from "hermes/utils/clean-string";
 
 interface NewProjectFormComponentSignature {}
@@ -81,7 +80,6 @@ export default class NewProjectFormComponent extends Component<NewProjectFormCom
           body: JSON.stringify({
             title: cleanString(this.title),
             description: cleanString(this.description),
-            status: ProjectStatus.Active,
           }),
         })
         .then((response) => response?.json());

--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -3,6 +3,7 @@
 import { Collection, Response, createServer } from "miragejs";
 import { getTestDocNumber } from "./factories/document";
 import algoliaHosts from "./algolia/hosts";
+import { ProjectStatus } from "hermes/types/project-status";
 
 // @ts-ignore - Mirage not detecting file
 import config from "../config/environment";
@@ -188,6 +189,9 @@ export default function (mirageConfig) {
       // Create a project
       this.post("/projects", (schema, request) => {
         let project = schema.projects.create(JSON.parse(request.requestBody));
+        project.update({
+          status: ProjectStatus.Active,
+        });
         return new Response(200, {}, project.attrs);
       });
 


### PR DESCRIPTION
Moves unnecessary `status` assignment from the New Project form into the Mirage post response.