### PR TITLE
Rename `project-resource-list` →  `divided-list`

### DIFF
--- a/web/app/components/project/index.hbs
+++ b/web/app/components/project/index.hbs
@@ -229,7 +229,7 @@
             @text="{{this.hermesDocuments.length}}"
           />
         </div>
-        <ol data-test-document-list class="project-resource-list mt-3">
+        <ol data-test-document-list class="divided-list mt-3">
           {{#each this.hermesDocuments as |document|}}
             <li class="group relative" data-test-document-list-item>
               <Project::Resource
@@ -262,7 +262,7 @@
             @text="{{this.externalLinks.length}}"
           />
         </div>
-        <ol data-test-external-link-list class="project-resource-list mt-5">
+        <ol data-test-external-link-list class="divided-list mt-5">
           {{#each this.externalLinks as |link i|}}
             <li class="group" data-test-document-list-item>
               <Project::Resource

--- a/web/app/styles/app.scss
+++ b/web/app/styles/app.scss
@@ -107,6 +107,12 @@ h1 {
   }
 }
 
+.divided-list {
+  > li:not(:first-child) {
+    @apply border-t border-t-color-border-faint;
+  }
+}
+
 // Prevent the Flight Icons shim from taking up space
 .flight-sprite-container {
   position: fixed;

--- a/web/app/styles/components/project.scss
+++ b/web/app/styles/components/project.scss
@@ -34,12 +34,6 @@
     @apply scale-105 transition-transform;
   }
 
-  .project-resource-list {
-    > li:not(:first-child) {
-      @apply border-t border-t-color-border-faint;
-    }
-  }
-
   .project-resource {
     @apply relative;
 


### PR DESCRIPTION
Renames a class so it makes sense in other contexts.