### PR TITLE
Configure `createDocsAsUser` in the front end

### DIFF
--- a/web/app/components/new/doc-form.ts
+++ b/web/app/components/new/doc-form.ts
@@ -15,8 +15,6 @@ import cleanString from "hermes/utils/clean-string";
 import { ProductArea } from "hermes/services/product-areas";
 import { next } from "@ember/runloop";
 import HermesFlashMessagesService from "hermes/services/flash-messages";
-import { ModelFrom } from "hermes/types/route-models";
-import AuthenticatedNewRoute from "hermes/routes/authenticated/new";
 import DocumentTypesService from "hermes/services/document-types";
 
 interface DocFormErrors {
@@ -25,7 +23,6 @@ interface DocFormErrors {
 }
 
 const AWAIT_DOC_DELAY = Ember.testing ? 0 : 2000;
-const AWAIT_DOC_CREATED_MODAL_DELAY = Ember.testing ? 0 : 1500;
 
 interface NewDocFormComponentSignature {
   Args: {
@@ -224,15 +221,23 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
       // Wait for document to be available.
       await timeout(AWAIT_DOC_DELAY);
 
-      // Set modal on a delay so it appears after transition.
-      this.modalAlerts.setActive.perform(
-        "draftCreated",
-        AWAIT_DOC_CREATED_MODAL_DELAY,
-      );
-
-      this.router.transitionTo("authenticated.document", doc.id, {
-        queryParams: { draft: true },
-      });
+      this.router
+        .transitionTo("authenticated.document", doc.id, {
+          queryParams: { draft: true },
+        })
+        .then(() => {
+          if (this.configSvc.config.create_docs_as_user) {
+            this.flashMessages.success("", {
+              title: "Draft created!",
+            });
+          } else {
+            /**
+             * If `create_docs_as_user` is false, show a modal alert
+             * explaining the limitations on notifications.
+             */
+            this.modalAlerts.setActive.perform("draftCreated");
+          }
+        });
     } catch (e) {
       this.docIsBeingCreated = false;
 

--- a/web/app/config/environment.d.ts
+++ b/web/app/config/environment.d.ts
@@ -16,6 +16,7 @@ export interface HermesConfig {
     draftsIndexName: string;
     internalIndexName: string;
   };
+  createDocsAsUser: boolean;
   featureFlags: Record<string, boolean>;
   google: {
     docFolders: string;

--- a/web/app/services/config.ts
+++ b/web/app/services/config.ts
@@ -7,6 +7,7 @@ export default class ConfigService extends Service {
     algolia_drafts_index_name: config.algolia.draftsIndexName,
     algolia_internal_index_name: config.algolia.internalIndexName,
     api_version: "v1",
+    create_docs_as_user: config.createDocsAsUser,
     feature_flags: config.featureFlags,
     google_doc_folders: config.google.docFolders ?? "",
     short_link_base_url: config.shortLinkBaseURL,


### PR DESCRIPTION
Configures `createDocsAsUser` property to conditionally replace the "Draft Created" modal with a flash message.