### PR TITLE
Enable using PostgreSQL as source of truth for indexer document data

### DIFF
--- a/configs/config.hcl
+++ b/configs/config.hcl
@@ -158,6 +158,10 @@ indexer {
   // update_draft_headers enables the indexer to automatically update document
   // headers for draft documents based on Hermes metadata.
   update_draft_headers = true
+
+  // use_database_for_document_data will use the database instead of Algolia as
+  // the source of truth for document data, if true.
+  use_database_for_document_data = false
 }
 
 // jira is the configuration for Hermes to work with Jira.

--- a/internal/cmd/commands/indexer/indexer.go
+++ b/internal/cmd/commands/indexer/indexer.go
@@ -162,6 +162,10 @@ func (c *Command) Run(args []string) int {
 		idxOpts = append(idxOpts,
 			indexer.WithUpdateDraftHeaders(true))
 	}
+	if cfg.Indexer.UseDatabaseForDocumentData {
+		idxOpts = append(idxOpts,
+			indexer.WithUseDatabaseForDocumentData(true))
+	}
 	idx, err := indexer.NewIndexer(idxOpts...)
 	if err != nil {
 		ui.Error(fmt.Sprintf("error creating indexer: %v", err))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -195,6 +195,10 @@ type Indexer struct {
 	// UpdateDraftHeaders enables the indexer to automatically update document
 	// headers for draft documents with Hermes document metadata.
 	UpdateDraftHeaders bool `hcl:"update_draft_headers,optional"`
+
+	// UseDatabaseForDocumentData will use the database instead of Algolia as the
+	// source of truth for document data, if true.
+	UseDatabaseForDocumentData bool `hcl:"use_database_for_document_data,optional"`
 }
 
 // GoogleWorkspace is the configuration to work with Google Workspace.

--- a/internal/indexer/refresh_headers.go
+++ b/internal/indexer/refresh_headers.go
@@ -173,41 +173,81 @@ func refreshDocumentHeader(
 		return
 	}
 
-	// Get document object from Algolia.
-	var algoObj map[string]any
-	switch ft {
-	case draftsFolderType:
-		if err = algo.Drafts.GetObject(file.Id, &algoObj); err != nil {
-			log.Error("error getting draft document object from Algolia",
+	var doc *document.Document
+	if idx.UseDatabaseForDocumentData {
+		// Get document from database.
+		model := models.Document{
+			GoogleFileID: file.Id,
+		}
+		if err := model.Get(idx.Database); err != nil {
+			log.Error("error getting document from database",
 				"error", err,
 				"google_file_id", file.Id,
 			)
 			os.Exit(1)
 		}
-	case documentsFolderType:
-		if err = algo.Docs.GetObject(file.Id, &algoObj); err != nil {
-			log.Error("error getting document object from Algolia",
-				"error", err,
-				"google_file_id", file.Id,
-			)
-			os.Exit(1)
-		}
-	default:
-		log.Error("bad folder type",
-			"folder_type", ft,
-		)
-		os.Exit(1)
-	}
 
-	// Convert Algolia object to a document.
-	doc, err := document.NewFromAlgoliaObject(
-		algoObj, idx.DocumentTypes)
-	if err != nil {
-		log.Error("error converting Algolia object to document",
-			"error", err,
-			"google_file_id", file.Id,
-		)
-		os.Exit(1)
+		// Get reviews for the document from the database.
+		var reviews models.DocumentReviews
+		if err := reviews.Find(idx.Database, models.DocumentReview{
+			Document: models.Document{
+				GoogleFileID: file.Id,
+			},
+		}); err != nil {
+			log.Error("error getting reviews for document",
+				"error", err,
+				"google_file_id", file.Id,
+			)
+			os.Exit(1)
+		}
+
+		// Convert database record to a document.
+		doc, err = document.NewFromDatabaseModel(
+			model, reviews)
+		if err != nil {
+			log.Error("error converting database record to document",
+				"error", err,
+				"google_file_id", file.Id,
+			)
+			os.Exit(1)
+		}
+	} else {
+		// Get document object from Algolia.
+		var algoObj map[string]any
+		switch ft {
+		case draftsFolderType:
+			if err = algo.Drafts.GetObject(file.Id, &algoObj); err != nil {
+				log.Error("error getting draft document object from Algolia",
+					"error", err,
+					"google_file_id", file.Id,
+				)
+				os.Exit(1)
+			}
+		case documentsFolderType:
+			if err = algo.Docs.GetObject(file.Id, &algoObj); err != nil {
+				log.Error("error getting document object from Algolia",
+					"error", err,
+					"google_file_id", file.Id,
+				)
+				os.Exit(1)
+			}
+		default:
+			log.Error("bad folder type",
+				"folder_type", ft,
+			)
+			os.Exit(1)
+		}
+
+		// Convert Algolia object to a document.
+		doc, err = document.NewFromAlgoliaObject(
+			algoObj, idx.DocumentTypes)
+		if err != nil {
+			log.Error("error converting Algolia object to document",
+				"error", err,
+				"google_file_id", file.Id,
+			)
+			os.Exit(1)
+		}
 	}
 
 	// If the document was created through Hermes and has a status of "WIP", it


### PR DESCRIPTION
The indexer was still using Algolia as the source of truth for document data, which isn't ideal for v2 of the Hermes API — effectively, this could result in race conditions where depending on when the indexer indexes a document vs. when changes like approving a document make it to Algolia in v2 of the API. This PR improves this by enabling the indexer to use PostgreSQL as the source of truth for document data.

### New config attribute

```hcl
indexer {
  ...
  use_database_for_document_data = true
  ...
}
```