### PR TITLE
Change default Algolia index for Related Resources

### DIFF
--- a/web/app/components/related-resources.ts
+++ b/web/app/components/related-resources.ts
@@ -178,8 +178,7 @@ export default class RelatedResourcesComponent extends Component<RelatedResource
       shouldIgnoreDelay?: boolean,
       options?: SearchOptions,
     ) => {
-      let index =
-        this.configSvc.config.algolia_docs_index_name + "_modifiedTime_desc";
+      let index = this.configSvc.config.algolia_docs_index_name;
 
       let filterString = "";
 


### PR DESCRIPTION
Changes the Algolia index of the Related Resources search from a `modifiedTime_desc` replica to the original index, which returns more accurate search results.