### PR TITLE
Update active product icon

### DIFF
--- a/web/app/types/project-status.ts
+++ b/web/app/types/project-status.ts
@@ -13,7 +13,7 @@ export const projectStatusObjects: Record<ProjectStatus, ProjectStatusObject> =
   {
     [ProjectStatus.Active]: {
       label: "Active",
-      icon: "check-circle",
+      icon: "zap",
     },
     [ProjectStatus.Completed]: {
       label: "Completed",


### PR DESCRIPTION
Sets the icon for `Active` Projects. I'm not totally committed to "zap," but I want to at least differentiate it from `Completed`.