### PR TITLE
Enable creating documents as logged-in user (take 2)

### DIFF
--- a/configs/config.hcl
+++ b/configs/config.hcl
@@ -128,6 +128,12 @@ google_workspace {
   //   {shortcut_folder}/{doc_type}/{product}/{document}
   shortcuts_folder = "my-shortcuts-folder-id"
 
+  // temporary_drafts_folder is a folder that will brieflly contain document
+  // drafts before they are moved to the drafts_folder. This is used when
+  // create_docs_as_user is true in the auth block, so document notification
+  // settings will be the same as when a user creates their own document.
+  // temporary_drafts_folder = "my-temporary-drafts-folder-id"
+
   // auth is the configuration for interacting with Google Workspace using a
   // service account.
   // auth {

--- a/internal/api/drafts.go
+++ b/internal/api/drafts.go
@@ -127,12 +127,16 @@ func DraftsHandler(
 			}
 			title := fmt.Sprintf("[%s-???] %s", req.ProductAbbreviation, req.Title)
 
-			// If configured to create documents as the logged-in Hermes user, create
-			// a new Google Drive service to do this.
-			copyTemplateSvc := *s
+			var (
+				err error
+				f   *drive.File
+			)
+
+			// Copy template to new draft file.
 			if cfg.GoogleWorkspace.Auth != nil &&
 				cfg.GoogleWorkspace.Auth.CreateDocsAsUser {
-
+				// If configured to create documents as the logged-in Hermes user,
+				// create a new Google Drive service to do this.
 				ctx := context.Background()
 				conf := &jwt.Config{
 					Email:      cfg.GoogleWorkspace.Auth.ClientEmail,
@@ -144,8 +148,7 @@ func DraftsHandler(
 					TokenURL: cfg.GoogleWorkspace.Auth.TokenURL,
 				}
 				client := conf.Client(ctx)
-
-				var err error
+				copyTemplateSvc := *s
 				copyTemplateSvc.Drive, err = drive.NewService(
 					ctx, option.WithHTTPClient(client))
 				if err != nil {
@@ -158,17 +161,60 @@ func DraftsHandler(
 						w, "Error processing request", http.StatusInternalServerError)
 					return
 				}
-			}
 
-			// Copy template to new draft file.
-			f, err := copyTemplateSvc.CopyFile(
-				template, title, cfg.GoogleWorkspace.DraftsFolder)
-			if err != nil {
-				l.Error("error creating draft", "error", err, "template", template,
-					"drafts_folder", cfg.GoogleWorkspace.DraftsFolder)
-				http.Error(w, "Error creating document draft",
-					http.StatusInternalServerError)
-				return
+				// Copy template as user to new draft file in temporary drafts folder.
+				f, err = copyTemplateSvc.CopyFile(
+					template, title, cfg.GoogleWorkspace.TemporaryDraftsFolder)
+				if err != nil {
+					l.Error(
+						"error copying template as user to temporary drafts folder",
+						"error", err,
+						"method", r.Method,
+						"path", r.URL.Path,
+						"template", template,
+						"drafts_folder", cfg.GoogleWorkspace.DraftsFolder,
+						"temporary_drafts_folder", cfg.GoogleWorkspace.
+							TemporaryDraftsFolder,
+					)
+					http.Error(w, "Error creating document draft",
+						http.StatusInternalServerError)
+					return
+				}
+
+				// Move draft file to drafts folder using service user.
+				_, err = s.MoveFile(
+					f.Id, cfg.GoogleWorkspace.DraftsFolder)
+				if err != nil {
+					l.Error(
+						"error moving draft file to drafts folder",
+						"error", err,
+						"method", r.Method,
+						"path", r.URL.Path,
+						"doc_id", f.Id,
+						"drafts_folder", cfg.GoogleWorkspace.DraftsFolder,
+						"temporary_drafts_folder", cfg.GoogleWorkspace.
+							TemporaryDraftsFolder,
+					)
+					http.Error(w, "Error creating document draft",
+						http.StatusInternalServerError)
+					return
+				}
+			} else {
+				// Copy template to new draft file as service user.
+				f, err = s.CopyFile(
+					template, title, cfg.GoogleWorkspace.DraftsFolder)
+				if err != nil {
+					l.Error("error creating draft",
+						"error", err,
+						"method", r.Method,
+						"path", r.URL.Path,
+						"template", template,
+						"drafts_folder", cfg.GoogleWorkspace.DraftsFolder,
+					)
+					http.Error(w, "Error creating document draft",
+						http.StatusInternalServerError)
+					return
+				}
 			}
 
 			// Build created date.

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -220,8 +220,16 @@ func (c *Command) Run(args []string) int {
 
 	// Initialize Google Workspace service.
 	var goog *gw.Service
+	// Use Google Workspace service user auth if it is defined in the config.
 	if cfg.GoogleWorkspace.Auth != nil {
-		// Use Google Workspace auth if it is defined in the config.
+		// Validate temporary drafts folder is configured if creating docs as user.
+		if cfg.GoogleWorkspace.Auth.CreateDocsAsUser &&
+			cfg.GoogleWorkspace.TemporaryDraftsFolder == "" {
+			c.UI.Error(
+				"error initializing server: Google Workspace temporary drafts folder is required if create_docs_as_user is true")
+			return 1
+		}
+
 		goog = gw.NewFromConfig(cfg.GoogleWorkspace.Auth)
 	} else {
 		// Use OAuth if Google Workspace auth is not defined in the config.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,6 +226,12 @@ type GoogleWorkspace struct {
 	// ShortcutsFolder is the folder that contains document shortcuts organized
 	// into doc type and product subfolders.
 	ShortcutsFolder string `hcl:"shortcuts_folder"`
+
+	// TemporaryDraftsFolder is a folder that will brieflly contain document
+	// drafts before they are moved to the DraftsFolder. This is used when
+	// create_docs_as_user is true in the auth block, so document notification
+	// settings will be the same as when a user creates their own document.
+	TemporaryDraftsFolder string `hcl:"temporary_drafts_folder,optional"`
 }
 
 // GoogleWorkspaceOAuth2 is the configuration to use OAuth 2.0 to access Google


### PR DESCRIPTION
This is a follow-up to #508 to (hopefully!) enable creating documents on behalf of logged-in Hermes users when running Hermes as a service account with domain-wide authority.

Shared drive permissions and Google Docs notification settings are _fun_, and hopefully this can create documents with the same notification settings as when a user creates their own Google Docs, by first copying the template to a new temporary drafts folder as the logged-in user, and then using the service user to copy the file to the drafts folder (which should have less permissive permissions - will submit another PR for these doc updates).

### New config attribute

```hcl
google_workspace {
  ...
  // temporary_drafts_folder is a folder that will brieflly contain document
  // drafts before they are moved to the drafts_folder. This is used when
  // create_docs_as_user is true in the auth block, so document notification
  // settings will be the same as when a user creates their own document.
  temporary_drafts_folder = "my-temporary-drafts-folder-id"
  ...
  }
}
```