### PR TITLE
Remove 1px margin on some ProductAvatars

### DIFF
--- a/web/app/styles/hermes/avatar.scss
+++ b/web/app/styles/hermes/avatar.scss
@@ -6,7 +6,6 @@
     .product-abbreviation {
       &.letter-count-1 {
         @apply text-[12px] font-semibold;
-        @apply mt-[1px];
       }
 
       &.letter-count-2 {


### PR DESCRIPTION
Removes a 1px margin declaration that was misaligning some product avatars. 