### PR TITLE
Fix avatar loading on projects screen

### DIFF
--- a/web/app/components/doc/tile-medium.hbs
+++ b/web/app/components/doc/tile-medium.hbs
@@ -18,10 +18,11 @@
       disabled={{not (get @doc.owners 0)}}
     >
       <Person::Avatar
+        {{did-insert this.maybeLoadAvatar}}
         @size="large"
         @email="{{get @doc.owners 0}}"
-        @imgURL={{get @doc.ownerPhotos 0}}
-        @isLoading={{@avatarIsLoading}}
+        @imgURL={{this.imgURL}}
+        @isLoading={{this.getOwnerPhoto.isRunning}}
         class="relative z-10 -mt-1 shrink-0"
       />
     </LinkTo>

--- a/web/app/components/doc/tile-medium.ts
+++ b/web/app/components/doc/tile-medium.ts
@@ -1,6 +1,12 @@
 import Component from "@glimmer/component";
 import { RelatedHermesDocument } from "../related-resources";
 import { HermesDocument } from "hermes/types/document";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
+import FetchService from "hermes/services/fetch";
+import ConfigService from "hermes/services/config";
+import { task } from "ember-concurrency";
 
 interface DocTileMediumComponentSignature {
   Element: HTMLAnchorElement;
@@ -14,6 +20,15 @@ interface DocTileMediumComponentSignature {
 }
 
 export default class DocTileMediumComponent extends Component<DocTileMediumComponentSignature> {
+  @service("fetch") declare fetchSvc: FetchService;
+  @service("config") declare configSvc: ConfigService;
+
+  /**
+   * The URL of the owner's avatar. If one isn't available,
+   * we'll attempt to fetch it.
+   */
+  @tracked protected imgURL = this.args.doc.ownerPhotos?.[0];
+
   protected get docID() {
     if ("googleFileID" in this.args.doc) {
       return this.args.doc.googleFileID;
@@ -41,6 +56,24 @@ export default class DocTileMediumComponent extends Component<DocTileMediumCompo
   protected get docIsDraft() {
     return this.args.doc.status?.toLowerCase() === "wip";
   }
+
+  @action protected maybeLoadAvatar() {
+    if (!this.imgURL) {
+      this.getOwnerPhoto.perform(this.docID);
+    }
+  }
+
+  /**
+   * The task to get the owner photo for a document.
+   */
+  private getOwnerPhoto = task(async (docID: string) => {
+    console.log("getOwnerPhoto");
+    const doc = await this.fetchSvc
+      .fetch(`/api/${this.configSvc.config.api_version}/documents/${docID}`)
+      .then((response) => response?.json());
+
+    this.imgURL = doc.ownerPhotos[0];
+  });
 }
 
 declare module "@glint/environment-ember-loose/registry" {

--- a/web/app/components/doc/tile-medium.ts
+++ b/web/app/components/doc/tile-medium.ts
@@ -67,7 +67,6 @@ export default class DocTileMediumComponent extends Component<DocTileMediumCompo
    * The task to get the owner photo for a document.
    */
   private getOwnerPhoto = task(async (docID: string) => {
-    console.log("getOwnerPhoto");
     const doc = await this.fetchSvc
       .fetch(`/api/${this.configSvc.config.api_version}/documents/${docID}`)
       .then((response) => response?.json());

--- a/web/app/components/project/index.hbs
+++ b/web/app/components/project/index.hbs
@@ -163,10 +163,7 @@
                   )
                 }}
               >
-                <Doc::TileMedium
-                  @doc={{document}}
-                  @avatarIsLoading={{this.getOwnerPhoto.isRunning}}
-                />
+                <Doc::TileMedium @doc={{document}} />
               </Project::Resource>
             </li>
           {{/each}}

--- a/web/app/components/project/index.ts
+++ b/web/app/components/project/index.ts
@@ -9,7 +9,7 @@ import {
 import { RelatedResourceSelector } from "hermes/components/related-resources";
 import { inject as service } from "@ember/service";
 import FetchService from "hermes/services/fetch";
-import { enqueueTask, restartableTask, task, timeout } from "ember-concurrency";
+import { enqueueTask, task, timeout } from "ember-concurrency";
 import { HermesProject, JiraPickerResult } from "hermes/types/project";
 import {
   ProjectStatus,
@@ -256,8 +256,6 @@ export default class ProjectIndexComponent extends Component<ProjectIndexCompone
    * Adds a resource to the correct array, then saves the project.
    */
   @action protected addDocument(resource: RelatedHermesDocument) {
-    void this.getOwnerPhoto.perform(resource.googleFileID);
-
     const cachedDocuments = this.hermesDocuments.slice();
 
     this.hermesDocuments.unshiftObject(resource);
@@ -309,27 +307,6 @@ export default class ProjectIndexComponent extends Component<ProjectIndexCompone
     this.resourceToEdit = undefined;
     this.resourceToEditIndex = undefined;
   }
-
-  /**
-   * The task to get the owner photo for a document.
-   */
-  private getOwnerPhoto = enqueueTask(async (docID: string) => {
-    const doc = await this.fetchSvc
-      .fetch(`/api/${this.configSvc.config.api_version}/documents/${docID}`)
-      .then((response) => response?.json());
-
-    const ownerPhoto = doc.ownerPhotos[0];
-
-    if (ownerPhoto) {
-      const hermesDoc = this.hermesDocuments.find(
-        (doc) => doc.googleFileID === docID,
-      );
-
-      if (hermesDoc) {
-        hermesDoc.ownerPhotos = [ownerPhoto];
-      }
-    }
-  });
 
   /**
    * The action to save basic project attributes,

--- a/web/tests/acceptance/authenticated/projects/project-test.ts
+++ b/web/tests/acceptance/authenticated/projects/project-test.ts
@@ -386,13 +386,8 @@ module("Acceptance | authenticated/projects/project", function (hooks) {
     await waitFor(ADD_PROJECT_RESOURCE_MODAL);
     assert.dom(ADD_PROJECT_RESOURCE_MODAL).exists();
 
-    const clickPromise = click(ADD_DOCUMENT_OPTION);
+    await click(ADD_DOCUMENT_OPTION);
 
-    await waitFor(`${DOCUMENT_OWNER_AVATAR} [data-test-is-loading]`);
-
-    await clickPromise;
-
-    assert.dom("[data-test-is-loading]").doesNotExist();
     assert
       .dom(`${DOCUMENT_OWNER_AVATAR} img`)
       .hasAttribute("src", TEST_USER_PHOTO);

--- a/web/tests/integration/components/doc/tile-medium-test.ts
+++ b/web/tests/integration/components/doc/tile-medium-test.ts
@@ -127,7 +127,6 @@ module("Integration | Component | doc/tile-medium", function (hooks) {
     });
 
     this.set("doc", this.server.schema.relatedHermesDocument.find(id).attrs);
-    console.log("this.doc", this.doc);
     const renderPromise = render<DocTileMediumComponentContext>(
       hbs`<Doc::TileMedium @doc={{this.doc}} />`,
     );


### PR DESCRIPTION
Fixes a bug on the projects screen causing already-loaded avatars to show their `isLoading` state when a new document is added. Now only the newly added document shows the `isLoading` state as intended.