### PR TITLE
Add projects filtering

### DIFF
--- a/internal/api/v2/projects.go
+++ b/internal/api/v2/projects.go
@@ -107,7 +107,7 @@ func ProjectsHandler(srv server.Server) http.Handler {
 					JiraIssueID:  p.JiraIssueID,
 					ModifiedTime: p.ProjectModifiedAt.Unix(),
 					Products:     products,
-					Status:       p.Status.ToString(),
+					Status:       p.Status.String(),
 					Title:        p.Title,
 				})
 			}
@@ -305,7 +305,7 @@ func ProjectHandler(srv server.Server) http.Handler {
 						JiraIssueID:  proj.JiraIssueID,
 						ModifiedTime: proj.ProjectModifiedAt.Unix(),
 						Products:     products,
-						Status:       proj.Status.ToString(),
+						Status:       proj.Status.String(),
 						Title:        proj.Title,
 					},
 				}
@@ -516,7 +516,7 @@ func saveProjectInAlgolia(
 		"jiraIssueID":  proj.JiraIssueID,
 		"modifiedTime": proj.ProjectModifiedAt.Unix(),
 		"objectID":     fmt.Sprintf("%d", proj.ID),
-		"status":       proj.Status.ToString(),
+		"status":       proj.Status.String(),
 		"title":        proj.Title,
 	}
 

--- a/internal/api/v2/projects.go
+++ b/internal/api/v2/projects.go
@@ -73,6 +73,7 @@ func ProjectsHandler(srv server.Server) http.Handler {
 			// Get query parameters.
 			q := r.URL.Query()
 			statusParam := q.Get("status")
+			titleParam := q.Get("title")
 
 			// Build status condition for database query.
 			var cond models.Project
@@ -89,9 +90,12 @@ func ProjectsHandler(srv server.Server) http.Handler {
 				}
 			}
 
-			// Get all projects from database.
+			// Get projects from database.
 			projs := []models.Project{}
-			if err := srv.DB.Find(&projs, cond).Error; err != nil &&
+			if err := srv.DB.
+				Where("title ILIKE ?", fmt.Sprintf("%%%s%%", titleParam)).
+				Find(&projs, cond).
+				Error; err != nil &&
 				!errors.Is(err, gorm.ErrRecordNotFound) {
 				srv.Logger.Error("error getting projects",
 					append([]interface{}{

--- a/pkg/models/project.go
+++ b/pkg/models/project.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
@@ -49,17 +50,27 @@ const (
 	ArchivedProjectStatus
 )
 
-func (s *ProjectStatus) ToString() string {
-	switch *s {
-	case ActiveProjectStatus:
-		return "active"
-	case CompletedProjectStatus:
-		return "completed"
-	case ArchivedProjectStatus:
-		return "archived"
+var (
+	projectStatusStrings = map[ProjectStatus]string{
+		ActiveProjectStatus:    "active",
+		CompletedProjectStatus: "completed",
+		ArchivedProjectStatus:  "archived",
+	}
+)
+
+func (s ProjectStatus) String() string {
+	return projectStatusStrings[s]
+}
+
+func ParseProjectStatusString(s string) (ProjectStatus, bool) {
+	// Reverse keys and values of strings map.
+	m := make(map[string]ProjectStatus, len(projectStatusStrings))
+	for k, v := range projectStatusStrings {
+		m[v] = k
 	}
 
-	return ""
+	v, ok := m[strings.ToLower(s)]
+	return v, ok
 }
 
 // Create creates a new project. The resulting project is saved back to the


### PR DESCRIPTION
This PR adds new `status` and `title` query parameters to the `/projects` API to filter results based on project status (exact match to status string) and/or title (does a `*title*` case-insensitive wildcard search). It also does a little cleanup to make the conversions between project statuses and their associated strings a bit nicer and more idiomatic.