### PR TITLE
Return names with people API response

### DIFF
--- a/internal/api/people.go
+++ b/internal/api/people.go
@@ -43,7 +43,7 @@ func PeopleDataHandler(
 				// Only query for photos and email addresses
 				// This may be expanded based on use case
 				// in the future
-				ReadMask("photos,emailAddresses").
+				ReadMask("emailAddresses,names,photos").
 				Sources("DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE").
 				Do()
 			if err != nil {
@@ -77,7 +77,7 @@ func PeopleDataHandler(
 				for _, email := range emails {
 					result, err := s.People.SearchDirectoryPeople().
 						Query(email).
-						ReadMask("photos,emailAddresses").
+						ReadMask("emailAddresses,names,photos").
 						Sources("DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE").
 						Do()
 

--- a/internal/api/v2/people.go
+++ b/internal/api/v2/people.go
@@ -37,7 +37,7 @@ func PeopleDataHandler(srv server.Server) http.Handler {
 				// Only query for photos and email addresses
 				// This may be expanded based on use case
 				// in the future
-				ReadMask("photos,emailAddresses").
+				ReadMask("emailAddresses,names,photos").
 				Sources("DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE").
 				Do()
 			if err != nil {
@@ -74,7 +74,7 @@ func PeopleDataHandler(srv server.Server) http.Handler {
 				for _, email := range emails {
 					result, err := srv.GWService.People.SearchDirectoryPeople().
 						Query(email).
-						ReadMask("photos,emailAddresses").
+						ReadMask("emailAddresses,names,photos").
 						Sources("DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE").
 						Do()
 


### PR DESCRIPTION
Google fixed [this issue](https://issuetracker.google.com/issues/196235775) and now we can finally enable using full names instead of email addresses around the app.