### PR TITLE
Remove unnecessary gradient from Project tiles

### DIFF
--- a/web/app/components/doc/tile-medium.hbs
+++ b/web/app/components/doc/tile-medium.hbs
@@ -8,7 +8,7 @@
 
 }}
 <div class="tile">
-  <div class="flex justify-between gap-[18px] pl-3 pr-8 pt-5 pb-6">
+  <div class="flex justify-between gap-[18px] pl-3 pr-9 pt-5 pb-6">
     {{! Avatar }}
     <LinkTo
       data-test-document-owner-avatar

--- a/web/app/styles/components/project.scss
+++ b/web/app/styles/components/project.scss
@@ -78,7 +78,7 @@
 
     .overflow-button-container {
       @apply absolute right-1 top-1 z-10 h-[calc(100%-16px)] items-start;
-      @apply from-color-page-faint;
+      @apply bg-none;
     }
   }
 }


### PR DESCRIPTION
Removes an unnecessary gradient that appeared on ProjectTile hover. Plus a padding tweak.