### PR TITLE
Fix patching a draft's product

### DIFF
--- a/internal/api/drafts.go
+++ b/internal/api/drafts.go
@@ -1132,6 +1132,10 @@ func DraftsDocumentHandler(
 				doc.Product = *req.Product
 				model.Product = models.Product{Name: *req.Product}
 
+				// Remove product ID so it gets updated during upsert (or else it will
+				// override the product name).
+				model.ProductID = 0
+
 				// Update doc number in document.
 				doc.DocNumber = fmt.Sprintf("%s-???", productAbbreviation)
 			}

--- a/internal/api/v2/drafts.go
+++ b/internal/api/v2/drafts.go
@@ -1272,6 +1272,10 @@ func DraftsDocumentHandler(srv server.Server) http.Handler {
 				doc.Product = *req.Product
 				model.Product = models.Product{Name: *req.Product}
 
+				// Remove product ID so it gets updated during upsert (or else it will
+				// override the product name).
+				model.ProductID = 0
+
 				// Update doc number in document.
 				doc.DocNumber = fmt.Sprintf("%s-???", productAbbreviation)
 			}
@@ -1301,7 +1305,6 @@ func DraftsDocumentHandler(srv server.Server) http.Handler {
 					http.StatusInternalServerError)
 				return
 			}
-			// }
 
 			// Replace the doc header.
 			if err := doc.ReplaceHeader(

--- a/pkg/models/document_test.go
+++ b/pkg/models/document_test.go
@@ -751,6 +751,20 @@ func TestDocumentModel(t *testing.T) {
 			assert.Equal("P2", d.Product.Abbreviation)
 			assert.EqualValues(2, d.Product.ID)
 		})
+
+		t.Run("Get the document", func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			d := Document{
+				GoogleFileID: "fileID1",
+			}
+			err := d.Get(db)
+			require.NoError(err)
+			assert.EqualValues(1, d.ID)
+			assert.Equal("fileID1", d.GoogleFileID)
+			assert.Equal("Product2", d.Product.Name)
+			assert.Equal("P2", d.Product.Abbreviation)
+			assert.EqualValues(2, d.Product.ID)
+		})
 	})
 
 	t.Run("Upsert a document with custom fields", func(t *testing.T) {


### PR DESCRIPTION
Patching a draft document's product would only be reflected in Algolia and not the database because the document's ProductID was overriding the new product's name during the upsert. This PR fixes the bug.