### PR TITLE
Set `isReadOnly` conditions on project title and description

### DIFF
--- a/web/app/components/project/index.hbs
+++ b/web/app/components/project/index.hbs
@@ -92,6 +92,7 @@
         @value="{{this.description}}"
         @onSave={{this.saveDescription}}
         @isReadOnly={{not this.projectIsActive}}
+        @isSaving={{this.descriptionIsSaving}}
         @placeholder="Add a description"
       />
     </div>

--- a/web/app/components/project/index.hbs
+++ b/web/app/components/project/index.hbs
@@ -78,20 +78,23 @@
       @tag="h1"
       @placeholder="Add project title"
       @onSave={{this.saveTitle}}
+      @isReadOnly={{not this.projectIsActive}}
       @isRequired={{true}}
     />
   </div>
-
-  {{! Description }}
-  <div class="flex">
-    <EditableField
-      class="project-description"
-      data-test-project-description
-      @value="{{this.description}}"
-      @onSave={{this.saveDescription}}
-      @placeholder="Add a description"
-    />
-  </div>
+  {{#if (or this.projectIsActive this.description)}}
+    {{! Description }}
+    <div class="flex">
+      <EditableField
+        class="project-description"
+        data-test-project-description
+        @value="{{this.description}}"
+        @onSave={{this.saveDescription}}
+        @isReadOnly={{not this.projectIsActive}}
+        @placeholder="Add a description"
+      />
+    </div>
+  {{/if}}
 </div>
 
 {{#if this.jiraIsEnabled}}

--- a/web/app/components/project/index.ts
+++ b/web/app/components/project/index.ts
@@ -95,6 +95,14 @@ export default class ProjectIndexComponent extends Component<ProjectIndexCompone
   }
 
   /**
+   * Whether the project is in the "active" state.
+   * Determines if project metadata is editable.
+   */
+  protected get projectIsActive() {
+    return this.status === ProjectStatus.Active;
+  }
+
+  /**
    * The related resources object, minimally formatted for a PUT request to the API.
    */
   private get formattedRelatedResources(): {


### PR DESCRIPTION
Follow-up to #519 

Makes project title and description read-only when a project is inactive. Hides empty descriptions in read-only view.

I'll do read-only states for the other elements separately.