### PR TITLE
Fix Related Resources search index

### DIFF
--- a/web/app/components/related-resources.ts
+++ b/web/app/components/related-resources.ts
@@ -178,7 +178,8 @@ export default class RelatedResourcesComponent extends Component<RelatedResource
       shouldIgnoreDelay?: boolean,
       options?: SearchOptions,
     ) => {
-      let index = this.configSvc.config.algolia_docs_index_name;
+      let index =
+        this.configSvc.config.algolia_docs_index_name + "_modifiedTime_desc";
 
       let filterString = "";
 

--- a/web/app/components/related-resources/add.hbs
+++ b/web/app/components/related-resources/add.hbs
@@ -64,7 +64,7 @@
                   {{#if this.query.length}}
                     Results
                   {{else}}
-                    Suggestions
+                    Latest docs
                   {{/if}}
                 </h4>
               </div>

--- a/web/tests/integration/components/related-resources/add-test.ts
+++ b/web/tests/integration/components/related-resources/add-test.ts
@@ -109,7 +109,7 @@ module("Integration | Component | related-resources/add", function (hooks) {
       `);
 
     assert.dom(MODAL_TITLE_SELECTOR).hasText("Test title");
-    assert.dom(LIST_HEADER_SELECTOR).hasText("Suggestions");
+    assert.dom(LIST_HEADER_SELECTOR).hasText("Latest docs");
     assert.dom(DOCUMENT_OPTION_SELECTOR).exists({ count: 4 });
     assert
       .dom(SEARCH_INPUT_SELECTOR)
@@ -133,7 +133,7 @@ module("Integration | Component | related-resources/add", function (hooks) {
         />
       `);
 
-    assert.dom(LIST_HEADER_SELECTOR).hasText("Suggestions");
+    assert.dom(LIST_HEADER_SELECTOR).hasText("Latest docs");
 
     // Create a search with results
     await fillIn(SEARCH_INPUT_SELECTOR, "3");


### PR DESCRIPTION
Sorts and renames Related Resource "suggestions" by recency. Currently we're always suggesting the same 4 docs which is not helpful.