### PR TITLE
Add read-only styles to Jira

### DIFF
--- a/web/app/components/overflow-menu.hbs
+++ b/web/app/components/overflow-menu.hbs
@@ -2,14 +2,14 @@
   @items={{@items}}
   @renderOut={{true}}
   @placement="bottom-end"
-  @offset={{hash mainAxis=-3 crossAxis=-3}}
+  @offset={{or @offset (hash mainAxis=-3 crossAxis=-3)}}
   data-test-overflow-menu
   ...attributes
 >
   <:anchor as |dd|>
     <div
       class="overflow-button-container
-        {{if dd.contentIsShown 'visible' 'invisible'}}
+        {{if (or @isShown dd.contentIsShown) 'visible' 'invisible'}}
         "
     >
       <dd.ToggleAction

--- a/web/app/components/overflow-menu.ts
+++ b/web/app/components/overflow-menu.ts
@@ -1,3 +1,4 @@
+import { OffsetOptions } from "@floating-ui/dom";
 import Component from "@glimmer/component";
 
 export interface OverflowItem {
@@ -10,6 +11,8 @@ interface OverflowMenuComponentSignature {
   Element: HTMLDivElement;
   Args: {
     items: Record<string, OverflowItem>;
+    offset?: OffsetOptions;
+    isShown?: boolean;
   };
 }
 

--- a/web/app/components/project/index.hbs
+++ b/web/app/components/project/index.hbs
@@ -107,6 +107,7 @@
       @onIssueRemove={{this.removeJiraIssue}}
       @onIssueSelect={{this.addJiraIssue}}
       @isLoading={{this.loadJiraIssue.isRunning}}
+      @isReadOnly={{not this.projectIsActive}}
     />
   </div>
 {{/if}}

--- a/web/app/components/project/jira-widget.hbs
+++ b/web/app/components/project/jira-widget.hbs
@@ -1,232 +1,213 @@
-<div
-  class="jira-widget relative flex h-[36px] w-full max-w-3xl items-center"
-  ...attributes
->
+{{#unless (and (not this.issue) (not @isLoading) @isReadOnly)}}
   <div
-    class="inner relative flex w-full
-      {{if
-        (and this.issue @isNewProjectForm)
-        'h-9 items-center rounded-button-md pr-2 shadow-surface-low'
-      }}"
+    data-test-jira-widget
+    class="jira-widget relative flex h-[36px] w-full max-w-3xl items-center"
+    ...attributes
   >
     <div
-      class="relative flex
-        {{unless this.issue 'w-full'}}
-        {{if @isNewProjectForm 'min-h-[24px] items-center'}}"
+      class="inner relative flex w-full
+        {{if
+          (and this.issue @isNewProjectForm)
+          'h-9 items-center rounded-button-md pr-2 shadow-surface-low'
+        }}"
     >
+      <div
+        class="relative flex items-center
+          {{unless this.issue 'w-full'}}
+          {{if @isNewProjectForm 'min-h-[24px]'}}"
+      >
 
-      {{#unless (or (not this.issue) @isNewProjectForm)}}
-        <div
-          data-test-jira-icon
-          class="relative z-10 mr-3 flex h-6 items-center"
-        >
-          <div class="mr-3 flex shrink-0 gap-2">
-            <FlightIcon @name="jira" />
-          </div>
+        {{#unless (or (not this.issue) @isNewProjectForm)}}
           <div
-            class="absolute top-1/2 right-0 h-5 w-px -translate-y-1/2 bg-color-border-strong"
-          />
-        </div>
-      {{/unless}}
-
-      {{#if this.issue}}
-        <ExternalLink
-          data-test-jira-link
-          href={{if @isNewProjectForm "" this.issue.url}}
-          class="mr-8
-            {{if
-              @isNewProjectForm
-              'disabled pointer-events-none block'
-              'inline-flex'
-            }}"
-        >
-
-          {{! Content }}
-          <div class="attached-jira-issue {{if @isNewProjectForm 'pl-2.5'}}">
-            <img
-              data-test-jira-issue-type-icon
-              width="16"
-              height="16"
-              alt="{{this.issueType}}"
-              src="{{this.issueTypeImage}}"
-              class="h-4 w-4"
+            data-test-jira-icon
+            class="relative z-10 mr-3 flex h-6 items-center"
+          >
+            <div class="mr-3 flex shrink-0 gap-2">
+              <FlightIcon @name="jira" />
+            </div>
+            <div
+              class="absolute top-1/2 right-0 h-5 w-px -translate-y-1/2 bg-color-border-strong"
             />
-            <div
-              class="primary-text w-full truncate text-color-foreground-faint"
-            >
-              <span
-                data-test-jira-key
-                class={{if (eq this.issueStatus "done") "line-through"}}
-              >
-                {{this.issue.key}}
-              </span>
-              <span data-test-jira-summary>
-                {{this.issue.summary}}
-              </span>
-            </div>
           </div>
+        {{/unless}}
 
-          {{#if (or this.issuePriority this.issueAssignee this.issueStatus)}}
-            <div class="relative flex h-6 shrink-0 items-center gap-2">
-              {{#if this.issuePriority}}
-                <img
-                  data-test-jira-priority-icon
-                  width="16"
-                  height="16"
-                  alt={{this.issuePriority}}
-                  src={{this.issuePriorityImage}}
-                  class="h-4 w-4"
-                />
-              {{/if}}
-              {{#if this.issueAssignee}}
-                <Person::Avatar
-                  data-test-jira-assignee-avatar-wrapper
-                  @email={{this.issueAssignee}}
-                  @imgURL={{this.assigneeAvatar}}
-                  @size="small"
-                />
-              {{/if}}
-              {{#if this.issueStatus}}
-                <div
-                  data-test-jira-status
-                  class="{{dasherize this.issueStatus}}
-                    rounded-sm px-1.5 py-px text-body-100 font-medium uppercase"
-                >
-                  {{this.issueStatus}}
-                </div>
-              {{/if}}
-            </div>
-          {{/if}}
-        </ExternalLink>
+        {{#if this.issue}}
+          <ExternalLink
+            data-test-jira-link
+            href={{if @isNewProjectForm "" this.issue.url}}
+            class="{{if
+                @isNewProjectForm
+                'disabled pointer-events-none block'
+                'inline-flex'
+              }}"
+          >
 
-        <X::DropdownList
-          @items={{hash
-            unlink=(hash
-              label="Remove Jira issue"
-              icon="x-circle"
-              action=(fn this.removeIssue)
-            )
-          }}
-          @placement="bottom-end"
-          @renderOut={{true}}
-        >
-          <:anchor as |dd|>
-            <dd.ToggleAction
-              data-test-jira-overflow-button
-              class="quarternary-button absolute right-0 top-0 grid h-6 w-6 place-items-center items-center p-0
-                {{if dd.contentIsShown 'open'}}"
-            >
-              <FlightIcon @name="more-vertical" />
-            </dd.ToggleAction>
-          </:anchor>
-          <:item as |dd|>
-            <dd.Action
-              data-test-remove-button
-              {{on "click" dd.attrs.action}}
-              class="flex items-center gap-2"
-            >
-              <FlightIcon @name={{dd.attrs.icon}} />
-              {{dd.attrs.label}}
-            </dd.Action>
-          </:item>
-        </X::DropdownList>
-      {{else if @isLoading}}
-        <FlightIcon data-test-jira-loading @name="loading" class="mt-[3px]" />
-      {{else}}
-        {{! + Add Jira issue }}
-        <X::DropdownList
-          @inputIsShown={{false}}
-          @onItemClick={{this.onIssueSelect}}
-          @items={{this.results}}
-          @matchAnchorWidth={{true}}
-          {{will-destroy this.onDropdownClose}}
-          class="theme--neutral"
-          data-test-jira-picker-dropdown
-        >
-          <:anchor as |dd|>
-            <div
-              class="relative h-9 w-full
-                {{unless @isNewProjectForm 'X-mt-1.5 -ml-1.5'}}"
-              {{did-insert (fn this.registerDropdown dd)}}
-              {{did-insert dd.registerAnchor}}
-            >
-              {{#if this.inputIsShown}}
-                <Hds::Form::TextInput::Base
-                  data-test-add-jira-input
-                  {{on "input" this.onInput}}
-                  {{on "focusout" this.hideInput}}
-                  {{(unless @isNewProjectForm (modifier "autofocus"))}}
-                  @value={{this.query}}
-                  disabled={{@isDisabled}}
-                  id="jira-search-input"
-                  placeholder={{if
-                    @isNewProjectForm
-                    "Search issues..."
-                    "Add Jira issue"
-                  }}
-                  class="jira-input relative"
-                  @type="search"
-                />
-                {{! search icon  }}
-                <div class="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2">
-                  <FlightIcon
-                    data-test-search-icon
-                    @name="search"
-                    class="text-color-foreground-faint
-                      {{unless @isNewProjectForm 'animated-icon'}}"
-                  />
-                </div>
-              {{else}}
-                <Action
-                  data-test-add-jira-button
-                  disabled={{@isDisabled}}
-                  class="add-jira-issue-button absolute flex h-full w-auto items-center gap-2 text-body-200 text-color-foreground-faint"
-                  {{on "click" this.showInput}}
-                >
-                  <FlightIcon
-                    data-test-add-jira-button-plus
-                    @name="plus"
-                    class={{if this.plusIconShouldAnimate "animated-icon"}}
-                  />
-                  Add Jira issue...
-                </Action>
-              {{/if}}
-
-              {{#if this.searchJiraIssues.isRunning}}
-                <div
-                  data-test-related-resources-search-loading-icon
-                  class="absolute top-1/2 right-3 flex -translate-y-1/2 bg-white"
-                >
-                  <FlightIcon @name="loading" />
-                </div>
-              {{/if}}
-            </div>
-          </:anchor>
-          <:no-matches>
-            {{#unless (lt this.query.length 1)}}
+            {{! Content }}
+            <div class="attached-jira-issue {{if @isNewProjectForm 'pl-2.5'}}">
+              <img
+                data-test-jira-issue-type-icon
+                width="16"
+                height="16"
+                alt="{{this.issueType}}"
+                src="{{this.issueTypeImage}}"
+                class="h-4 w-4"
+              />
               <div
-                data-test-no-matches
-                class="x-dropdown-list-default-empty-state"
+                class="primary-text w-full truncate text-color-foreground-faint"
               >
-                {{#unless this.searchJiraIssues.isRunning}}
-                  No matches
-                {{/unless}}
+                <span
+                  data-test-jira-key
+                  class={{if (eq this.issueStatus "done") "line-through"}}
+                >
+                  {{this.issue.key}}
+                </span>
+                <span data-test-jira-summary>
+                  {{this.issue.summary}}
+                </span>
               </div>
-            {{/unless}}
-          </:no-matches>
-          <:item as |dd|>
-            <dd.Action data-test-jira-picker-result class="block py-1">
-              <div class="flex items-center gap-1.5">
-                <img width="16" height="16" src={{dd.attrs.issueTypeImage}} />
-                <div class="truncate">
-                  {{dd.attrs.key}}
-                  {{dd.attrs.summary}}
+            </div>
+
+            {{#if (or this.issuePriority this.issueAssignee this.issueStatus)}}
+              <div class="relative flex h-6 shrink-0 items-center gap-2">
+                {{#if this.issuePriority}}
+                  <img
+                    data-test-jira-priority-icon
+                    width="16"
+                    height="16"
+                    alt={{this.issuePriority}}
+                    src={{this.issuePriorityImage}}
+                    class="h-4 w-4"
+                  />
+                {{/if}}
+                {{#if this.issueAssignee}}
+                  <Person::Avatar
+                    data-test-jira-assignee-avatar-wrapper
+                    @email={{this.issueAssignee}}
+                    @imgURL={{this.assigneeAvatar}}
+                    @size="small"
+                  />
+                {{/if}}
+                {{#if this.issueStatus}}
+                  <div
+                    data-test-jira-status
+                    class="{{dasherize this.issueStatus}}
+                      rounded-sm px-1.5 py-px text-body-100 font-medium uppercase"
+                  >
+                    {{this.issueStatus}}
+                  </div>
+                {{/if}}
+              </div>
+            {{/if}}
+          </ExternalLink>
+          {{#unless @isReadOnly}}
+            <OverflowMenu
+              @items={{hash
+                unlink=(hash
+                  label="Remove" icon="trash" action=(fn this.removeIssue)
+                )
+              }}
+              @isShown={{true}}
+              @offset={{hash mainAxis=1 crossAxis=-3}}
+            />
+          {{/unless}}
+        {{else if @isLoading}}
+          <FlightIcon data-test-jira-loading @name="loading" class="mt-[3px]" />
+        {{else}}
+          {{! + Add Jira issue }}
+          <X::DropdownList
+            @inputIsShown={{false}}
+            @onItemClick={{this.onIssueSelect}}
+            @items={{this.results}}
+            @matchAnchorWidth={{true}}
+            {{will-destroy this.onDropdownClose}}
+            class="theme--neutral"
+            data-test-jira-picker-dropdown
+          >
+            <:anchor as |dd|>
+              <div
+                class="relative h-9 w-full
+                  {{unless @isNewProjectForm 'X-mt-1.5 -ml-1.5'}}"
+                {{did-insert (fn this.registerDropdown dd)}}
+                {{did-insert dd.registerAnchor}}
+              >
+                {{#if this.inputIsShown}}
+                  <Hds::Form::TextInput::Base
+                    data-test-add-jira-input
+                    {{on "input" this.onInput}}
+                    {{on "focusout" this.hideInput}}
+                    {{(unless @isNewProjectForm (modifier "autofocus"))}}
+                    @value={{this.query}}
+                    disabled={{@isDisabled}}
+                    id="jira-search-input"
+                    placeholder={{if
+                      @isNewProjectForm
+                      "Search issues..."
+                      "Add Jira issue"
+                    }}
+                    class="jira-input relative"
+                    @type="search"
+                  />
+                  {{! search icon  }}
+                  <div class="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2">
+                    <FlightIcon
+                      data-test-search-icon
+                      @name="search"
+                      class="text-color-foreground-faint
+                        {{unless @isNewProjectForm 'animated-icon'}}"
+                    />
+                  </div>
+                {{else}}
+                  <Action
+                    data-test-add-jira-button
+                    disabled={{@isDisabled}}
+                    class="add-jira-issue-button absolute flex h-full w-auto items-center gap-2 text-body-200 text-color-foreground-faint"
+                    {{on "click" this.showInput}}
+                  >
+                    <FlightIcon
+                      data-test-add-jira-button-plus
+                      @name="plus"
+                      class={{if this.plusIconShouldAnimate "animated-icon"}}
+                    />
+                    Add Jira issue...
+                  </Action>
+                {{/if}}
+
+                {{#if this.searchJiraIssues.isRunning}}
+                  <div
+                    data-test-related-resources-search-loading-icon
+                    class="absolute top-1/2 right-3 flex -translate-y-1/2 bg-white"
+                  >
+                    <FlightIcon @name="loading" />
+                  </div>
+                {{/if}}
+              </div>
+            </:anchor>
+            <:no-matches>
+              {{#unless (lt this.query.length 1)}}
+                <div
+                  data-test-no-matches
+                  class="x-dropdown-list-default-empty-state"
+                >
+                  {{#unless this.searchJiraIssues.isRunning}}
+                    No matches
+                  {{/unless}}
                 </div>
-              </div>
-            </dd.Action>
-          </:item>
-        </X::DropdownList>
-      {{/if}}
+              {{/unless}}
+            </:no-matches>
+            <:item as |dd|>
+              <dd.Action data-test-jira-picker-result class="block py-1">
+                <div class="flex items-center gap-1.5">
+                  <img width="16" height="16" src={{dd.attrs.issueTypeImage}} />
+                  <div class="truncate">
+                    {{dd.attrs.key}}
+                    {{dd.attrs.summary}}
+                  </div>
+                </div>
+              </dd.Action>
+            </:item>
+          </X::DropdownList>
+        {{/if}}
+      </div>
     </div>
   </div>
-</div>
+{{/unless}}

--- a/web/app/components/project/jira-widget.ts
+++ b/web/app/components/project/jira-widget.ts
@@ -18,6 +18,7 @@ interface ProjectJiraWidgetComponentSignature {
     onIssueRemove?: () => void;
     isDisabled?: boolean;
     isLoading?: boolean;
+    isReadOnly?: boolean;
     /**
      * Whether the component is being used in a form context.
      * If true, removes the leading Jira icon and shows the input, autofocused,

--- a/web/app/components/project/resource.hbs
+++ b/web/app/components/project/resource.hbs
@@ -3,6 +3,9 @@
   {{yield}}
 
   {{#unless @isReadOnly}}
-    <OverflowMenu @items={{@overflowMenuItems}} />
+    <OverflowMenu
+      @items={{@overflowMenuItems}}
+      @offset={{hash mainAxis=1 crossAxis=-3}}
+    />
   {{/unless}}
 </div>

--- a/web/app/styles/components/jira-widget.scss
+++ b/web/app/styles/components/jira-widget.scss
@@ -17,10 +17,15 @@
       }
     }
   }
+
+  .overflow-button-container {
+    @apply relative top-auto right-auto mr-1 ml-2 w-auto bg-none;
+  }
 }
 
 .add-jira-issue-button {
   @apply py-0 pl-[8px] pr-[14px];
+
   &:hover,
   &:focus {
     @apply rounded-button-md shadow-surface-low;

--- a/web/tests/acceptance/authenticated/projects/project-test.ts
+++ b/web/tests/acceptance/authenticated/projects/project-test.ts
@@ -67,7 +67,7 @@ const EXTERNAL_LINK_COUNT = "[data-test-external-link-count]";
 const EXTERNAL_LINK_LIST = "[data-test-external-link-list]";
 
 const DOCUMENT_LIST_ITEM = "[data-test-document-list-item]";
-const OVERFLOW_MENU_BUTTON = "[data-test-overflow-menu-button]";
+const DOCUMENT_OVERFLOW_MENU_BUTTON = `${DOCUMENT_LIST_ITEM} [data-test-overflow-menu-button]`;
 const OVERFLOW_MENU_EDIT = "[data-test-overflow-menu-action='edit']";
 const OVERFLOW_MENU_REMOVE = "[data-test-overflow-menu-action='remove']";
 
@@ -89,12 +89,13 @@ const EXTERNAL_LINK = "[data-test-related-link]";
 const STATUS_TOGGLE = "[data-test-project-status-toggle]";
 const COPY_URL_BUTTON = "[data-test-copy-url-button]";
 
+const JIRA_WIDGET = "[data-test-jira-widget]";
 const ADD_JIRA_BUTTON = "[data-test-add-jira-button]";
 const ADD_JIRA_INPUT = "[data-test-add-jira-input]";
 const JIRA_PICKER_RESULT = "[data-test-jira-picker-result]";
 const JIRA_ISSUE_TYPE_ICON = "[data-test-jira-issue-type-icon]";
 
-const JIRA_OVERFLOW_BUTTON = "[data-test-jira-overflow-button]";
+const JIRA_OVERFLOW_BUTTON = `${JIRA_WIDGET} [data-test-overflow-menu-button]`;
 const JIRA_LINK = "[data-test-jira-link]";
 const JIRA_PRIORITY_ICON = "[data-test-jira-priority-icon]";
 const JIRA_ASSIGNEE_AVATAR = "[data-test-jira-assignee-avatar-wrapper] img";
@@ -102,7 +103,7 @@ const JIRA_STATUS = "[data-test-jira-status]";
 const JIRA_TYPE_ICON = "[data-test-jira-issue-type-icon]";
 const JIRA_KEY = "[data-test-jira-key]";
 const JIRA_SUMMARY = "[data-test-jira-summary]";
-const JIRA_REMOVE_BUTTON = "[data-test-remove-button]";
+const JIRA_REMOVE_BUTTON = "[data-test-overflow-menu-action='remove']";
 
 const ACTIVE_STATUS_ACTION = "[data-test-status-action='active']";
 const COMPLETED_STATUS_ACTION = "[data-test-status-action='completed']";
@@ -413,7 +414,7 @@ module("Acceptance | authenticated/projects/project", function (hooks) {
 
     assert.dom(DOCUMENT_LIST_ITEM).exists({ count: 1 });
 
-    await click(OVERFLOW_MENU_BUTTON);
+    await click(DOCUMENT_OVERFLOW_MENU_BUTTON);
     await click(OVERFLOW_MENU_REMOVE);
 
     assert.dom(DOCUMENT_LIST_ITEM).doesNotExist();
@@ -428,19 +429,19 @@ module("Acceptance | authenticated/projects/project", function (hooks) {
     await visit("/projects/1");
 
     assert.dom(DOCUMENT_LIST_ITEM).exists();
-    assert.dom(OVERFLOW_MENU_BUTTON).exists();
+    assert.dom(DOCUMENT_OVERFLOW_MENU_BUTTON).exists();
 
     await click(STATUS_TOGGLE);
     await click(COMPLETED_STATUS_ACTION);
 
     assert.dom(DOCUMENT_LIST_ITEM).exists();
-    assert.dom(OVERFLOW_MENU_BUTTON).doesNotExist();
+    assert.dom(DOCUMENT_OVERFLOW_MENU_BUTTON).doesNotExist();
 
     await click(STATUS_TOGGLE);
     await click(ARCHIVED_STATUS_ACTION);
 
     assert.dom(DOCUMENT_LIST_ITEM).exists();
-    assert.dom(OVERFLOW_MENU_BUTTON).doesNotExist();
+    assert.dom(DOCUMENT_OVERFLOW_MENU_BUTTON).doesNotExist();
   });
 
   test("you can add external links to a project", async function (this: AuthenticatedProjectsProjectRouteTestContext, assert) {
@@ -500,7 +501,7 @@ module("Acceptance | authenticated/projects/project", function (hooks) {
 
     assert.dom(EXTERNAL_LINK).exists({ count: 1 });
 
-    await click(OVERFLOW_MENU_BUTTON);
+    await click(DOCUMENT_OVERFLOW_MENU_BUTTON);
     await click(OVERFLOW_MENU_EDIT);
 
     const linkTitle = "Bar";
@@ -545,7 +546,7 @@ module("Acceptance | authenticated/projects/project", function (hooks) {
 
     assert.dom(EXTERNAL_LINK).exists({ count: 1 });
 
-    await click(OVERFLOW_MENU_BUTTON);
+    await click(DOCUMENT_OVERFLOW_MENU_BUTTON);
     await click(OVERFLOW_MENU_REMOVE);
 
     assert.dom(EXTERNAL_LINK).doesNotExist();
@@ -564,19 +565,19 @@ module("Acceptance | authenticated/projects/project", function (hooks) {
     await visit("/projects/1");
 
     assert.dom(EXTERNAL_LINK).exists();
-    assert.dom(OVERFLOW_MENU_BUTTON).exists();
+    assert.dom(DOCUMENT_OVERFLOW_MENU_BUTTON).exists();
 
     await click(STATUS_TOGGLE);
     await click(COMPLETED_STATUS_ACTION);
 
     assert.dom(EXTERNAL_LINK).exists();
-    assert.dom(OVERFLOW_MENU_BUTTON).doesNotExist();
+    assert.dom(DOCUMENT_OVERFLOW_MENU_BUTTON).doesNotExist();
 
     await click(STATUS_TOGGLE);
     await click(ARCHIVED_STATUS_ACTION);
 
     assert.dom(EXTERNAL_LINK).exists();
-    assert.dom(OVERFLOW_MENU_BUTTON).doesNotExist();
+    assert.dom(DOCUMENT_OVERFLOW_MENU_BUTTON).doesNotExist();
   });
 
   test("you can't save an empty project title", async function (this: AuthenticatedProjectsProjectRouteTestContext, assert) {

--- a/web/tests/integration/components/project/jira-widget-test.ts
+++ b/web/tests/integration/components/project/jira-widget-test.ts
@@ -17,8 +17,9 @@ const KEY = "[data-test-jira-key]";
 const SUMMARY = "[data-test-jira-summary]";
 const LINK = "[data-test-jira-link]";
 const ISSUE_TYPE_ICON = "[data-test-jira-issue-type-icon]";
-const OVERFLOW_BUTTON = "[data-test-jira-overflow-button]";
-const REMOVE_JIRA_BUTTON = "[data-test-remove-button]";
+const JIRA_WIDGET = "[data-test-jira-widget]";
+const OVERFLOW_BUTTON = `${JIRA_WIDGET} [data-test-overflow-menu-button]`;
+const REMOVE_JIRA_BUTTON = "[data-test-overflow-menu-action='remove']";
 const PRIORITY_ICON = "[data-test-jira-priority-icon]";
 const ASSIGNEE_AVATAR = "[data-test-jira-assignee-avatar-wrapper] img";
 const STATUS = "[data-test-jira-status]";
@@ -485,6 +486,27 @@ module("Integration | Component | project/jira-widget", function (hooks) {
       .doesNotHaveClass(
         "animated-icon",
         "the search icon does not animate in the form context",
+      );
+  });
+
+  test("it can be rendered read-only", async function (this: Context, assert) {
+    this.set("issue", this.server.create("jira-picker-result"));
+
+    await render<Context>(hbs`
+      <Project::JiraWidget
+        @issue={{this.issue}}
+        @isReadOnly={{true}}
+      />
+    `);
+    assert.dom(LINK).exists();
+    assert.dom(OVERFLOW_BUTTON).doesNotExist();
+
+    this.set("issue", undefined);
+
+    assert
+      .dom(LINK)
+      .doesNotExist(
+        "the link is not rendered if read-only with an undefined issue",
       );
   });
 });

--- a/web/tests/integration/components/related-resources/overflow-menu-test.ts
+++ b/web/tests/integration/components/related-resources/overflow-menu-test.ts
@@ -2,6 +2,7 @@ import { TestContext, click, findAll, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupRenderingTest } from "ember-qunit";
 import { OverflowItem } from "hermes/components/overflow-menu";
+import htmlElement from "hermes/utils/html-element";
 import { module, test } from "qunit";
 
 const POPOVER = "[data-test-overflow-menu]";
@@ -12,6 +13,7 @@ const LABEL = `${POPOVER} [data-test-label]`;
 
 interface OverflowMenuTestContext extends TestContext {
   items: Record<string, OverflowItem>;
+  isShown?: boolean;
 }
 
 module("Integration | Component | related-resources/add", function (hooks) {
@@ -70,5 +72,28 @@ module("Integration | Component | related-resources/add", function (hooks) {
     await click(`${POPOVER} li:nth-child(2) button`);
 
     assert.equal(actionTwoCount, 1);
+  });
+
+  test("it can be force-shown", async function (this: OverflowMenuTestContext, assert) {
+    this.set("isShown", false);
+    this.set("items", {
+      item1: {
+        label: "Item 1",
+        icon: "square",
+        action: () => {},
+      },
+    });
+    await render<OverflowMenuTestContext>(hbs`
+      <OverflowMenu
+        @items={{this.items}}
+        @isShown={{this.isShown}}
+      />
+    `);
+
+    assert.dom(TOGGLE).hasStyle({ visibility: "hidden" });
+
+    this.set("isShown", true);
+
+    assert.dom(TOGGLE).hasStyle({ visibility: "visible" });
   });
 });


### PR DESCRIPTION
Adds read-only styles to the Jira widget. Inactive projects will no longer have the Jira overflow button (to remove). For inactive projects without a Jira issue, the widget is removed entirely.

Also updates the Jira widget to use the same OverflowMenu settings as the project resource tiles. Now when the Jira issue is at max width, its overflow button aligns vertically with the resource overflow buttons 🥹