### PR TITLE
Switch `patchDocument` from `task` to `enqueueTask`

### DIFF
--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -4,6 +4,7 @@ import { action } from "@ember/object";
 import { getOwner } from "@ember/application";
 import { inject as service } from "@ember/service";
 import {
+  enqueueTask,
   keepLatestTask,
   restartableTask,
   task,
@@ -648,7 +649,7 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
     },
   );
 
-  patchDocument = task(async (fields) => {
+  patchDocument = enqueueTask(async (fields) => {
     const endpoint = this.isDraft ? "drafts" : "documents";
 
     try {


### PR DESCRIPTION
Makes the `patchDocument` task enqueue-able to handle instances where two patches fire at once, corrupting the document. If an `EditableField` is open and has changes, clicking the "change status" button (e.g., "Move to approved") will trigger two patch calls: one to save the EditableField change; the other to save the status. Now, Hermes waits for the first task to finish before starting the second. 