### PR TITLE
Save projects in Algolia

### DIFF
--- a/configs/config.hcl
+++ b/configs/config.hcl
@@ -14,6 +14,7 @@ algolia {
   internal_index_name       = "internal"
   links_index_name          = "links"
   missing_fields_index_name = "missing_fields"
+  projects_index_name       = "projects"
   search_api_key            = ""
   write_api_key             = ""
 }

--- a/configs/config.hcl
+++ b/configs/config.hcl
@@ -97,6 +97,11 @@ feature_flags {
   flag "api_v2" {
     enabled = false
   }
+
+  // projects enables the projects feature in the UI.
+  flag "projects" {
+    enabled = false
+  }
 }
 
 // google_workspace configures Hermes to work with Google Workspace.

--- a/internal/api/v2/projects.go
+++ b/internal/api/v2/projects.go
@@ -317,11 +317,11 @@ func ProjectHandler(srv server.Server) http.Handler {
 					switch strings.ToLower(*req.Status) {
 					case "active":
 					case "archived":
-					case "complete":
+					case "completed":
 					default:
 						http.Error(w,
 							"Bad request: invalid status"+
-								` (valid values are "active", "archived", "complete")`,
+								` (valid values are "active", "archived", "completed")`,
 							http.StatusBadRequest)
 						return
 					}
@@ -368,7 +368,7 @@ func ProjectHandler(srv server.Server) http.Handler {
 						patch.Status = models.ActiveProjectStatus
 					case "archived":
 						patch.Status = models.ArchivedProjectStatus
-					case "complete":
+					case "completed":
 						patch.Status = models.CompletedProjectStatus
 					}
 				}

--- a/pkg/algolia/client.go
+++ b/pkg/algolia/client.go
@@ -52,6 +52,9 @@ type Client struct {
 	// MissingFields is an Algolia index for storing missing fields from indexed
 	// documents.
 	MissingFields *search.Index
+
+	// Projects is an Algolia index for storing projects.
+	Projects *search.Index
 }
 
 // Config is the configuration for interacting with the Algolia API.
@@ -77,6 +80,9 @@ type Config struct {
 	// MissingFieldsIndexName is the name of the Algolia index for storing missing
 	// fields from indexed documents.
 	MissingFieldsIndexName string `hcl:"missing_fields_index_name,optional"`
+
+	// ProjectsIndexName is the name of the Algolia index for storing projects.
+	ProjectsIndexName string `hcl:"projects_index_name,optional"`
 
 	// SearchAPIKey is the Algolia API Key for searching Hermes indices.
 	SearchAPIKey string `hcl:"search_api_key,optional"`
@@ -107,6 +113,7 @@ func New(cfg *Config) (*Client, error) {
 	c.Internal = a.InitIndex(cfg.InternalIndexName)
 	c.Links = a.InitIndex(cfg.LinksIndexName)
 	c.MissingFields = a.InitIndex(cfg.MissingFieldsIndexName)
+	c.Projects = a.InitIndex(cfg.ProjectsIndexName)
 
 	// Configure the docs index.
 	err := configureMainIndex(cfg.DocsIndexName, c.Docs, search.Settings{
@@ -297,6 +304,7 @@ func NewSearchClient(cfg *Config) (*Client, error) {
 	c.DraftsModifiedTimeDesc = a.InitIndex(cfg.DraftsIndexName + "_modifiedTime_desc")
 	c.Internal = a.InitIndex(cfg.InternalIndexName)
 	c.Links = a.InitIndex(cfg.LinksIndexName)
+	c.Projects = a.InitIndex(cfg.ProjectsIndexName)
 
 	return c, nil
 }
@@ -310,6 +318,7 @@ func validate(c *Config) error {
 		validation.Field(&c.InternalIndexName, validation.Required),
 		validation.Field(&c.LinksIndexName, validation.Required),
 		validation.Field(&c.MissingFieldsIndexName, validation.Required),
+		validation.Field(&c.ProjectsIndexName, validation.Required),
 		validation.Field(&c.SearchAPIKey, validation.Required),
 	)
 }


### PR DESCRIPTION
This PR adds functionality to save projects in a new "projects" Algolia search index. It also fixes a bug where the `completed` status in a project PATCH request was previously `complete`.

### New required config attribute `projects_index_name` (breaking change)

```hcl
algolia {
  projects_index_name       = "projects"
}
```