### PR TITLE
Remove `product_colors` flag

### DIFF
--- a/web/app/components/doc/thumbnail.ts
+++ b/web/app/components/doc/thumbnail.ts
@@ -38,10 +38,6 @@ export default class DocThumbnailComponent extends Component<DocThumbnailCompone
       return true;
     }
 
-    if (!this.flags.productColors) {
-      return false;
-    }
-
     if (this.productAreas.getAbbreviation(this.args.product)) {
       return true;
     }

--- a/web/app/components/product/avatar.gts
+++ b/web/app/components/product/avatar.gts
@@ -42,7 +42,6 @@ export default class ProductAvatarComponent extends Component<ProductAvatarCompo
   }
 
   private get colorStyles() {
-    if (!this.flags.productColors) return;
     if (this.productID) return;
 
     const bgColor = this.productAreas.getProductColor(this.args.product);
@@ -72,7 +71,6 @@ export default class ProductAvatarComponent extends Component<ProductAvatarCompo
 
   private get iconIsShown() {
     if (this.productID) return true;
-    if (!this.flags.productColors) return true;
     if (this.abbreviation) return false;
     return true;
   }

--- a/web/app/components/project/tile.hbs
+++ b/web/app/components/project/tile.hbs
@@ -28,11 +28,7 @@
         <ul class="flex gap-px">
           {{#each @project.products as |product|}}
             <li class="flex items-center" data-test-product>
-              {{#if this.productColorsAreEnabled}}
-                <Product::Avatar @product={{product}} />
-              {{else}}
-                {{product}}
-              {{/if}}
+              <Product::Avatar @product={{product}} />
             </li>
           {{/each}}
         </ul>

--- a/web/app/components/project/tile.ts
+++ b/web/app/components/project/tile.ts
@@ -1,6 +1,4 @@
-import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
-import FlagsService from "hermes/services/flags";
 import { HermesProject } from "hermes/types/project";
 
 interface ProjectTileComponentSignature {
@@ -10,13 +8,7 @@ interface ProjectTileComponentSignature {
   };
 }
 
-export default class ProjectTileComponent extends Component<ProjectTileComponentSignature> {
-  @service declare flags: FlagsService;
-
-  protected get productColorsAreEnabled(): boolean {
-    return this.flags.productColors === true;
-  }
-}
+export default class ProjectTileComponent extends Component<ProjectTileComponentSignature> {}
 
 declare module "@glint/environment-ember-loose/registry" {
   export default interface Registry {

--- a/web/app/services/flags.ts
+++ b/web/app/services/flags.ts
@@ -7,8 +7,4 @@ export default class FlagsService extends Service {
   get projects() {
     return this.configSvc.config.feature_flags?.["projects"];
   }
-
-  get productColors() {
-    return this.configSvc.config.feature_flags?.["product_colors"];
-  }
 }

--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -422,7 +422,6 @@ export default function (mirageConfig) {
             algolia_internal_index_name: config.algolia.internalIndexName,
             feature_flags: {
               projects: true,
-              product_colors: true,
             },
             google_doc_folders: "",
             short_link_base_url: TEST_SHORT_LINK_BASE_URL,

--- a/web/tests/integration/components/doc/thumbnail-test.ts
+++ b/web/tests/integration/components/doc/thumbnail-test.ts
@@ -113,19 +113,6 @@ module("Integration | Component | doc/thumbnail", function (hooks) {
       .dom(PRODUCT_BADGE)
       .exists("badge is shown for a product with an icon");
 
-    setFeatureFlag(this, "product_colors", false);
-
-    // If product colors were enabled, this would render a badge
-    this.set("product", "Labs");
-
-    assert
-      .dom(PRODUCT_BADGE)
-      .doesNotExist(
-        "abbreviation not shown if the productColors flag is disabled",
-      );
-
-    setFeatureFlag(this, "product_colors", true);
-
     // Config is not tracked by glimmer, so we force
     // a re-compute on the "badgeIsShown" getter
     this.set("product", undefined);

--- a/web/tests/integration/components/product/avatar-test.ts
+++ b/web/tests/integration/components/product/avatar-test.ts
@@ -58,8 +58,6 @@ module("Integration | Component | product/avatar", function (hooks) {
 
     await setupProductIndex(this);
 
-    setFeatureFlag(this, "product_colors", true);
-
     await render<ProductAvatarTestContext>(hbs`
       <Product::Avatar @product="Labs" />
     `);
@@ -71,8 +69,6 @@ module("Integration | Component | product/avatar", function (hooks) {
   });
 
   test("it conditionally shows a product icon", async function (this: ProductAvatarTestContext, assert) {
-    setFeatureFlag(this, "product_colors", true);
-
     this.server.create("product", {
       name: "Vault",
     });
@@ -97,21 +93,6 @@ module("Integration | Component | product/avatar", function (hooks) {
     assert
       .dom(ICON)
       .doesNotExist("it does not render an icon for non-icon products");
-
-    setFeatureFlag(this, "product_colors", false);
-
-    // Config is not tracked by glimmer, so we force
-    // a re-compute on the "badgeIsShown" getter
-    this.set("product", undefined);
-    this.set("product", "Labs");
-
-    assert
-      .dom(ICON)
-      .hasAttribute(
-        "data-test-icon",
-        "folder",
-        "it renders a folder icon if productColors is disabled",
-      );
   });
 
   test("it conditionally renders a product abbreviation", async function (this: ProductAvatarTestContext, assert) {
@@ -127,8 +108,6 @@ module("Integration | Component | product/avatar", function (hooks) {
 
     await setupProductIndex(this);
 
-    setFeatureFlag(this, "product_colors", true);
-
     await render<ProductAvatarTestContext>(hbs`
       <Product::Avatar @product={{this.product}} />
     `);
@@ -142,15 +121,6 @@ module("Integration | Component | product/avatar", function (hooks) {
     this.set("product", "Labs");
 
     assert.dom(ABBREVIATION).exists();
-
-    setFeatureFlag(this, "product_colors", false);
-
-    // Config is not tracked by glimmer, so we force
-    // a re-compute on the "badgeIsShown" getter
-    this.set("product", undefined);
-    this.set("product", "Labs");
-
-    assert.dom(ABBREVIATION).doesNotExist();
   });
 
   test("it renders a fallback icon if the product has no ID nor abbreviation", async function (this: ProductAvatarTestContext, assert) {
@@ -192,8 +162,6 @@ module("Integration | Component | product/avatar", function (hooks) {
     this.set("product", "Labs");
 
     await setupProductIndex(this);
-
-    setFeatureFlag(this, "product_colors", true);
 
     await render<ProductAvatarTestContext>(hbs`
       <Product::Avatar @product={{this.product}} />

--- a/web/tests/integration/components/project/tile-test.ts
+++ b/web/tests/integration/components/project/tile-test.ts
@@ -117,17 +117,6 @@ module("Integration | Component | project/tile", function (hooks) {
     assert.dom(PRODUCT_AVATAR).exists({ count: 2 });
   });
 
-  test("it renders products in text if the productColors flag is disabled", async function (this: ProjectTileComponentTestContext, assert) {
-    setFeatureFlag(this, "product_colors", false);
-
-    await render<ProjectTileComponentTestContext>(hbs`
-      <Project::Tile @project={{this.project}} />
-    `);
-
-    assert.dom(PRODUCT).exists({ count: 1 });
-    assert.dom(PRODUCT_AVATAR).doesNotExist();
-  });
-
   test('if the status of a jiraIssue is "Done," the key is rendered with a line through it', async function (this: ProjectTileComponentTestContext, assert) {
     await render<ProjectTileComponentTestContext>(hbs`
       <Project::Tile @project={{this.project}} />


### PR DESCRIPTION
Removes the `product_colors` flag that was conditionally [hiding] color ProductAvatars. 