### PR TITLE
Add flight icon to document types configuration

### DIFF
--- a/configs/config.hcl
+++ b/configs/config.hcl
@@ -30,6 +30,7 @@ document_types {
   document_type "RFC" {
     long_name   = "Request for Comments"
     description = "Create a Request for Comments document to present a proposal to colleagues for their review and feedback."
+    flight_icon = "discussion-circle"
     template    = "1Oz_7FhaWxdFUDEzKCC5Cy58t57C4znmC_Qr80BORy1U"
 
     more_info_link {
@@ -58,6 +59,7 @@ document_types {
   document_type "PRD" {
     long_name   = "Product Requirements"
     description = "Create a Product Requirements Document to summarize a problem statement and outline a phased approach to addressing the problem."
+    flight_icon = "target"
     template    = "1oS4q6IPDr3aMSTTk9UDdOnEcFwVWW9kT8ePCNqcg1P4"
 
     more_info_link {
@@ -78,6 +80,7 @@ document_types {
   // document_type "Memo" {
   //   long_name = "Memo"
   //   description = "Create a Memo document to share an idea or brief note with colleagues."
+  //   flight_icon = "radio"
   //   template = "file-id-for-a-blank-doc"
   // }
 }

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -495,6 +495,7 @@ func registerDocumentTypes(cfg config.Config, db *gorm.DB) error {
 			Name:         d.Name,
 			LongName:     d.LongName,
 			Description:  d.Description,
+			FlightIcon:   d.FlightIcon,
 			Checks:       checksJSON,
 			CustomFields: cfs,
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,6 +100,10 @@ type DocumentType struct {
 	//   colleagues for their review and feedback."
 	Description string `hcl:"description,optional" json:"description"`
 
+	// FlightIcon is the name of the Helios flight icon.
+	// From: https://helios.hashicorp.design/icons/library
+	FlightIcon string `hcl:"flight_icon,optional" json:"flightIcon"`
+
 	// Template is the Google file ID for the document template used for this
 	// document type.
 	Template string `hcl:"template"`

--- a/pkg/models/document_type.go
+++ b/pkg/models/document_type.go
@@ -26,6 +26,10 @@ type DocumentType struct {
 	// colleagues for their review and feedback."
 	Description string
 
+	// FlightIcon is the name of the Helios flight icon.
+	// From: https://helios.hashicorp.design/icons/library
+	FlightIcon string
+
 	// MoreInfoLinkText is the text for a "more info" link.
 	// Example: "When should I create an RFC?"
 	MoreInfoLinkText string


### PR DESCRIPTION
This PR enables a configurable [Helios flight icon](https://helios.hashicorp.design/icons/library) per document type. The `/document-types` API response now includes `flightIcon` per document type (if configured). This will essentially be a breaking change once the [hardcoded](https://github.com/hashicorp-forge/hermes/blob/2376bcafb486c2a1f309448372ca0d75c5c19b7a/web/app/helpers/get-doctype-icon.ts#L18-L25) icons are removed in the web app.

### New config option

```hcl
document_types {
  document_type "RFC" {
    ...
    flight_icon = "discussion-circle"
    ...
  }
}
```