### PR TITLE
Fix DropdownListItemCount CSS bug

### DIFF
--- a/web/app/styles/hds-overrides.scss
+++ b/web/app/styles/hds-overrides.scss
@@ -20,13 +20,15 @@
 }
 /* Maintain contrast across hover and focus states */
 .hds-badge-count--color-neutral.hds-badge-count--type-filled {
-  @apply mix-blend-multiply;
+  &:not(.checkable-item-count) {
+    @apply mix-blend-multiply;
+  }
 }
 
 .x-dropdown-list-item-link {
   &.is-aria-selected {
     .hds-badge-count--color-neutral.hds-badge-count--type-filled {
-      @apply bg-white bg-opacity-10 text-color-foreground-high-contrast mix-blend-screen;
+      @apply bg-white bg-opacity-10 text-color-foreground-high-contrast;
     }
   }
 }


### PR DESCRIPTION
Fixes a bug causing badge counts to sometimes not appear in the filter dropdowns. You can observe the bug on main by scrolling up and down on a long filter list, e.g., Owner.