### PR TITLE
Add GET documents API

### DIFF
--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -341,6 +341,7 @@ func (c *Command) Run(args []string) int {
 		{"/api/v1/approvals/",
 			api.ApprovalHandler(cfg, c.Log, algoSearch, algoWrite, goog, db)},
 		{"/api/v1/document-types", api.DocumentTypesHandler(*cfg, c.Log)},
+		{"/api/v1/documents", apiv2.DocumentsHandler(srv)},
 		{"/api/v1/documents/",
 			api.DocumentHandler(cfg, c.Log, algoSearch, algoWrite, goog, db)},
 		{"/api/v1/drafts",
@@ -365,6 +366,7 @@ func (c *Command) Run(args []string) int {
 		// API v2.
 		{"/api/v2/approvals/", apiv2.ApprovalsHandler(srv)},
 		{"/api/v2/document-types", apiv2.DocumentTypesHandler(srv)},
+		{"/api/v2/documents", apiv2.DocumentsHandler(srv)},
 		{"/api/v2/documents/", apiv2.DocumentHandler(srv)},
 		{"/api/v2/drafts", apiv2.DraftsHandler(srv)},
 		{"/api/v2/drafts/", apiv2.DraftsDocumentHandler(srv)},


### PR DESCRIPTION
This PR adds a GET `/documents` API that behaves similarly to GET `/drafts` - it uses Algolia for results and accepts Algolia query parameters: `facetFilters`, `facets`, `hitsPerPage`, `maxValuesPerFacet` and `page`.

This API fetches owner photos from Google in parallel to add to the API response. The PR is currently in draft to explore its performance and we can look into caching if the UX isn't acceptable.