### PR TITLE
Fix approver checkmark

### DIFF
--- a/web/app/components/person/index.hbs
+++ b/web/app/components/person/index.hbs
@@ -1,6 +1,7 @@
 {{#unless this.isHidden}}
   <div class="flex w-full space-x-2" ...attributes>
     <div class="relative shrink-0">
+      <Person::Avatar @size="small" @email={{@email}} @imgURL={{@imgURL}} />
       {{#if (eq @badge "approved")}}
         <div
           data-test-person-approved-badge
@@ -12,7 +13,6 @@
           />
         </div>
       {{/if}}
-      <Person::Avatar @size="small" @email={{@email}} @imgURL={{@imgURL}} />
     </div>
     <div
       data-test-person-email

--- a/web/tests/integration/components/person-test.ts
+++ b/web/tests/integration/components/person-test.ts
@@ -8,6 +8,8 @@ import {
   authenticateTestUser,
 } from "hermes/utils/mirage-utils";
 
+const APPROVED_BADGE = "[data-test-person-approved-badge]";
+
 interface PersonComponentTestContext extends MirageTestContext {
   ignoreUnknown: boolean;
   imgURL: string;
@@ -72,16 +74,16 @@ module("Integration | Component | person", function (hooks) {
       <Person @email="" @badge={{this.badge}} />
     `);
 
-    assert.dom("[data-test-person-approved-badge]").doesNotExist();
+    assert.dom(APPROVED_BADGE).doesNotExist();
 
     this.set("badge", "approved");
 
-    assert.dom("[data-test-person-approved-badge]").exists();
+    assert.dom(APPROVED_BADGE).exists();
 
     this.set("badge", "pending");
 
     assert
-      .dom("[data-test-person-approved-badge]")
+      .dom(APPROVED_BADGE)
       .doesNotExist("only shows a badge if the correct value is passed in");
   });
 


### PR DESCRIPTION
Fixes a z-index issue making the "approved" badge appear below the avatar rather than above it.

Also cleans up the component test a bit.