### PR TITLE
Add Jira proxy

### DIFF
--- a/configs/config.hcl
+++ b/configs/config.hcl
@@ -157,6 +157,21 @@ indexer {
   update_draft_headers = true
 }
 
+// jira is the configuration for Hermes to work with Jira.
+jira {
+  // api_token is the API token for authenticating to Jira.
+  api_token = ""
+
+  // enabled enables integration with Jira.
+  enabled = false
+
+  // url is the URL of the Jira instance (ex: https://your-domain.atlassian.net).
+  url = ""
+
+  // user is the user for authenticating to Jira.
+  user = ""
+}
+
 // okta configures Hermes to authenticate users using an AWS Application Load
 // Balancer and Okta instead of using Google OAuth.
 okta {

--- a/internal/api/v2/jira_issue.go
+++ b/internal/api/v2/jira_issue.go
@@ -1,0 +1,232 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"regexp"
+	"time"
+
+	"github.com/hashicorp-forge/hermes/internal/jira"
+	"github.com/hashicorp-forge/hermes/internal/server"
+)
+
+type JiraIssueGetResponse struct {
+	Assignee string `json:"assignee,omitempty"`
+	Key      string `json:"key"`
+	Priority string `json:"priority"`
+	Project  string `json:"project"`
+	Reporter string `json:"reporter"`
+	Status   string `json:"status"`
+	Summary  string `json:"summary"`
+	URL      string `json:"url"`
+}
+
+// JiraIssueHandler proxies Jira issue API requests.
+func JiraIssueHandler(srv server.Server) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log := srv.Logger
+		logArgs := []any{
+			"path", r.URL.Path,
+		}
+
+		// Authorize request.
+		userEmail := r.Context().Value("userEmail").(string)
+		if userEmail == "" {
+			log.Error("user email not found in request context", logArgs...)
+			http.Error(
+				w, "No authorization information for request", http.StatusUnauthorized)
+			return
+		}
+
+		// Respond with error if Jira is not enabled.
+		if srv.Jira == nil || srv.Config.Jira == nil || !srv.Config.Jira.Enabled {
+			log.Warn("Jira not enabled", logArgs...)
+			http.Error(
+				w, "Jira has not been enabled", http.StatusUnprocessableEntity)
+			return
+		}
+
+		// Parse Jira issue ID.
+		jiraIssueRegex := regexp.MustCompile(
+			`^\/api\/v\d+\/jira\/issues\/([0-9A-Za-z_\-]+)$`)
+		if jiraIssueRegex.MatchString(r.URL.Path) {
+			issueID, err := getJiraIssueIDFromPath(r.URL.Path, jiraIssueRegex)
+			if err != nil {
+				log.Warn("error getting Jira issue ID from path",
+					append([]interface{}{
+						"error", err,
+					}, logArgs...)...)
+				http.Error(w, "Jira issue not found", http.StatusNotFound)
+				return
+			}
+			logArgs = append(logArgs, "jira_issue_id", issueID)
+
+			switch r.Method {
+			case "GET":
+				logArgs = append(logArgs, "method", r.Method)
+
+				// Parse Jira URL.
+				jiraURL, err := url.Parse(srv.Jira.URL)
+				if err != nil {
+					// This shouldn't happen because we check this when creating the Jira
+					// service.
+					log.Error("error parsing Jira URL",
+						append([]interface{}{
+							"error", err,
+						}, logArgs...)...)
+					http.Error(w, "Error processing request",
+						http.StatusInternalServerError)
+					return
+				}
+
+				// Build URL for HTTP request.
+				jiraIssueURL := *jiraURL
+				jiraIssueURL.Path = path.Join(
+					jiraURL.Path,
+					fmt.Sprintf("rest/api/3/issue/%s", issueID),
+				)
+				q := jiraIssueURL.Query()
+				q.Add("fields",
+					"assignee,issuetype,key,priority,project,reporter,status,summary")
+				jiraIssueURL.RawQuery = q.Encode()
+
+				resp, err := executeJiraRequest(jiraIssueURL.String(), srv)
+				if err != nil {
+					log.Error("error executing Jira request",
+						append([]interface{}{
+							"error", err,
+						}, logArgs...)...)
+					http.Error(w, "Error processing request",
+						http.StatusInternalServerError)
+					return
+				}
+				defer resp.Body.Close()
+
+				switch {
+				case resp.StatusCode >= 200 && resp.StatusCode <= 299:
+					respBody, err := io.ReadAll(resp.Body)
+					if err != nil {
+						log.Error("error reading body of response",
+							append([]interface{}{
+								"error", err,
+							}, logArgs...)...)
+						http.Error(w, "Error processing request",
+							http.StatusInternalServerError)
+						return
+					}
+
+					var jiraAPIResp jira.APIResponseIssueGet
+					if err := json.Unmarshal(respBody, &jiraAPIResp); err != nil {
+						log.Error("error unmarshaling issue response",
+							append([]interface{}{
+								"error", err,
+							}, logArgs...)...)
+						http.Error(w, "Error processing request",
+							http.StatusInternalServerError)
+						return
+					}
+
+					// Build issue URL.
+					issueURL := *jiraURL
+					issueURL.Path = path.Join(
+						jiraURL.Path,
+						"browse",
+						jiraAPIResp.Key,
+					)
+
+					resp := JiraIssueGetResponse{
+						Assignee: jiraAPIResp.Fields.Assignee.DisplayName,
+						Key:      jiraAPIResp.Key,
+						Priority: jiraAPIResp.Fields.Priority.Name,
+						Project:  jiraAPIResp.Fields.Project.Name,
+						Reporter: jiraAPIResp.Fields.Reporter.DisplayName,
+						Status:   jiraAPIResp.Fields.Status.Name,
+						Summary:  jiraAPIResp.Fields.Summary,
+						URL:      issueURL.String(),
+					}
+
+					// Write response.
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					enc := json.NewEncoder(w)
+					if err := enc.Encode(resp); err != nil {
+						log.Error("error encoding response",
+							append([]interface{}{
+								"error", err,
+							}, logArgs...)...,
+						)
+						http.Error(
+							w, "Error processing request", http.StatusInternalServerError)
+						return
+					}
+
+				case resp.StatusCode == http.StatusNotFound:
+					log.Warn("issue not found", logArgs...)
+					http.Error(w, "Not found", http.StatusNotFound)
+					return
+
+				default:
+					log.Error("received bad status code in Jira response",
+						append([]interface{}{
+							"error", err,
+							"status_code", resp.StatusCode,
+						}, logArgs...)...)
+					http.Error(w, "Error processing request",
+						http.StatusInternalServerError)
+					return
+				}
+
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+		} else {
+			log.Warn("path not found", logArgs...)
+			http.Error(w, "Not found", http.StatusNotFound)
+			return
+		}
+	})
+}
+
+func executeJiraRequest(url string, srv server.Server) (*http.Response, error) {
+	// Create HTTP request.
+	client := &http.Client{
+		Timeout: time.Second * 10,
+	}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating HTTP request: %w", err)
+	}
+
+	// Add authorization to request.
+	req.SetBasicAuth(
+		srv.Jira.User,
+		srv.Jira.APIToken,
+	)
+
+	// Execute HTTP request.
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error executing HTTP request: %w", err)
+	}
+
+	return resp, nil
+}
+
+// getJiraIssueIDFromPath returns the Jira issue ID from a request path and
+// corresponding regular expression.
+func getJiraIssueIDFromPath(path string, re *regexp.Regexp) (string, error) {
+	matches := re.FindStringSubmatch(path)
+	if len(matches) != 2 {
+		return "",
+			fmt.Errorf(
+				"wrong number of string submatches for resource URL path: %d",
+				len(matches),
+			)
+	}
+	return matches[1], nil
+}

