### PR TITLE
Remove redundant loading spinner

### DIFF
--- a/web/app/components/related-resources/add.hbs
+++ b/web/app/components/related-resources/add.hbs
@@ -49,7 +49,7 @@
                   aria-expanded={{dd.contentIsShown}}
                   aria-haspopup="listbox"
                 />
-                {{#if @searchIsRunning}}
+                {{#if this.searchLoaderIsShown}}
                   <div
                     data-test-related-resources-search-loading-icon
                     class="absolute top-1/2 right-3 flex -translate-y-1/2 bg-white"
@@ -84,11 +84,12 @@
             {{/if}}
           </:header>
           <:loading>
-            <FlightIcon
-              data-test-add-related-resource-spinner
-              @name="loading"
-              class="ml-2 mt-4"
-            />
+            <div class="pl-6 pt-4">
+              <FlightIcon
+                data-test-add-related-resource-spinner
+                @name="loading"
+              />
+            </div>
           </:loading>
           <:no-matches>
             {{#unless this.noResultsMessageIsHidden}}

--- a/web/app/components/related-resources/add.ts
+++ b/web/app/components/related-resources/add.ts
@@ -287,6 +287,10 @@ export default class RelatedResourcesAddComponent extends Component<RelatedResou
     }
   }
 
+  protected get searchLoaderIsShown() {
+    return this.args.searchIsRunning && !this.loadInitialData.isRunning;
+  }
+
   /**
    * The action to disable keyboard navigation.
    * Called when the search input loses focus.


### PR DESCRIPTION
Removes a redundant loading spinner from the "Add related resources" modal and fixes its placement after #506 moved it.