### PR TITLE
Add FormsService

### DIFF
--- a/web/app/components/new/project-form.hbs
+++ b/web/app/components/new/project-form.hbs
@@ -1,6 +1,6 @@
 <New::Form
   data-test-project-form
-  @taskIsRunning={{this.projectIsBeingCreated}}
+  @taskIsRunning={{this.forms.projectIsBeingCreated}}
   @icon="grid"
   @headline="Start a project"
   @taskIsRunningHeadline="Creating project..."

--- a/web/app/services/forms.ts
+++ b/web/app/services/forms.ts
@@ -1,0 +1,18 @@
+import Service from "@ember/service";
+import { tracked } from "@glimmer/tracking";
+
+export default class FormsService extends Service {
+  /**
+   * Whether the project is being created, or in the process of
+   * transitioning to the project screen after successful creation.
+   * Set by the `ProjectForm` and used to show loading states.
+   * Reverted on error or when the project route is reached.
+   */
+  @tracked projectIsBeingCreated = false;
+}
+
+declare module "@ember/service" {
+  interface Registry {
+    forms: FormsService;
+  }
+}

--- a/web/tests/unit/services/forms-test.ts
+++ b/web/tests/unit/services/forms-test.ts
@@ -1,0 +1,15 @@
+import { module, test } from "qunit";
+import { setupTest } from "ember-qunit";
+import FormsService from "hermes/services/forms";
+
+module("Unit | Service | forms", function (hooks) {
+  setupTest(hooks);
+
+  test("the projectIsBeingCreated attribute works as expected", async function (assert) {
+    const service = this.owner.lookup("service:forms") as FormsService;
+    assert.equal(service.projectIsBeingCreated, false);
+
+    service.projectIsBeingCreated = true;
+    assert.equal(service.projectIsBeingCreated, true);
+  });
+});


### PR DESCRIPTION
Moves the `projectIsBeingCreated` property, which triggers the "Creating..." state, from the `ProjectForm` component into a new `FormsService`. This will allow external components, e.g., Modal, to access properties they otherwise wouldn't have:

```
<M.Body class={{if this.forms.projectIsBeingCreated 'some-class'}}>
  {{! the form }}
</M.Body>
```

In prep for projects-in-the-document-sidebar (#414)