--- a/internal/api/v2/jira_issue_picker.go
+++ b/internal/api/v2/jira_issue_picker.go
@@ -1,0 +1,171 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/hashicorp-forge/hermes/internal/jira"
+	"github.com/hashicorp-forge/hermes/internal/server"
+)
+
+type JiraIssuePickerGetResponse []JiraIssuePickerGetResponseIssue
+
+type JiraIssuePickerGetResponseIssue struct {
+	Key            string `json:"key"`
+	IssueTypeImage string `json:"issueTypeImage"`
+	Summary        string `json:"summary"`
+	URL            string `json:"url"`
+}
+
+// JiraIssuePickerHandler proxies Jira issue picker API requests.
+func JiraIssuePickerHandler(srv server.Server) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log := srv.Logger
+		logArgs := []any{
+			"path", r.URL.Path,
+		}
+
+		// Authorize request.
+		userEmail := r.Context().Value("userEmail").(string)
+		if userEmail == "" {
+			log.Error("user email not found in request context", logArgs...)
+			http.Error(
+				w, "No authorization information for request", http.StatusUnauthorized)
+			return
+		}
+
+		// Respond with error if Jira is not enabled.
+		if srv.Jira == nil || srv.Config.Jira == nil || !srv.Config.Jira.Enabled {
+			log.Warn("Jira not enabled", logArgs...)
+			http.Error(
+				w, "Jira has not been enabled", http.StatusUnprocessableEntity)
+			return
+		}
+
+		switch r.Method {
+		case "GET":
+			logArgs = append(logArgs, "method", r.Method)
+
+			// Get "query" query parameter.
+			query := r.URL.Query().Get("query")
+
+			// Parse Jira URL.
+			jiraURL, err := url.Parse(srv.Jira.URL)
+			if err != nil {
+				// This shouldn't happen because we check this when creating the Jira
+				// service.
+				log.Error("error parsing Jira URL",
+					append([]interface{}{
+						"error", err,
+					}, logArgs...)...)
+				http.Error(w, "Error processing request",
+					http.StatusInternalServerError)
+				return
+			}
+
+			// Build URL for HTTP request.
+			jiraIssuePickerURL := *jiraURL
+			jiraIssuePickerURL.Path = path.Join(
+				jiraURL.Path,
+				"rest/api/3/issue/picker",
+			)
+			q := jiraIssuePickerURL.Query()
+			q.Add("currentJQL", fmt.Sprintf(`text ~ "%s"`, query))
+			q.Add("query", query)
+			jiraIssuePickerURL.RawQuery = q.Encode()
+
+			resp, err := executeJiraRequest(jiraIssuePickerURL.String(), srv)
+			if err != nil {
+				log.Error("error executing issue picker request",
+					append([]interface{}{
+						"error", err,
+					}, logArgs...)...)
+				http.Error(w, "Error processing request",
+					http.StatusInternalServerError)
+				return
+			}
+			defer resp.Body.Close()
+
+			// Only write the response body if the response was successful.
+			if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+				respBody, err := io.ReadAll(resp.Body)
+				if err != nil {
+					log.Error("error reading body of issue picker response",
+						append([]interface{}{
+							"error", err,
+						}, logArgs...)...)
+					http.Error(w, "Error processing request",
+						http.StatusInternalServerError)
+					return
+				}
+
+				var jiraAPIResp jira.APIResponseIssuePickerGet
+				if err := json.Unmarshal(respBody, &jiraAPIResp); err != nil {
+					log.Error("error unmarshaling issue picker response",
+						append([]interface{}{
+							"error", err,
+						}, logArgs...)...)
+					http.Error(w, "Error processing request",
+						http.StatusInternalServerError)
+					return
+				}
+
+				// Build response.
+				issues := []JiraIssuePickerGetResponseIssue{}
+				for _, sec := range jiraAPIResp.Sections {
+					// We only want "Current Search" results.
+					if sec.ID == "cs" {
+						for _, iss := range sec.Issues {
+							// Build issue URL.
+							issueURL := *jiraURL
+							issueURL.Path = path.Join(
+								jiraURL.Path,
+								"browse",
+								iss.Key,
+							)
+
+							issues = append(issues, JiraIssuePickerGetResponseIssue{
+								Key:            iss.Key,
+								IssueTypeImage: iss.Img,
+								Summary:        iss.SummaryText,
+								URL:            issueURL.String(),
+							})
+						}
+					}
+				}
+
+				// Write response.
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				enc := json.NewEncoder(w)
+				if err := enc.Encode(issues); err != nil {
+					log.Error("error encoding response",
+						append([]interface{}{
+							"error", err,
+						}, logArgs...)...,
+					)
+					http.Error(
+						w, "Error processing request", http.StatusInternalServerError)
+					return
+				}
+			} else {
+				log.Error("received bad status code in Jira response",
+					append([]interface{}{
+						"error", err,
+						"status_code", resp.StatusCode,
+					}, logArgs...)...)
+				http.Error(w, "Error processing request",
+					http.StatusInternalServerError)
+				return
+			}
+
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+	})
+}

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp-forge/hermes/internal/config"
 	"github.com/hashicorp-forge/hermes/internal/datadog"
 	"github.com/hashicorp-forge/hermes/internal/db"
