### PR TITLE
Add `.gts` boilerplate to `Hds::Button`

### DIFF
--- a/web/types/hds/button.d.ts
+++ b/web/types/hds/button.d.ts
@@ -1,23 +1,26 @@
 // https://helios.hashicorp.design/components/button?tab=code#component-api
+declare module "@hashicorp/design-system-components/components/hds/button" {
+  import Component from "@glimmer/component";
+  import { ComponentLike } from "@glint/template";
+  import {
+    HdsButtonColor,
+    HdsIconPosition,
+    HdsComponentSize,
+    HdsAnchorComponentArgs,
+  } from "hds/_shared";
 
-import { ComponentLike } from "@glint/template";
-import {
-  HdsButtonColor,
-  HdsIconPosition,
-  HdsComponentSize,
-  HdsAnchorComponentArgs,
-} from "hds/_shared";
+  interface HdsButtonComponentSignature {
+    Element: HTMLButtonElement;
+    Args: HdsAnchorComponentArgs & {
+      text: string;
+      size?: HdsComponentSize;
+      color?: HdsButtonColor;
+      isIconOnly?: boolean;
+      isFullWidth?: boolean;
+      isRouteExternal?: boolean;
+    };
+  }
 
-interface HdsButtonComponentSignature {
-  Element: HTMLButtonElement;
-  Args: HdsAnchorComponentArgs & {
-    text: string;
-    size?: HdsComponentSize;
-    color?: HdsButtonColor;
-    isIconOnly?: boolean;
-    isFullWidth?: boolean;
-    isRouteExternal?: boolean;
-  };
+  export type HdsButtonComponent = ComponentLike<HdsButtonComponentSignature>;
+  export default class HdsButton extends Component<HdsButtonComponentSignature> {}
 }
-
-export type HdsButtonComponent = ComponentLike<HdsButtonComponentSignature>;


### PR DESCRIPTION
Adds boilerplate to import `Hds::Button` into `.gts` files.