### PR TITLE
Improve `closeDropdown` handling

### DIFF
--- a/web/app/components/x/dropdown-list/item.hbs
+++ b/web/app/components/x/dropdown-list/item.hbs
@@ -55,6 +55,7 @@
             registerElement=this.registerElement
             focusMouseTarget=(perform this.maybeFocusMouseTarget)
             onClick=this.onClick
+            hideContent=@hideContent
           )
           ExternalLink=(component
             "x/dropdown-list/external-link"

--- a/web/app/components/x/dropdown-list/item.hbs
+++ b/web/app/components/x/dropdown-list/item.hbs
@@ -55,7 +55,6 @@
             registerElement=this.registerElement
             focusMouseTarget=(perform this.maybeFocusMouseTarget)
             onClick=this.onClick
-            hideContent=@hideContent
           )
           ExternalLink=(component
             "x/dropdown-list/external-link"

--- a/web/app/components/x/dropdown-list/item.ts
+++ b/web/app/components/x/dropdown-list/item.ts
@@ -124,6 +124,12 @@ export default class XDropdownListItemComponent extends Component<XDropdownListI
     this._domElement = element;
   }
 
+  /**
+   * The action called on clicked. Runs the parent component's
+   * `onItemClick` action, if it exists, and hides the dropdown.
+   * The "link-to" sub-component runs this on the next run loop
+   * to avoid interfering with Ember's <LinkTo> handling.
+   */
   @action onClick() {
     if (this.args.onItemClick) {
       this.args.onItemClick(this.args.value, this.args.attributes);

--- a/web/app/components/x/dropdown-list/item.ts
+++ b/web/app/components/x/dropdown-list/item.ts
@@ -129,24 +129,7 @@ export default class XDropdownListItemComponent extends Component<XDropdownListI
       this.args.onItemClick(this.args.value, this.args.attributes);
     }
 
-    /**
-     * In production, close the dropdown on the next run loop
-     * so that we don't interfere with Ember's <LinkTo> handling.
-     *
-     * This approach causes issues when testing, so we
-     * use `schedule` as an approximation.
-     *
-     * TODO: Improve this.
-     */
-    if (Ember.testing) {
-      schedule("afterRender", () => {
-        this.args.hideContent();
-      });
-    } else {
-      next(() => {
-        this.args.hideContent();
-      });
-    }
+    this.args.hideContent();
   }
 
   /**

--- a/web/app/components/x/dropdown-list/link-to.hbs
+++ b/web/app/components/x/dropdown-list/link-to.hbs
@@ -2,7 +2,7 @@
   data-test-x-dropdown-list-item-link-to
   {{did-insert @registerElement}}
   {{on "mouseenter" @focusMouseTarget}}
-  {{on "click" @onClick}}
+  {{on "click" this.hideDropdown}}
   role={{@role}}
   aria-selected={{@isAriaSelected}}
   tabindex="-1"

--- a/web/app/components/x/dropdown-list/link-to.hbs
+++ b/web/app/components/x/dropdown-list/link-to.hbs
@@ -2,7 +2,7 @@
   data-test-x-dropdown-list-item-link-to
   {{did-insert @registerElement}}
   {{on "mouseenter" @focusMouseTarget}}
-  {{on "click" this.hideDropdown}}
+  {{on "click" this.onClick}}
   role={{@role}}
   aria-selected={{@isAriaSelected}}
   tabindex="-1"

--- a/web/app/components/x/dropdown-list/link-to.ts
+++ b/web/app/components/x/dropdown-list/link-to.ts
@@ -1,5 +1,8 @@
 import Component from "@glimmer/component";
 import { XDropdownListInteractiveComponentArgs } from "./_shared";
+import { action } from "@ember/object";
+import Ember from "ember";
+import { next, schedule } from "@ember/runloop";
 
 interface XDropdownListLinkToComponentSignature {
   Element: HTMLAnchorElement;
@@ -8,13 +11,30 @@ interface XDropdownListLinkToComponentSignature {
     query?: Record<string, unknown>;
     model?: unknown;
     models?: unknown[];
+    hideContent: () => void;
   };
   Blocks: {
     default: [];
   };
 }
 
-export default class XDropdownListLinkToComponent extends Component<XDropdownListLinkToComponentSignature> {}
+export default class XDropdownListLinkToComponent extends Component<XDropdownListLinkToComponentSignature> {
+  /**
+   * The action to close the dropdown. Called on click.
+   * We wait until the next run loop so that we don't interfere with
+   * Ember's <LinkTo> handling. Because this approach causes issues
+   * when testing, we use `schedule` as an approximation.
+   */
+  @action protected hideDropdown(): void {
+    if (Ember.testing) {
+      schedule("afterRender", this.args.hideContent);
+    } else {
+      next(() => {
+        this.args.hideContent();
+      });
+    }
+  }
+}
 
 declare module "@glint/environment-ember-loose/registry" {
   export default interface Registry {

--- a/web/app/components/x/dropdown-list/link-to.ts
+++ b/web/app/components/x/dropdown-list/link-to.ts
@@ -11,7 +11,6 @@ interface XDropdownListLinkToComponentSignature {
     query?: Record<string, unknown>;
     model?: unknown;
     models?: unknown[];
-    hideContent: () => void;
   };
   Blocks: {
     default: [];
@@ -20,17 +19,17 @@ interface XDropdownListLinkToComponentSignature {
 
 export default class XDropdownListLinkToComponent extends Component<XDropdownListLinkToComponentSignature> {
   /**
-   * The action to close the dropdown. Called on click.
+   * The action to run when the item is clicked.
    * We wait until the next run loop so that we don't interfere with
    * Ember's <LinkTo> handling. Because this approach causes issues
    * when testing, we use `schedule` as an approximation.
    */
-  @action protected hideDropdown(): void {
+  @action protected onClick(): void {
     if (Ember.testing) {
-      schedule("afterRender", this.args.hideContent);
+      schedule("afterRender", this.args.onClick);
     } else {
       next(() => {
-        this.args.hideContent();
+        this.args.onClick();
       });
     }
   }


### PR DESCRIPTION
Moves the "hide dropdown on the next runloop" function to the `DropdownListLinkTo` sub-component. This is the only place it's needed and it was causing minor issues elsewhere.