### PR TITLE
Add `draft` queryParam support to `DocTileMedium`

### DIFF
--- a/web/app/components/doc/tile-medium.hbs
+++ b/web/app/components/doc/tile-medium.hbs
@@ -32,6 +32,7 @@
         <LinkTo
           data-test-document-link
           @route="authenticated.document"
+          @query={{hash draft=this.docIsDraft}}
           @model={{this.docID}}
         >
           {{! Primary click area }}

--- a/web/app/components/doc/tile-medium.ts
+++ b/web/app/components/doc/tile-medium.ts
@@ -37,6 +37,10 @@ export default class DocTileMediumComponent extends Component<DocTileMediumCompo
       return this.args.doc.docType;
     }
   }
+
+  protected get docIsDraft() {
+    return this.args.doc.status.toLowerCase() === "wip";
+  }
 }
 
 declare module "@glint/environment-ember-loose/registry" {

--- a/web/tests/integration/components/doc/tile-medium-test.ts
+++ b/web/tests/integration/components/doc/tile-medium-test.ts
@@ -88,4 +88,24 @@ module("Integration | Component | doc/tile-medium", function (hooks) {
 
     assertDocumentInfo(relatedHermesDocument);
   });
+
+  test("the doc link has the correct url depending on whether its a draft", async function (this: DocTileMediumComponentContext, assert) {
+    this.set("doc", this.server.schema.document.first().attrs);
+
+    await render<DocTileMediumComponentContext>(
+      hbs`<Doc::TileMedium @doc={{this.doc}} />`,
+    );
+
+    assert
+      .dom("[data-test-document-link]")
+      .hasAttribute("href", `/document/doc-0?draft=true`);
+
+    this.server.schema.document.first().update({ status: "In-Review" });
+
+    this.set("doc", this.server.schema.document.first().attrs);
+
+    assert
+      .dom("[data-test-document-link]")
+      .hasAttribute("href", `/document/doc-0`);
+  });
 });


### PR DESCRIPTION
Conditionally adds the `?draft=true` query parameter to Doc::TileMedium links.