### PR TITLE
Add `waitUntilNextRunloop` to `autofocus`

### DIFF
--- a/web/app/components/related-resources/add.hbs
+++ b/web/app/components/related-resources/add.hbs
@@ -32,6 +32,7 @@
             <div class="relative">
               <Hds::Form::TextInput::Base
                 data-test-related-resources-search-input
+                {{autofocus waitUntilNextRunloop=true}}
                 {{did-insert (fn this.didInsertInput dd)}}
                 {{on "input" this.onInput}}
                 {{on "keydown" this.onInputKeydown}}

--- a/web/app/components/related-resources/add.ts
+++ b/web/app/components/related-resources/add.ts
@@ -398,9 +398,7 @@ export default class RelatedResourcesAddComponent extends Component<RelatedResou
   }
 
   /**
-   * The action run when the search input is inserted.
-   * Saves the input locally, loads initial data, then
-   * focuses the search input.
+   * Saves the input locally and loads initial data.
    */
   @action protected didInsertInput(
     dd: XDropdownListAnchorAPI,
@@ -410,11 +408,6 @@ export default class RelatedResourcesAddComponent extends Component<RelatedResou
     this._dd = dd;
     this.dd.registerAnchor(this.searchInput);
     void this.loadInitialData.perform();
-
-    next(() => {
-      assert("searchInput expected", this.searchInput);
-      this.searchInput.focus();
-    });
   }
 
   /**

--- a/web/app/modifiers/autofocus.ts
+++ b/web/app/modifiers/autofocus.ts
@@ -1,5 +1,6 @@
 import { assert } from "@ember/debug";
 import { action } from "@ember/object";
+import { next } from "@ember/runloop";
 import { tracked } from "@glimmer/tracking";
 import Modifier from "ember-modifier";
 import { FOCUSABLE } from "hermes/components/editable-field";
@@ -10,6 +11,7 @@ interface AutofocusModifierSignature {
     Positional: [];
     Named: {
       targetChildren?: boolean;
+      waitUntilNextRunloop?: boolean;
     };
   };
 }
@@ -39,12 +41,16 @@ export default class AutofocusModifier extends Modifier<AutofocusModifierSignatu
   modify(
     element: Element,
     _positional: [],
-    named: AutofocusModifierSignature["Args"]["Named"]
+    named: AutofocusModifierSignature["Args"]["Named"],
   ) {
     this._element = element;
     this.targetChildren = named.targetChildren ?? false;
 
-    this.maybeAutofocus();
+    if (named.waitUntilNextRunloop) {
+      next(this, this.maybeAutofocus);
+    } else {
+      this.maybeAutofocus();
+    }
   }
 }
 


### PR DESCRIPTION
Adds wait-until-the-next-runloop functionality to the `autofocus` modifier. Implements it on the `related-resources/add` component.