### PR TITLE
Add `updateRelatedResourcesSortOrder` utility

### DIFF
--- a/web/app/components/document/sidebar/related-resources.ts
+++ b/web/app/components/document/sidebar/related-resources.ts
@@ -19,6 +19,7 @@ import {
 import { assert } from "@ember/debug";
 import HermesFlashMessagesService from "hermes/services/flash-messages";
 import { FLASH_MESSAGES_LONG_TIMEOUT } from "hermes/utils/ember-cli-flash/timeouts";
+import updateRelatedResourcesSortOrder from "hermes/utils/update-related-resources-sort-order";
 
 export interface DocumentSidebarRelatedResourcesComponentArgs {
   productArea?: string;
@@ -122,13 +123,7 @@ export default class DocumentSidebarRelatedResourcesComponent extends Component<
    * Called when the resource list is saved.
    */
   @action private updateSortOrder() {
-    this.relatedDocuments.forEach((doc, index) => {
-      doc.sortOrder = index + 1;
-    });
-
-    this.relatedLinks.forEach((link, index) => {
-      link.sortOrder = index + 1 + this.relatedDocuments.length;
-    });
+    updateRelatedResourcesSortOrder(this.relatedDocuments, this.relatedLinks);
   }
 
   /**

--- a/web/app/components/project/index.ts
+++ b/web/app/components/project/index.ts
@@ -19,6 +19,7 @@ import { assert } from "@ember/debug";
 import ConfigService from "hermes/services/config";
 import HermesFlashMessagesService from "hermes/services/flash-messages";
 import { FLASH_MESSAGES_LONG_TIMEOUT } from "hermes/utils/ember-cli-flash/timeouts";
+import updateRelatedResourcesSortOrder from "hermes/utils/update-related-resources-sort-order";
 
 interface ProjectIndexComponentSignature {
   Args: {
@@ -99,7 +100,7 @@ export default class ProjectIndexComponent extends Component<ProjectIndexCompone
     hermesDocuments: Partial<RelatedHermesDocument>[];
     externalLinks: Partial<RelatedExternalLink>[];
   } {
-    this.updateSortOrder();
+    updateRelatedResourcesSortOrder(this.hermesDocuments, this.externalLinks);
 
     const hermesDocuments = this.hermesDocuments.map((doc) => {
       return {
@@ -120,21 +121,6 @@ export default class ProjectIndexComponent extends Component<ProjectIndexCompone
       externalLinks,
       hermesDocuments,
     };
-  }
-
-  /**
-   * The action to update the `sortOrder` attribute of
-   * the resources, based on their position in the array.
-   * Called when the resource list is saved.
-   */
-  private updateSortOrder() {
-    this.hermesDocuments.forEach((doc, index) => {
-      doc.sortOrder = index + 1;
-    });
-
-    this.externalLinks.forEach((link, index) => {
-      link.sortOrder = index + 1 + this.hermesDocuments.length;
-    });
   }
 
   /**

--- a/web/app/utils/update-related-resources-sort-order.ts
+++ b/web/app/utils/update-related-resources-sort-order.ts
@@ -1,0 +1,17 @@
+import {
+  RelatedExternalLink,
+  RelatedHermesDocument,
+} from "hermes/components/related-resources";
+
+export default function updateRelatedResourcesSortOrder(
+  hermesDocuments: RelatedHermesDocument[],
+  externalLinks: RelatedExternalLink[],
+) {
+  hermesDocuments.forEach((doc, index) => {
+    doc.sortOrder = index + 1;
+  });
+
+  externalLinks.forEach((link, index) => {
+    link.sortOrder = index + 1 + hermesDocuments.length;
+  });
+}

--- a/web/mirage/factories/related-external-link.ts
+++ b/web/mirage/factories/related-external-link.ts
@@ -1,11 +1,7 @@
 import { Factory } from "miragejs";
 
-// TODO: Improve how this generates IDs.
-// We should be able to use the `i` argument to generate IDs,
-// but that doesn't work when using `createList` in tests.
-
 export default Factory.extend({
-  id: 0,
+  id: (i) => i,
   sortOrder: (i) => i,
   name() {
     return `Related External Link ${this.id}`;

--- a/web/tests/unit/utils/update-related-resources-sort-order-test.ts
+++ b/web/tests/unit/utils/update-related-resources-sort-order-test.ts
@@ -1,0 +1,40 @@
+import { module, test } from "qunit";
+import updateRelatedResourcesSortOrder from "hermes/utils/update-related-resources-sort-order";
+import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
+import { setupTest } from "ember-qunit";
+
+module(
+  "Unit | Utility | update-related-resources-sort-order",
+  function (this: MirageTestContext, hooks) {
+    setupTest(hooks);
+    setupMirage(hooks);
+
+    test("it updates the relative sortOrder of related resources", function (this: MirageTestContext, assert) {
+      this.server.create("related-hermes-document", { sortOrder: 20 });
+      this.server.create("related-hermes-document", { sortOrder: 10 });
+      this.server.create("related-external-link", { sortOrder: 40 });
+      this.server.create("related-external-link", { sortOrder: 30 });
+
+      const hermesDocuments =
+        this.server.schema.relatedHermesDocument.all().models;
+
+      const externalLinks =
+        this.server.schema.relatedExternalLinks.all().models;
+
+      assert.equal(hermesDocuments[0].sortOrder, 20);
+      assert.equal(hermesDocuments[1].sortOrder, 10);
+      assert.equal(externalLinks[0].sortOrder, 40);
+      assert.equal(externalLinks[1].sortOrder, 30);
+
+      updateRelatedResourcesSortOrder(hermesDocuments, externalLinks);
+
+      console.log("hermesDocuments", hermesDocuments);
+      console.log("externalLinks", externalLinks);
+
+      assert.equal(hermesDocuments[0].sortOrder, 1);
+      assert.equal(hermesDocuments[1].sortOrder, 2);
+      assert.equal(externalLinks[0].sortOrder, 3);
+      assert.equal(externalLinks[1].sortOrder, 4);
+    });
+  },
+);


### PR DESCRIPTION
Adds a utility to share related-resource-sorting code between Documents and Projects.