### PR TITLE
Expand `Doc::TileMedium` interface

### DIFF
--- a/web/app/components/doc/thumbnail.hbs
+++ b/web/app/components/doc/thumbnail.hbs
@@ -26,6 +26,7 @@
 
     {{#if this.badgeIsShown}}
       <Product::Avatar
+        data-test-product={{@product}}
         data-test-doc-thumbnail-product-badge
         @product={{@product}}
         @size={{this.size}}

--- a/web/app/components/doc/tile-medium.hbs
+++ b/web/app/components/doc/tile-medium.hbs
@@ -1,9 +1,11 @@
-{{! Notes:
-  - The hover effect requires a parent with the `group` class.
-  - Non-essential links have `tabindex="-1"` so they're not focusable
-    with the keyboard. This allows the user to tab through documents
-    without having to skip through the meta links that are otherwise
-    accessible on the document details screen.
+{{!
+
+  1.
+  The hover effect requires a parent with the `group` and `relative` classes. Normally, we'd include that wrapper within this template, but we want the flexibility to work with components whose absolutely positioned controls are unknown to us but that we nonetheless consider "within the click area," such that interacting with them maintains the tile's hover and focus states. For example, in the projects screen, we want to keep the tile's hover state when the user focuses the overflow menu.
+
+  2.
+  Non-essential links have `tabindex="-1"` so they're not focusable with the keyboard. This allows the user to tab through documents without having to skip through the meta links that are otherwise accessible on the document details screen.
+
 }}
 <div class="tile">
   <div class="flex justify-between gap-[18px] pl-3 pr-8 pt-5 pb-6">
@@ -13,6 +15,7 @@
       tabindex="-1"
       @route="authenticated.documents"
       @query={{hash owners=(array (get @doc.owners 0))}}
+      disabled={{not (get @doc.owners 0)}}
     >
       <Person::Avatar
         @size="large"
@@ -29,7 +32,7 @@
         <LinkTo
           data-test-document-link
           @route="authenticated.document"
-          @model={{@doc.googleFileID}}
+          @model={{this.docID}}
         >
           {{! Primary click area }}
           <div
@@ -46,7 +49,7 @@
             {{! Doc Number }}
             <span data-test-document-number class="shrink-0 font-regular">
               <span class="whitespace-nowrap">
-                {{@doc.documentNumber}}
+                {{this.docNumber}}
               </span>
             </span>
           </h3>
@@ -55,24 +58,25 @@
 
       <div class="pointer-events-none relative">
         <div class="mt-1.5 flex gap-[5px] text-color-foreground-faint">
-          By
           {{! Owner }}
           <LinkTo
             tabindex="-1"
             data-test-document-owner-name
             @route="authenticated.documents"
             @query={{hash owners=(array (get @doc.owners 0))}}
-            class="underline underline-offset-[3px] hover:text-color-foreground-strong"
+            disabled={{not (get @doc.owners 0)}}
+            class="underlined-link text-color-foreground-primary"
           >
-            {{get @doc.owners 0}}
+            {{or (get @doc.owners 0) "Unknown"}}
           </LinkTo>
           <span class="vertical-line">
             |
           </span>
           {{! Product }}
           <ProductLink
+            @product={{@doc.product}}
             tabindex="-1"
-            class="underline underline-offset-[3px] hover:text-color-foreground-strong"
+            class="underlined-link text-color-foreground-faint"
           >
             <:default>
               {{@doc.product}}
@@ -82,7 +86,9 @@
             |
           </span>
           {{! Created time }}
-          {{time-ago @doc.createdTime}}
+          <span class="text-color-foreground-disabled">
+            {{time-ago @doc.createdTime}}
+          </span>
         </div>
 
         {{! Summary }}
@@ -101,7 +107,7 @@
             class="interactive"
           />
           {{! Doc type }}
-          <Hds::Badge data-test-document-type @text={{@doc.documentType}} />
+          <Hds::Badge data-test-document-type @text={{this.docType}} />
         </div>
       </div>
     </div>

--- a/web/app/components/doc/tile-medium.ts
+++ b/web/app/components/doc/tile-medium.ts
@@ -1,10 +1,11 @@
 import Component from "@glimmer/component";
 import { RelatedHermesDocument } from "../related-resources";
+import { HermesDocument } from "hermes/types/document";
 
 interface DocTileMediumComponentSignature {
   Element: HTMLAnchorElement;
   Args: {
-    doc: RelatedHermesDocument;
+    doc: RelatedHermesDocument | HermesDocument;
     avatarIsLoading?: boolean;
   };
   Blocks: {
@@ -12,7 +13,31 @@ interface DocTileMediumComponentSignature {
   };
 }
 
-export default class DocTileMediumComponent extends Component<DocTileMediumComponentSignature> {}
+export default class DocTileMediumComponent extends Component<DocTileMediumComponentSignature> {
+  protected get docID() {
+    if ("googleFileID" in this.args.doc) {
+      return this.args.doc.googleFileID;
+    } else {
+      return this.args.doc.objectID;
+    }
+  }
+
+  protected get docNumber() {
+    if ("documentNumber" in this.args.doc) {
+      return this.args.doc.documentNumber;
+    } else {
+      return this.args.doc.docNumber;
+    }
+  }
+
+  protected get docType() {
+    if ("documentType" in this.args.doc) {
+      return this.args.doc.documentType;
+    } else {
+      return this.args.doc.docType;
+    }
+  }
+}
 
 declare module "@glint/environment-ember-loose/registry" {
   export default interface Registry {

--- a/web/mirage/factories/related-hermes-document.ts
+++ b/web/mirage/factories/related-hermes-document.ts
@@ -1,5 +1,5 @@
 import { Factory } from "miragejs";
-import { TEST_USER_EMAIL } from "hermes/utils/mirage-utils";
+import { TEST_USER_EMAIL, TEST_USER_PHOTO } from "hermes/utils/mirage-utils";
 
 export default Factory.extend({
   id: (i) => `doc-${i}`,
@@ -15,7 +15,7 @@ export default Factory.extend({
     return `LAB-00${this.id}`;
   },
   owners: [TEST_USER_EMAIL],
-  ownerPhotos: [],
+  ownerPhotos: [TEST_USER_PHOTO],
   product: "Vault",
   status: "In-Review",
   summary() {

--- a/web/tests/integration/components/doc/tile-medium-test.ts
+++ b/web/tests/integration/components/doc/tile-medium-test.ts
@@ -1,0 +1,91 @@
+import { render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
+import { setupRenderingTest } from "ember-qunit";
+import { module, test } from "qunit";
+import { RelatedHermesDocument } from "hermes/components/related-resources";
+import { HermesDocument } from "hermes/types/document";
+import { TEST_USER_EMAIL, TEST_USER_PHOTO } from "hermes/utils/mirage-utils";
+
+const AVATAR_LINK = "[data-test-document-owner-avatar]";
+const TITLE = "[data-test-document-title]";
+const DOC_NUMBER = "[data-test-document-number]";
+const USER_NAME = "[data-test-document-owner-name]";
+const STATUS = "[data-test-document-status]";
+const TYPE = "[data-test-document-type]";
+const THUMBNAIL_BADGE = "[data-test-doc-thumbnail-product-badge]";
+
+interface DocTileMediumComponentContext extends MirageTestContext {
+  doc: HermesDocument | RelatedHermesDocument;
+}
+
+module("Integration | Component | doc/tile-medium", function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function (this: DocTileMediumComponentContext) {
+    this.server.create("document", {
+      title: "Bar",
+      summary: "Bar",
+      product: "Terraform",
+      docNumber: "456",
+      docType: "Bar",
+      status: "WIP",
+      owners: [TEST_USER_EMAIL],
+    });
+
+    this.server.create("related-hermes-document", {
+      title: "Foo",
+      summary: "Foo",
+      product: "Vault",
+      documentNumber: "123",
+      documentType: "Foo",
+      status: "Approved",
+      owners: [TEST_USER_EMAIL],
+    });
+  });
+
+  test("it can render HermesDocuments or RelatedHermesDocuments", async function (this: DocTileMediumComponentContext, assert) {
+    this.set("doc", this.server.schema.document.first().attrs);
+
+    const hermesDocument = this.doc as HermesDocument;
+
+    function assertDocumentInfo(doc: HermesDocument | RelatedHermesDocument) {
+      const docNumber = "docNumber" in doc ? doc.docNumber : doc.documentNumber;
+      const docType = "docType" in doc ? doc.docType : doc.documentType;
+
+      assert
+        .dom(AVATAR_LINK)
+        .hasAttribute(
+          "href",
+          `/documents?owners=%5B%22${encodeURIComponent(
+            TEST_USER_EMAIL,
+          )}%22%5D`,
+        );
+
+      assert.dom(`${AVATAR_LINK} img`).hasAttribute("src", TEST_USER_PHOTO);
+
+      assert.dom(TITLE).hasText(doc.title);
+      assert.dom(DOC_NUMBER).hasText(docNumber);
+      assert.dom(USER_NAME).hasText(doc.owners?.[0] as string);
+      assert.dom(STATUS).hasText(doc.status);
+      assert.dom(TYPE).hasText(docType);
+
+      assert
+        .dom(THUMBNAIL_BADGE)
+        .hasAttribute("data-test-product", doc.product as string);
+    }
+
+    await render<DocTileMediumComponentContext>(
+      hbs`<Doc::TileMedium @doc={{this.doc}} />`,
+    );
+
+    assertDocumentInfo(hermesDocument);
+
+    this.set("doc", this.server.schema.relatedHermesDocument.first().attrs);
+
+    const relatedHermesDocument = this.doc as RelatedHermesDocument;
+
+    assertDocumentInfo(relatedHermesDocument);
+  });
+});


### PR DESCRIPTION
Expands `Doc::TileMedium` to handle `HermesDocuments` as well as `RelatedHermesDocuments` so it can be used on the forthcoming Product Areas screen. Also improves documentation.

Pending #463 which has shared `underlined-link` styles. 