### PR TITLE
Get doc again after inserting header table

### DIFF
--- a/pkg/document/replace_header.go
+++ b/pkg/document/replace_header.go
@@ -124,6 +124,12 @@ func (doc *Document) ReplaceHeader(
 		return fmt.Errorf("error inserting header table: %w", err)
 	}
 
+	// Get doc again after inserting the header table.
+	d, err = s.GetDoc(doc.ObjectID)
+	if err != nil {
+		return fmt.Errorf("error getting doc after inserting header table: %w", err)
+	}
+
 	// Find new table index.
 	elems = d.Body.Content
 	for _, e := range elems {


### PR DESCRIPTION
Docs can get in a bad state if someone adds text above the document header and Hermes attempts to add a new header table. We weren't re-getting the doc to find the new header table location and this PR fixes that.