### PR TITLE
Calculate if document is a draft when refreshing header

### DIFF
--- a/internal/indexer/refresh_headers.go
+++ b/internal/indexer/refresh_headers.go
@@ -210,9 +210,16 @@ func refreshDocumentHeader(
 		os.Exit(1)
 	}
 
+	// If the document was created through Hermes and has a status of "WIP", it
+	// is a document draft.
+	isDraft := false
+	if doc.AppCreated && doc.Status == "WIP" {
+		isDraft = true
+	}
+
 	// Replace document header.
 	if err := doc.ReplaceHeader(
-		idx.BaseURL, true, idx.GoogleWorkspaceService); err != nil {
+		idx.BaseURL, isDraft, idx.GoogleWorkspaceService); err != nil {
 		log.Error("error replacing document header",
 			"error", err,
 			"google_file_id", file.Id,


### PR DESCRIPTION
This PR fixes a bug where refreshing the header when indexing a doc would always add a `isDraft=true` query parameter in the Hermes document link URL.