### PR TITLE
Tweak project EditableField affordances

### DIFF
--- a/web/app/components/editable-field.hbs
+++ b/web/app/components/editable-field.hbs
@@ -47,7 +47,7 @@
       <div class="edit-overlay-affordance">
         <Hds::Button
           data-test-save-button
-          @size="small"
+          @size={{or @buttonSize "small"}}
           @text="Save"
           @icon="check"
           @isIconOnly={{true}}
@@ -58,7 +58,7 @@
           @text="Cancel"
           @icon="x"
           @isIconOnly={{true}}
-          @size="small"
+          @size={{or @buttonSize "small"}}
           @color="secondary"
           {{did-insert this.registerCancelButton}}
           {{on "click" this.disableAndRevertChanges}}

--- a/web/app/components/editable-field.ts
+++ b/web/app/components/editable-field.ts
@@ -21,6 +21,7 @@ interface EditableFieldComponentSignature {
     isRequired?: boolean;
     name?: string;
     placeholder?: string;
+    buttonSize?: "medium"; // Default is `small`
     tag?: "h1"; // Default is `p`
     document?: HermesDocument; // Used to check an approver's approval status
   };

--- a/web/app/components/project/index.hbs
+++ b/web/app/components/project/index.hbs
@@ -67,7 +67,7 @@
 
   </div>
 </div>
-<div class="max-w-3xl">
+<div class="relative z-20 max-w-3xl">
 
   {{! Title }}
   <div class="mt-7 flex">
@@ -77,6 +77,7 @@
       @value={{this.title}}
       @tag="h1"
       @placeholder="Add project title"
+      @buttonSize="medium"
       @onSave={{this.saveTitle}}
       @isReadOnly={{not this.projectIsActive}}
       @isRequired={{true}}
@@ -94,6 +95,7 @@
         @isReadOnly={{not this.projectIsActive}}
         @isSaving={{this.descriptionIsSaving}}
         @placeholder="Add a description"
+        @buttonSize="medium"
       />
     </div>
   {{/if}}

--- a/web/app/styles/components/project.scss
+++ b/web/app/styles/components/project.scss
@@ -6,17 +6,31 @@
       &:hover,
       &:focus-visible,
       &:focus {
-        @apply bg-color-surface-interactive-hover;
+        @apply bg-color-page-primary shadow-surface-low;
       }
     }
 
     .edit-affordance {
       &.gray {
         &::before {
-          @apply from-color-surface-interactive-hover via-color-surface-interactive-hover to-transparent;
+          @apply from-color-page-primary via-color-page-primary to-transparent;
         }
       }
     }
+  }
+
+  .edit-overlay-affordance::before {
+    @apply hidden;
+  }
+
+  .edit-overlay-affordance {
+    @apply pb-0;
+    filter: drop-shadow(0px 20px 15px white);
+  }
+
+  textarea:focus,
+  .active textarea {
+    filter: drop-shadow(0px 30px 15px white);
   }
 
   .project-title,
@@ -38,7 +52,7 @@
   .project-description {
     .field-toggle,
     textarea {
-      @apply py-1 text-display-400 text-color-foreground-primary;
+      @apply py-1.5 text-display-400 text-color-foreground-primary;
     }
   }
 

--- a/web/tests/integration/components/editable-field-test.ts
+++ b/web/tests/integration/components/editable-field-test.ts
@@ -26,6 +26,7 @@ interface EditableFieldComponentTestContext extends MirageTestContext {
   value: string;
   newArray: string[];
   disabled: boolean;
+  buttonSize?: "medium";
 }
 
 module("Integration | Component | editable-field", function (hooks) {
@@ -445,5 +446,25 @@ module("Integration | Component | editable-field", function (hooks) {
     await click(FIELD_TOGGLE);
 
     assert.dom("textarea").hasValue("bar");
+  });
+
+  test("it can render medium-sized buttons", async function (this: EditableFieldComponentTestContext, assert) {
+    this.set("buttonSize", undefined);
+
+    await render<EditableFieldComponentTestContext>(hbs`
+      <EditableField
+        @value="foo"
+        @onSave={{this.onCommit}}
+        @buttonSize={{this.buttonSize}}
+      />
+    `);
+
+    await click(FIELD_TOGGLE);
+
+    assert.dom(SAVE_BUTTON).hasClass("hds-button--size-small");
+
+    this.set("buttonSize", "medium");
+
+    assert.dom(SAVE_BUTTON).hasClass("hds-button--size-medium");
   });
 });


### PR DESCRIPTION
Tweaks the affordances of the Title and Description fields on the Projects screen to be less gray. Increases the size of the save/cancel buttons to better match the size of the inputs. Improves outer-glow logic of active inputs.