### PR TITLE
Add fields to projects API responses

### DIFF
--- a/internal/api/v2/projects_related_resources.go
+++ b/internal/api/v2/projects_related_resources.go
@@ -78,7 +78,7 @@ func projectsResourceRelatedResourcesHandler(
 						"error", err,
 					}, logArgs...)...)
 				http.Error(
-					w, "Error processing requst", http.StatusInternalServerError)
+					w, "Error processing request", http.StatusInternalServerError)
 				return
 			}
 		}
@@ -134,7 +134,7 @@ func projectsResourceRelatedResourcesHandler(
 						"error", err,
 					}, logArgs...)...)
 				http.Error(
-					w, "Error processing requst", http.StatusInternalServerError)
+					w, "Error processing request", http.StatusInternalServerError)
 				return
 			}
 
@@ -163,7 +163,7 @@ func projectsResourceRelatedResourcesHandler(
 						"error", err,
 					}, logArgs...)...)
 				http.Error(
-					w, "Error processing requst", http.StatusInternalServerError)
+					w, "Error processing request", http.StatusInternalServerError)
 				return
 			}
 
@@ -211,7 +211,7 @@ func projectsResourceRelatedResourcesHandler(
 					"error", err,
 				}, logArgs...)...)
 			http.Error(
-				w, "Error processing requst", http.StatusInternalServerError)
+				w, "Error processing request", http.StatusInternalServerError)
 			return
 		}
 

--- a/internal/api/v2/projects_related_resources.go
+++ b/internal/api/v2/projects_related_resources.go
@@ -23,11 +23,15 @@ type ProjectRelatedResourcesGetResponseExternalLink struct {
 }
 
 type ProjectRelatedResourcesGetResponseHermesDocument struct {
-	GoogleFileID   string `json:"googleFileID"`
-	Title          string `json:"title"`
-	DocumentType   string `json:"documentType"`
-	DocumentNumber string `json:"documentNumber"`
-	SortOrder      int    `json:"sortOrder"`
+	GoogleFileID   string   `json:"googleFileID"`
+	Title          string   `json:"title"`
+	DocumentType   string   `json:"documentType"`
+	DocumentNumber string   `json:"documentNumber"`
+	Owners         []string `json:"owners"`
+	OwnerPhotos    []string `json:"ownerPhotos,omitempty"`
+	Product        string   `json:"product"`
+	SortOrder      int      `json:"sortOrder"`
+	Status         string   `json:"status"`
 }
 
 type ProjectRelatedResourcesPutRequest struct {
@@ -163,6 +167,24 @@ func projectsResourceRelatedResourcesHandler(
 				return
 			}
 
+			// Get owner photo by searching Google Workspace directory.
+			if len(doc.Owners) > 0 {
+				ppl, err := srv.GWService.SearchPeople(doc.Owners[0], "photos")
+				if err != nil {
+					// Log but don't return an error.
+					srv.Logger.Error("error searching directory for person",
+						append([]interface{}{
+							"error", err,
+							"person", doc.Owners[0],
+						}, logArgs...)...)
+				}
+				if len(ppl) > 0 {
+					if len(ppl[0].Photos) > 0 {
+						doc.OwnerPhotos = []string{ppl[0].Photos[0].Url}
+					}
+				}
+			}
+
 			resp.HermesDocuments = append(
 				resp.HermesDocuments,
 				ProjectRelatedResourcesGetResponseHermesDocument{
@@ -170,7 +192,11 @@ func projectsResourceRelatedResourcesHandler(
 					Title:          doc.Title,
 					DocumentType:   doc.DocType,
 					DocumentNumber: doc.DocNumber,
+					Owners:         doc.Owners,
+					OwnerPhotos:    doc.OwnerPhotos,
+					Product:        doc.Product,
 					SortOrder:      hdrr.RelatedResource.SortOrder,
+					Status:         doc.Status,
 				})
 		}
 


### PR DESCRIPTION
Adds fields to projects API responses:

GET `/projects`: adds `products`

GET `/projects/{project_id}`: adds `owners`, `ownerPhotos`, `product`, and `status`