### PR TITLE
Use the `modifiedTime` index for empty Algolia searches

### DIFF
--- a/web/app/components/related-resources.ts
+++ b/web/app/components/related-resources.ts
@@ -180,6 +180,12 @@ export default class RelatedResourcesComponent extends Component<RelatedResource
     ) => {
       let index = this.configSvc.config.algolia_docs_index_name;
 
+      // Empty queries target the modifiedTime-sorted replica index
+      // to return a list of recently updated documents.
+      if (query === "") {
+        index += "_modifiedTime_desc";
+      }
+
       let filterString = "";
 
       // Make sure the current document is omitted from the results


### PR DESCRIPTION
Follow up to #547 which fixed Related Resources search results but broke "Latest docs" suggestions.

This PR fixes the "latest docs" results in the "Add resource" modal by changing the index for empty queries from `docs` to `docs_modifiedTime_desc`. All other queries will continue to go through the default index.