### PR TITLE
Fix Product/Area select styles on New Document screen

### DIFF
--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -142,6 +142,7 @@
               @isSaving={{this.saveIsRunning}}
               @selectedAbbreviationIsHidden={{true}}
               @renderOut={{true}}
+              @color="quarternary"
               class="max-h-[275px] w-[320px]"
             />
           </div>

--- a/web/app/components/inputs/product-select.hbs
+++ b/web/app/components/inputs/product-select.hbs
@@ -21,7 +21,7 @@
     <:anchor as |dd|>
       <dd.ToggleSelect
         data-test-product-select-toggle
-        class="quarternary-button gap-2
+        class="gap-2
           {{if @isSaving 'opacity-50'}}
           {{if
             (eq @color 'quarternary')

--- a/web/app/components/inputs/product-select.hbs
+++ b/web/app/components/inputs/product-select.hbs
@@ -21,7 +21,13 @@
     <:anchor as |dd|>
       <dd.ToggleSelect
         data-test-product-select-toggle
-        class="quarternary-button gap-2 {{if @isSaving 'opacity-50'}}"
+        class="quarternary-button gap-2
+          {{if @isSaving 'opacity-50'}}
+          {{if
+            (eq @color 'quarternary')
+            'quarternary-button'
+            'border-color-border-input shadow-elevation-low'
+          }}"
         id="product-select"
       >
         <Inputs::ProductSelect::Item

--- a/web/app/components/inputs/product-select.ts
+++ b/web/app/components/inputs/product-select.ts
@@ -22,6 +22,7 @@ interface InputsProductSelectSignature {
     renderOut?: boolean;
     offset?: OffsetOptions;
     matchAnchorWidth?: MatchAnchorWidthOptions;
+    color?: "quarternary";
   };
 }
 

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -48,6 +48,7 @@ module.exports = {
         "button-md": "5px",
       },
       boxShadow: {
+        "elevation-low": "var(--token-elevation-low-box-shadow)",
         "surface-low": "var(--token-surface-low-box-shadow)",
         "surface-mid": "var(--token-surface-mid-box-shadow)",
         "focus-ring-action": "var(--token-focus-ring-action-box-shadow)",

--- a/web/tests/integration/components/inputs/product-select-test.ts
+++ b/web/tests/integration/components/inputs/product-select-test.ts
@@ -21,6 +21,7 @@ interface InputsProductSelectContext extends MirageTestContext {
   onChange: (value: string) => void;
   placement?: Placement;
   isSaving?: boolean;
+  color?: "quarternary";
 }
 
 module("Integration | Component | inputs/product-select", function (hooks) {
@@ -154,5 +155,31 @@ module("Integration | Component | inputs/product-select", function (hooks) {
 
     assert.dom(`${TOGGLE} ${PRODUCT_NAME}`).hasText("Vault");
     assert.dom(ABBREVIATION).doesNotExist();
+  });
+
+  test("it can render in the quarternary button style", async function (this: InputsProductSelectContext, assert) {
+    this.set("color", undefined);
+
+    await render<InputsProductSelectContext>(hbs`
+      <Inputs::ProductSelect
+        @selected={{this.selected}}
+        @onChange={{this.onChange}}
+        @color={{this.color}}
+      />
+    `);
+
+    assert
+      .dom(TOGGLE)
+      .hasClass("shadow-elevation-low")
+      .hasClass("border-color-border-input")
+      .doesNotHaveClass("quarternary-button");
+
+    this.set("color", "quarternary");
+
+    assert
+      .dom(TOGGLE)
+      .doesNotHaveClass("shadow-elevation-low")
+      .doesNotHaveClass("border-color-border-input")
+      .hasClass("quarternary-button");
   });
 });


### PR DESCRIPTION
Fixes a regression causing the ProductSelect input on the New Document form to be missing a border and shadow.