+	"github.com/hashicorp-forge/hermes/internal/jira"
 	"github.com/hashicorp-forge/hermes/internal/pkg/doctypes"
 	"github.com/hashicorp-forge/hermes/internal/pub"
 	"github.com/hashicorp-forge/hermes/internal/server"
@@ -257,6 +258,16 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 
+	// Initialize Jira service.
+	var jiraSvc *jira.Service
+	if cfg.Jira != nil && cfg.Jira.Enabled {
+		jiraSvc, err = jira.NewService(*cfg.Jira)
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("error initializing Jira service: %v", err))
+			return 1
+		}
+	}
+
 	// Initialize database.
 	if val, ok := os.LookupEnv("HERMES_SERVER_POSTGRES_PASSWORD"); ok {
 		cfg.Postgres.Password = val
@@ -316,6 +327,7 @@ func (c *Command) Run(args []string) int {
 		Config:     cfg,
 		DB:         db,
 		GWService:  goog,
+		Jira:       jiraSvc,
 		Logger:     c.Log,
 	}
 
@@ -335,6 +347,8 @@ func (c *Command) Run(args []string) int {
 			api.DraftsHandler(cfg, c.Log, algoSearch, algoWrite, goog, db)},
 		{"/api/v1/drafts/",
 			api.DraftsDocumentHandler(cfg, c.Log, algoSearch, algoWrite, goog, db)},
+		{"/api/v1/jira/issue/picker", apiv2.JiraIssuePickerHandler(srv)},
+		{"/api/v1/jira/issues/", apiv2.JiraIssueHandler(srv)},
 		{"/api/v1/me", api.MeHandler(c.Log, goog)},
 		{"/api/v1/me/recently-viewed-docs",
 			api.MeRecentlyViewedDocsHandler(cfg, c.Log, db)},
@@ -354,6 +368,8 @@ func (c *Command) Run(args []string) int {
 		{"/api/v2/documents/", apiv2.DocumentHandler(srv)},
 		{"/api/v2/drafts", apiv2.DraftsHandler(srv)},
 		{"/api/v2/drafts/", apiv2.DraftsDocumentHandler(srv)},
+		{"/api/v2/jira/issues/", apiv2.JiraIssueHandler(srv)},
+		{"/api/v2/jira/issue/picker", apiv2.JiraIssuePickerHandler(srv)},
 		{"/api/v2/me", apiv2.MeHandler(srv)},
 		{"/api/v2/me/recently-viewed-docs", apiv2.MeRecentlyViewedDocsHandler(srv)},
 		{"/api/v2/me/subscriptions", apiv2.MeSubscriptionsHandler(srv)},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,9 @@ type Config struct {
 	// Indexer contains the configuration for the Hermes indexer.
 	Indexer *Indexer `hcl:"indexer,block"`
 
+	// Jira is the configuration for Hermes to work with Jira.
+	Jira *Jira `hcl:"jira,block"`
+
 	// LogFormat configures the logging format. Supported values are "standard" or
 	// "json".
 	LogFormat string `hcl:"log_format,optional"`
@@ -230,6 +233,21 @@ type GoogleWorkspaceOAuth2 struct {
 	// RedirectURI is an authorized redirect URI for the given client_id as
 	// specified in the Google API Console Credentials page.
 	RedirectURI string `hcl:"redirect_uri,optional"`
+}
+
+// Jira is the configuration for Hermes to work with Jira.
+type Jira struct {
+	// APIToken is the API token for authenticating to Jira.
+	APIToken string `hcl:"api_token,optional"`
+
+	// Enabled enables integration with Jira.
+	Enabled bool `hcl:"enabled,optional"`
+
+	// URL is the URL of the Jira instance (ex: https://your-domain.atlassian.net).
+	URL string `hcl:"url,optional"`
+
+	// User is the user for authenticating to Jira.
+	User string `hcl:"user,optional"`
 }
 
 // Postgres configures PostgreSQL as the app database.

--- a/internal/jira/api_responses.go
+++ b/internal/jira/api_responses.go
@@ -1,0 +1,57 @@
+package jira
+
+// GET /rest/api/3/issue/{issueIdOrKey}
+type APIResponseIssueGet struct {
+	Fields APIResponseIssueGetFields `json:"fields"`
+	Key    string                    `json:"key"`
+}
+type APIResponseIssueGetFields struct {
+	Assignee  APIResponseIssueGetFieldsAssignee  `json:"assignee"`
+	IssueType APIResponseIssueGetFieldsIssueType `json:"issuetype"`
+	Priority  APIResponseIssueGetFieldsPriority  `json:"priority"`
+	Project   APIResponseIssueGetFieldsPriority  `json:"project"`
+	Reporter  APIResponseIssueGetFieldsReporter  `json:"reporter"`
+	Status    APIResponseIssueGetFieldsStatus    `json:"status"`
+	Summary   string                             `json:"summary"`
+}
+type APIResponseIssueGetFieldsAssignee struct {
+	AvatarURLs   APIResponseIssueGetFieldsReporterAvatarURLs `json:"avatarUrls"`
+	DisplayName  string                                      `json:"displayName"`
+	EmailAddress string                                      `json:"emailAddress"`
+}
+type APIResponseIssueGetFieldsIssueType struct {
+	Name string `json:"name"`
+}
+type APIResponseIssueGetFieldsPriority struct {
+	Name string `json:"name"`
+}
+type APIResponseIssueGetFieldsProject struct {
+	Name string `json:"name"`
+}
+type APIResponseIssueGetFieldsReporter struct {
+	AvatarURLs   APIResponseIssueGetFieldsReporterAvatarURLs `json:"avatarUrls"`
+	DisplayName  string                                      `json:"displayName"`
+	EmailAddress string                                      `json:"emailAddress"`
+}
+type APIResponseIssueGetFieldsReporterAvatarURLs struct {
+	FourtyEightByFourtyEight string `json:"48x48"`
+}
+type APIResponseIssueGetFieldsStatus struct {
+	Name string `json:"name"`
+}
+
+// GET /rest/api/3/issue/picker
+type APIResponseIssuePickerGet struct {
+	Sections []APIResponseIssuePickerGetSection `json:"sections"`
+}
+type APIResponseIssuePickerGetSection struct {
+	ID     string                                  `json:"id"`
+	Issues []APIResponseIssuePickerGetSectionIssue `json:"issues"`
+	Label  string                                  `json:"label"`
+}
+type APIResponseIssuePickerGetSectionIssue struct {
+	ID          int    `json:"id"`
+	Key         string `json:"key"`
+	Img         string `json:"img"`
+	SummaryText string `json:"summaryText"`
+}

--- a/internal/jira/doc.go
+++ b/internal/jira/doc.go
@@ -1,0 +1,2 @@
+// Package jira contains logic for working with Jira.
+package jira

--- a/internal/jira/service.go
+++ b/internal/jira/service.go
@@ -1,0 +1,56 @@
+package jira
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/hashicorp-forge/hermes/internal/config"
+)
+
+// Service is a service for interacting with Jira.
+type Service struct {
+	// APIToken is the API token for authenticating to Jira.
+	APIToken string
+
+	// URL is the URL of the Jira instance.
+	URL string
+
+	// User is the user for authenticating to Jira.
+	User string
+}
+
+// NewService creates a new Service.
+func NewService(cfg config.Jira) (*Service, error) {
+	// Validate configuration.
+	if err := validate(cfg); err != nil {
+		return nil, fmt.Errorf("error validating Jira configuration: %w", err)
+	}
+
+	// Verify that we can parse the Jira URL.
+	u, err := url.Parse(cfg.URL)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing Jira URL: %w", err)
+	}
+
+	// Verify scheme is HTTPS so the Jira credentials are secure.
+	if u.Scheme != "https" {
+		return nil, errors.New("only HTTPS URL scheme is allowed")
+	}
+
+	return &Service{
+		APIToken: cfg.APIToken,
+		URL:      cfg.URL,
+		User:     cfg.User,
+	}, nil
+}
+
+// validate validates the service configuration.
+func validate(cfg config.Jira) error {
+	return validation.ValidateStruct(&cfg,
+		validation.Field(&cfg.APIToken, validation.Required),
+		validation.Field(&cfg.URL, validation.Required),
+		validation.Field(&cfg.User, validation.Required),
+	)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"github.com/hashicorp-forge/hermes/internal/config"
+	"github.com/hashicorp-forge/hermes/internal/jira"
 	"github.com/hashicorp-forge/hermes/pkg/algolia"
 	gw "github.com/hashicorp-forge/hermes/pkg/googleworkspace"
 	"github.com/hashicorp/go-hclog"
@@ -24,6 +25,9 @@ type Server struct {
 
 	// GWService is the Google Workspace service for the server.
 	GWService *gw.Service
+
+	// Jira is the Jira service for the server.
+	Jira *jira.Service
 
 	// Logger is the logger for the server.
 	Logger hclog.Logger


### PR DESCRIPTION
This PR adds a Jira proxy for a couple of APIs to support Hermes projects.

### New (optional) configuration block

```hcl
// jira is the configuration for Hermes to work with Jira.
jira {
  // api_token is the API token for authenticating to Jira.
  api_token = ""

  // enabled enables integration with Jira.
  enabled = false

  // url is the URL of the Jira instance (ex: https://your-domain.atlassian.net).
  url = ""

  // user is the user for authenticating to Jira.
  user = ""
}
```

### New APIs

- GET `/api/v1/jira/issue/picker`
- GET `/api/v1/jira/issues/{issue_key}`
- GET `/api/v2/jira/issue/picker`
- GET `/api/v2/jira/issues/{issue_key}`