### PR TITLE
Add document type to Google Doc header title

### DIFF
--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -522,7 +522,7 @@ func compareAlgoliaAndDatabaseDocument(
 			result = multierror.Append(result,
 				fmt.Errorf(
 					"summary not equal, algolia=%v, db=%v",
-					algoSummary, dbSummary),
+					algoSummary, *dbSummary),
 			)
 		}
 	}

--- a/internal/api/v2/helpers.go
+++ b/internal/api/v2/helpers.go
@@ -522,7 +522,7 @@ func CompareAlgoliaAndDatabaseDocument(
 			result = multierror.Append(result,
 				fmt.Errorf(
 					"summary not equal, algolia=%v, db=%v",
-					algoSummary, dbSummary),
+					algoSummary, *dbSummary),
 			)
 		}
 	}

--- a/pkg/document/replace_header.go
+++ b/pkg/document/replace_header.go
@@ -391,7 +391,7 @@ func (doc *Document) ReplaceHeader(
 
 	// Title cell.
 	pos = int(startIndex) + 3
-	titleText := fmt.Sprintf("[%s] %s", doc.DocNumber, doc.Title)
+	titleText := fmt.Sprintf("[%s] %s: %s", doc.DocType, doc.DocNumber, doc.Title)
 	reqs = append(reqs,
 		[]*docs.Request{
 			{


### PR DESCRIPTION
This PR adds the document type to the (Google Doc) header title so it now has the format of `[RFC] ABC-123: Title of my doc`. Without this, the document type isn't explicitly in the Google Doc so it can make things confusing.

This PR also fixes a small bug when checking equality of Algolia vs. database doc summary where we were logging the memory address of the database summary instead of the text (missed this when converting the summary to a pointer).
