### PR TITLE
Enable creating documents as logged-in user

### DIFF
--- a/configs/config.hcl
+++ b/configs/config.hcl
@@ -131,10 +131,11 @@ google_workspace {
   // auth is the configuration for interacting with Google Workspace using a
   // service account.
   // auth {
-  //   client_email = ""
-  //   private_key  = ""
-  //   subject      = ""
-  //   token_url    = "https://oauth2.googleapis.com/token"
+  //   client_email        = ""
+  //   create_docs_as_user = true
+  //   private_key         = ""
+  //   subject             = ""
+  //   token_url           = "https://oauth2.googleapis.com/token"
   // }
 
   // oauth2 is the configuration used to authenticate users via Google.

--- a/pkg/googleworkspace/service.go
+++ b/pkg/googleworkspace/service.go
@@ -40,6 +40,9 @@ type Config struct {
 	PrivateKey  string `hcl:"private_key,optional"`
 	Subject     string `hcl:"subject,optional"`
 	TokenURL    string `hcl:"token_url,optional"`
+
+	// CreateDocsAsUser creates Google Docs as the logged-in Hermes user, if true.
+	CreateDocsAsUser bool `hcl:"create_docs_as_user,optional"`
 }
 
 // New returns a service with the required Google Workspace access for

--- a/web/web.go
+++ b/web/web.go
@@ -58,6 +58,7 @@ type ConfigResponse struct {
 	AlgoliaDocsIndexName     string          `json:"algolia_docs_index_name"`
 	AlgoliaDraftsIndexName   string          `json:"algolia_drafts_index_name"`
 	AlgoliaInternalIndexName string          `json:"algolia_internal_index_name"`
+	CreateDocsAsUser         bool            `json:"create_docs_as_user"`
 	FeatureFlags             map[string]bool `json:"feature_flags"`
 	GoogleAnalyticsTagID     string          `json:"google_analytics_tag_id"`
 	GoogleOAuth2ClientID     string          `json:"google_oauth2_client_id"`
@@ -111,6 +112,13 @@ func ConfigHandler(
 			skipGoogleAuth = true
 		}
 
+		// Set CreateDocsAsUser if enabled in the config.
+		createDocsAsUser := false
+		if cfg.GoogleWorkspace.Auth != nil &&
+			cfg.GoogleWorkspace.Auth.CreateDocsAsUser {
+			createDocsAsUser = true
+		}
+
 		// Set JiraURL if enabled in the config.
 		jiraURL := ""
 		if cfg.Jira != nil && cfg.Jira.Enabled {
@@ -121,6 +129,7 @@ func ConfigHandler(
 			AlgoliaDocsIndexName:     cfg.Algolia.DocsIndexName,
 			AlgoliaDraftsIndexName:   cfg.Algolia.DraftsIndexName,
 			AlgoliaInternalIndexName: cfg.Algolia.InternalIndexName,
+			CreateDocsAsUser:         createDocsAsUser,
 			FeatureFlags:             featureFlags,
 			GoogleAnalyticsTagID:     cfg.GoogleAnalyticsTagID,
 			GoogleOAuth2ClientID:     cfg.GoogleWorkspace.OAuth2.ClientID,


### PR DESCRIPTION
This PR enables creating documents on behalf of logged-in Hermes users when running Hermes as a service account with domain-wide authority.

### New config attribute

```hcl
google_workspace {
  ...
  auth {
    ...
    create_docs_as_user = true
    ...
  }
  ...
}
```