### PR TITLE
Improve EditableFields on the Projects screen

### DIFF
--- a/web/app/components/editable-field.hbs
+++ b/web/app/components/editable-field.hbs
@@ -1,7 +1,7 @@
 <div
   class="editable-field
     {{if @isSaving 'saving'}}
-    {{if (and this.editingIsEnabled (not @isSaving)) 'z-10'}}"
+    {{if (and this.editingIsEnabled (not @isSaving)) 'active z-10'}}"
   ...attributes
 >
   {{#if (and this.editingIsEnabled (not @isSaving))}}
@@ -44,7 +44,7 @@
       {{/if}}
 
       {{! "Confirm" and "Cancel" buttons }}
-      <div class="edit-overlay-affordance page-faint pb-[125px] pl-[5px]">
+      <div class="edit-overlay-affordance">
         <Hds::Button
           data-test-save-button
           @size="small"

--- a/web/app/components/editable-field.hbs
+++ b/web/app/components/editable-field.hbs
@@ -1,7 +1,7 @@
 <div
   class="editable-field
     {{if @isSaving 'saving'}}
-    {{if (and this.editingIsEnabled (not @isSaving)) 'z-10'}}"
+    {{if (and this.editingIsEnabled (not @isSaving)) 'active z-10'}}"
   ...attributes
 >
   {{#if (and this.editingIsEnabled (not @isSaving))}}

--- a/web/app/components/editable-field.hbs
+++ b/web/app/components/editable-field.hbs
@@ -1,7 +1,7 @@
 <div
   class="editable-field
     {{if @isSaving 'saving'}}
-    {{if (and this.editingIsEnabled (not @isSaving)) 'active z-10'}}"
+    {{if (and this.editingIsEnabled (not @isSaving)) 'z-10'}}"
   ...attributes
 >
   {{#if (and this.editingIsEnabled (not @isSaving))}}

--- a/web/app/styles/components/editable-field.scss
+++ b/web/app/styles/components/editable-field.scss
@@ -121,15 +121,11 @@
   }
 
   .edit-overlay-affordance {
-    @apply absolute -left-[5px] bottom-0 flex w-[calc(100%+10px)] translate-y-full gap-1 pt-2.5;
+    @apply absolute -left-[5px] bottom-0 flex w-[calc(100%+10px)] translate-y-full gap-1 pt-2.5 pl-[5px] pb-[80px];
 
     &::before {
       content: "";
-      @apply absolute left-0 h-full w-full bg-gradient-to-b;
-    }
-
-    &.page-faint::before {
-      @apply from-color-page-faint via-color-page-faint-90 to-transparent;
+      @apply absolute left-0 h-full w-full bg-gradient-to-b from-white via-white/90 to-transparent;
     }
 
     button {

--- a/web/app/styles/components/project.scss
+++ b/web/app/styles/components/project.scss
@@ -1,6 +1,7 @@
 .project-screen {
   .editable-field {
     @apply -mx-2;
+
     &:not(.active) {
       @apply w-auto min-w-[30%];
     }

--- a/web/app/styles/components/sidebar.scss
+++ b/web/app/styles/components/sidebar.scss
@@ -21,6 +21,16 @@
     @apply mt-[3px];
   }
 
+  .editable-field {
+    .edit-overlay-affordance {
+      @apply pb-[125px];
+
+      &::before {
+        @apply from-color-page-faint via-color-page-faint-90 to-transparent;
+      }
+    }
+  }
+
   .sidebar-header {
     @apply sticky top-0 z-10 flex justify-between bg-color-page-faint px-3.5 py-4;
 

--- a/web/tests/integration/components/editable-field-test.ts
+++ b/web/tests/integration/components/editable-field-test.ts
@@ -408,13 +408,13 @@ module("Integration | Component | editable-field", function (hooks) {
       />
     `);
 
-    assert.dom(EDITABLE_FIELD).doesNotHaveClass("z-10");
+    assert.dom(EDITABLE_FIELD).doesNotHaveClass("active");
     assert.dom(SAVE_BUTTON).doesNotExist();
     assert.dom(CANCEL_BUTTON).doesNotExist();
 
     await click(FIELD_TOGGLE);
 
-    assert.dom(EDITABLE_FIELD).hasClass("z-10");
+    assert.dom(EDITABLE_FIELD).hasClass("active");
     assert.dom(SAVE_BUTTON).exists();
     assert.dom(CANCEL_BUTTON).exists();
   });

--- a/web/tests/integration/components/editable-field-test.ts
+++ b/web/tests/integration/components/editable-field-test.ts
@@ -408,13 +408,13 @@ module("Integration | Component | editable-field", function (hooks) {
       />
     `);
 
-    assert.dom(EDITABLE_FIELD).doesNotHaveClass("active");
+    assert.dom(EDITABLE_FIELD).doesNotHaveClass("z-10");
     assert.dom(SAVE_BUTTON).doesNotExist();
     assert.dom(CANCEL_BUTTON).doesNotExist();
 
     await click(FIELD_TOGGLE);
 
-    assert.dom(EDITABLE_FIELD).hasClass("active");
+    assert.dom(EDITABLE_FIELD).hasClass("z-10");
     assert.dom(SAVE_BUTTON).exists();
     assert.dom(CANCEL_BUTTON).exists();
   });

--- a/web/tests/integration/components/editable-field-test.ts
+++ b/web/tests/integration/components/editable-field-test.ts
@@ -400,7 +400,7 @@ module("Integration | Component | editable-field", function (hooks) {
     assert.dom(`[data-test-two] ${PEOPLE_SELECT} input`).isFocused();
   });
 
-  test("it shows confirm and cancel buttons when in editing mode", async function (this: EditableFieldComponentTestContext, assert) {
+  test("it shows buttons and uses the correct classes when in editing mode", async function (this: EditableFieldComponentTestContext, assert) {
     await render<EditableFieldComponentTestContext>(hbs`
       <EditableField
         @value="foo"
@@ -408,11 +408,13 @@ module("Integration | Component | editable-field", function (hooks) {
       />
     `);
 
+    assert.dom(EDITABLE_FIELD).doesNotHaveClass("active");
     assert.dom(SAVE_BUTTON).doesNotExist();
     assert.dom(CANCEL_BUTTON).doesNotExist();
 
     await click(FIELD_TOGGLE);
 
+    assert.dom(EDITABLE_FIELD).hasClass("active");
     assert.dom(SAVE_BUTTON).exists();
     assert.dom(CANCEL_BUTTON).exists();
   });


### PR DESCRIPTION
Improves EditableField `active` styles on the projects screen.

- Increases title/description inputs to full width on click to reduce layout shift
- Adds `edit-overlay-affordance` support for white backgrounds