### PR TITLE
Fix visual bug on ProjectResource overflow button

### DIFF
--- a/web/app/styles/components/project.scss
+++ b/web/app/styles/components/project.scss
@@ -57,6 +57,18 @@
       @apply text-color-foreground-faint;
     }
 
+    .overflow-button {
+      &:hover,
+      &:focus,
+      &:active,
+      &:focus-visible,
+      &.open {
+        .button-affordance {
+          @apply bg-color-page-primary;
+        }
+      }
+    }
+
     .overflow-button-container {
       @apply absolute right-1 top-1;
       @apply from-color-page-faint;

--- a/web/app/styles/components/project.scss
+++ b/web/app/styles/components/project.scss
@@ -59,6 +59,7 @@
 
     .overflow-button-container {
       @apply absolute right-1 top-1;
+      @apply from-color-page-faint;
     }
   }
 }


### PR DESCRIPTION
You can currently see a faintly darker gradient when hovering project resources:
<img width="175" alt="CleanShot 2023-11-27 at 15 11 55@2x" src="https://github.com/hashicorp-forge/hermes/assets/754957/3347c5a9-60df-4926-9133-6be09e9ed799">

This PR fixes it:
<img width="182" alt="CleanShot 2023-11-27 at 15 11 38@2x" src="https://github.com/hashicorp-forge/hermes/assets/754957/7305e9b8-263f-4de3-8d27-0161ed75c87a">
