### PR TITLE
Add ProductAvatars to ProjectTiles

### DIFF
--- a/web/app/components/project/tile.hbs
+++ b/web/app/components/project/tile.hbs
@@ -28,7 +28,11 @@
         <ul class="flex gap-px">
           {{#each @project.products as |product|}}
             <li class="flex items-center" data-test-product>
-              {{product}}
+              {{#if this.productColorsAreEnabled}}
+                <Product::Avatar @product={{product}} />
+              {{else}}
+                {{product}}
+              {{/if}}
             </li>
           {{/each}}
         </ul>

--- a/web/app/components/project/tile.ts
+++ b/web/app/components/project/tile.ts
@@ -1,4 +1,6 @@
+import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
+import FlagsService from "hermes/services/flags";
 import { HermesProject } from "hermes/types/project";
 
 interface ProjectTileComponentSignature {
@@ -8,7 +10,13 @@ interface ProjectTileComponentSignature {
   };
 }
 
-export default class ProjectTileComponent extends Component<ProjectTileComponentSignature> {}
+export default class ProjectTileComponent extends Component<ProjectTileComponentSignature> {
+  @service declare flags: FlagsService;
+
+  protected get productColorsAreEnabled(): boolean {
+    return this.flags.productColors === true;
+  }
+}
 
 declare module "@glint/environment-ember-loose/registry" {
   export default interface Registry {

--- a/web/tests/acceptance/authenticated/projects-test.ts
+++ b/web/tests/acceptance/authenticated/projects-test.ts
@@ -56,7 +56,7 @@ module("Acceptance | authenticated/projects", function (hooks) {
 
     let expectedTitles: string[] = [];
     let expectedDescriptions: string[] = [];
-    let expectedProducts: string[] = [];
+    let expectedProductCount = 0;
     let expectedKeys: string[] = [];
     let expectedJiraTypes: string[] = [];
 
@@ -75,7 +75,7 @@ module("Acceptance | authenticated/projects", function (hooks) {
         }
 
         if (project.products) {
-          expectedProducts.push(...project.products);
+          expectedProductCount += project.products.length;
         }
       });
 
@@ -87,9 +87,7 @@ module("Acceptance | authenticated/projects", function (hooks) {
       (e) => e.textContent?.trim(),
     );
 
-    const renderedProducts = findAll(PROJECT_PRODUCT).map(
-      (e) => e.textContent?.trim(),
-    );
+    const renderedProductsCount = findAll(PROJECT_PRODUCT).length;
 
     const renderedKeys = findAll(PROJECT_JIRA_KEY).map(
       (e) => e.textContent?.trim(),
@@ -101,7 +99,7 @@ module("Acceptance | authenticated/projects", function (hooks) {
 
     assert.deepEqual(renderedTitles, expectedTitles);
     assert.deepEqual(renderedDescriptions, expectedDescriptions);
-    assert.deepEqual(renderedProducts, expectedProducts);
+    assert.deepEqual(renderedProductsCount, expectedProductCount);
     assert.deepEqual(renderedKeys, expectedKeys);
     assert.deepEqual(renderedJiraTypes, expectedJiraTypes);
   });


### PR DESCRIPTION
Adds product avatars to the project tiles if the `productColors` flag is enabled. 