### PR TITLE
Configure `Person` in EmberData

### DIFF
--- a/web/app/adapters/application.ts
+++ b/web/app/adapters/application.ts
@@ -1,0 +1,22 @@
+import JSONAdapter from "@ember-data/adapter/json-api";
+import { inject as service } from "@ember/service";
+import ConfigService from "hermes/services/config";
+import FetchService from "hermes/services/fetch";
+import SessionService from "hermes/services/session";
+
+export default class ApplicationAdapter extends JSONAdapter {
+  @service("config") declare configSvc: ConfigService;
+  @service("fetch") declare fetchSvc: FetchService;
+  @service declare session: SessionService;
+
+  get namespace() {
+    return `api/${this.configSvc.config.api_version}`;
+  }
+
+  get headers() {
+    return {
+      "Hermes-Google-Access-Token":
+        this.session.data.authenticated.access_token,
+    };
+  }
+}

--- a/web/app/adapters/person.ts
+++ b/web/app/adapters/person.ts
@@ -2,9 +2,13 @@ import DS from "ember-data";
 import ApplicationAdapter from "./application";
 import RSVP from "rsvp";
 
-// TODO: Improve `query` type
 export default class PersonAdapter extends ApplicationAdapter {
-  query(_store: DS.Store, _type: DS.Model, query: any) {
+  /**
+   * Queries using the `body` parameter instead of a queryParam.
+   * Default query:     `/people?query=foo`
+   * Our custom query:  `/people` with `{ query: "foo" }` in the request body.
+   */
+  query(_store: DS.Store, _type: DS.Model, query: { query: string }) {
     const results = this.fetchSvc
       .fetch(`/api/${this.configSvc.config.api_version}/people`, {
         method: "POST",

--- a/web/app/adapters/person.ts
+++ b/web/app/adapters/person.ts
@@ -1,0 +1,19 @@
+import DS from "ember-data";
+import ApplicationAdapter from "./application";
+import RSVP from "rsvp";
+
+// TODO: Improve `query` type
+export default class PersonAdapter extends ApplicationAdapter {
+  query(_store: DS.Store, _type: DS.Model, query: any) {
+    const results = this.fetchSvc
+      .fetch(`/api/${this.configSvc.config.api_version}/people`, {
+        method: "POST",
+        body: JSON.stringify({
+          query: query.query,
+        }),
+      })
+      .then((r) => r?.json());
+
+    return RSVP.hash({ results });
+  }
+}

--- a/web/app/components/inputs/people-select.ts
+++ b/web/app/components/inputs/people-select.ts
@@ -10,6 +10,7 @@ import Ember from "ember";
 
 export interface GoogleUser {
   emailAddresses: { value: string }[];
+  names: { displayName: string; givenName: string }[];
   photos: { url: string }[];
 }
 

--- a/web/app/models/person.ts
+++ b/web/app/models/person.ts
@@ -1,0 +1,8 @@
+import Model, { attr } from "@ember-data/model";
+
+export default class PersonModel extends Model {
+  @attr declare name: string;
+  @attr declare firstName: string;
+  @attr declare email: string;
+  @attr declare picture: string;
+}

--- a/web/app/models/person.ts
+++ b/web/app/models/person.ts
@@ -1,8 +1,23 @@
 import Model, { attr } from "@ember-data/model";
 
 export default class PersonModel extends Model {
+  /**
+   * The person's full name, e.g., "Jane Doe".
+   */
   @attr declare name: string;
+
+  /**
+   * The person's first name, e.g., "Jane".
+   */
   @attr declare firstName: string;
+
+  /**
+   * The person's email address, e.g., "jane.doe@hashicorp.com"
+   */
   @attr declare email: string;
+
+  /**
+   * The person's profile picture URL.
+   */
   @attr declare picture: string;
 }

--- a/web/app/serializers/application.ts
+++ b/web/app/serializers/application.ts
@@ -1,0 +1,25 @@
+import JSONSerializer from "@ember-data/serializer/json";
+import DS from "ember-data";
+
+export default class ApplicationSerializer extends JSONSerializer {
+  normalizeResponse(
+    _store: DS.Store,
+    primaryModelClass: DS.Model,
+    payload: any,
+    _id: string | number,
+    _requestType: string,
+  ) {
+    payload = {
+      data: [
+        {
+          id: payload.id,
+          // @ts-ignore - FIXME: what is the correct type
+          type: primaryModelClass.modelName,
+          attributes: payload,
+        },
+      ],
+    };
+
+    return payload;
+  }
+}

--- a/web/app/serializers/application.ts
+++ b/web/app/serializers/application.ts
@@ -2,9 +2,14 @@ import JSONSerializer from "@ember-data/serializer/json";
 import DS from "ember-data";
 
 export default class ApplicationSerializer extends JSONSerializer {
+  /**
+   * The default serializer for all models.
+   * Formats the response to match the JSON spec.
+   * Model-specific serializers should extend this class.
+   */
   normalizeResponse(
     _store: DS.Store,
-    primaryModelClass: DS.Model,
+    primaryModelClass: any,
     payload: any,
     _id: string | number,
     _requestType: string,
@@ -13,7 +18,6 @@ export default class ApplicationSerializer extends JSONSerializer {
       data: [
         {
           id: payload.id,
-          // @ts-ignore - FIXME: what is the correct type
           type: primaryModelClass.modelName,
           attributes: payload,
         },

--- a/web/app/serializers/person.ts
+++ b/web/app/serializers/person.ts
@@ -4,6 +4,11 @@ import DS from "ember-data";
 import { GoogleUser } from "hermes/components/inputs/people-select";
 
 export default class PersonSerializer extends JSONSerializer {
+  /**
+   * The serializer for the `person` model.
+   * Handles `query` and `queryRecord` requests to the EmberData store.
+   * Formats the response to match the JSON spec.
+   */
   normalizeResponse(
     _store: DS.Store,
     primaryModelClass: any,
@@ -27,9 +32,7 @@ export default class PersonSerializer extends JSONSerializer {
         };
       });
 
-      return {
-        data: people,
-      };
+      return { data: people };
     } else if (requestType === "queryRecord") {
       assert(
         "payload should not be an array of results",
@@ -52,8 +55,9 @@ export default class PersonSerializer extends JSONSerializer {
           },
         },
       };
+    } else {
+      // Currently only `query` and `queryRecord` requests are handled.
+      return {};
     }
-
-    return {};
   }
 }

--- a/web/app/serializers/person.ts
+++ b/web/app/serializers/person.ts
@@ -1,0 +1,59 @@
+import JSONSerializer from "@ember-data/serializer/json";
+import { assert } from "@ember/debug";
+import DS from "ember-data";
+import { GoogleUser } from "hermes/components/inputs/people-select";
+
+export default class PersonSerializer extends JSONSerializer {
+  normalizeResponse(
+    _store: DS.Store,
+    primaryModelClass: any,
+    payload: GoogleUser[] | { results: GoogleUser[] },
+    _id: string | number,
+    requestType: string,
+  ) {
+    if (requestType === "query") {
+      assert("results are expected for query requests", "results" in payload);
+
+      const people = payload.results.map((p: any) => {
+        return {
+          id: p.emailAddresses[0].value,
+          type: primaryModelClass.modelName,
+          attributes: {
+            name: p.names[0].displayName,
+            firstName: p.names[0].givenName,
+            email: p.emailAddresses[0].value,
+            picture: p.photos[0].url,
+          },
+        };
+      });
+
+      return {
+        data: people,
+      };
+    } else if (requestType === "queryRecord") {
+      assert(
+        "payload should not be an array of results",
+        !("results" in payload),
+      );
+
+      const record = payload[0];
+
+      if (!record) return {};
+
+      return {
+        data: {
+          id: record.emailAddresses?.[0]?.value,
+          type: primaryModelClass.modelName,
+          attributes: {
+            name: record.names[0]?.displayName,
+            firstName: record.names[0]?.givenName,
+            email: record.emailAddresses[0]?.value,
+            picture: record.photos[0]?.url,
+          },
+        },
+      };
+    }
+
+    return {};
+  }
+}

--- a/web/app/services/store.ts
+++ b/web/app/services/store.ts
@@ -4,34 +4,37 @@ import Store from "@ember-data/store";
 export default class StoreService extends Store {
   /**
    * The task to fetch a person's record if it's not already in the EmberData store.
-   * Retrieving the record pushes it to the store to be used by components like
-   * `Avatar` and `Person` to show rich data from an email reference.
+   * Retrieves the record, which pushes it to the store to be used by components like
+   * `Avatar` and `Person` for showing rich data from an email reference.
    */
   maybeFetchPeople = task(async (emails: string[]) => {
     let promises: Promise<void>[] = [];
 
-    emails = emails.uniq();
+    emails = emails.uniq(); // Remove duplicates
 
     emails.forEach((email?: string) => {
       if (!email) {
         return;
       }
 
+      /**
+       * Check if the record is already in the store.
+       */
       let cachedRecord = this.peekRecord("person", email);
 
       if (!cachedRecord) {
+        /**
+         * Queue a promise request to `/api/v2/person?emails=${email}`
+         * to return a GoogleUser object when resolved.
+         */
         promises.push(
-          /**
-           * This queues a promise request to `/api/v2/person?emails=${email}`
-           * that returns a GoogleUser object when resolved.
-           */
           this.queryRecord("person", {
             emails: email,
           }).catch(() => {
             /**
              * Errors here are not necessarily indicative of a problem;
              * for example, we get a 404 if a once-valid user is no longer in
-             * the directory. So we allow the component to handle the empty state.
+             * the directory. So we let the component to handle the undefined state.
              */
             console.warn(`No results for ${email}`);
           }),

--- a/web/app/services/store.ts
+++ b/web/app/services/store.ts
@@ -1,0 +1,44 @@
+import { task } from "ember-concurrency";
+import Store from "@ember-data/store";
+
+export default class StoreService extends Store {
+  /**
+   * The task to fetch a person's record if it's not already in the EmberData store.
+   * Retrieving the record pushes it to the store to be used by components like
+   * `Avatar` and `Person` to show rich data from an email reference.
+   */
+  maybeFetchPeople = task(async (emails: string[]) => {
+    let promises: Promise<void>[] = [];
+
+    emails = emails.uniq();
+
+    emails.forEach((email?: string) => {
+      if (!email) {
+        return;
+      }
+
+      let cachedRecord = this.peekRecord("person", email);
+
+      if (!cachedRecord) {
+        promises.push(
+          /**
+           * This queues a promise request to `/api/v2/person?emails=${email}`
+           * that returns a GoogleUser object when resolved.
+           */
+          this.queryRecord("person", {
+            emails: email,
+          }).catch(() => {
+            /**
+             * Errors here are not necessarily indicative of a problem;
+             * for example, we get a 404 if a once-valid user is no longer in
+             * the directory. So we allow the component to handle the empty state.
+             */
+            console.warn(`No results for ${email}`);
+          }),
+        );
+      }
+    });
+
+    await Promise.all(promises);
+  });
+}


### PR DESCRIPTION
Prepares the app to use EmberData to handle People requests. This will fix avatars, add `name` attributes, and add caching.

Calls to the `people` endpoint will soon change from, e.g.,

```
await this.fetchSvc
  .fetch(`/api/${this.configSvc.config.api_version}/people`, {
    method: "POST",
    headers: { "Content-Type": "application/json" },
    body: JSON.stringify({
      query: query,
    }),
  },
);
```
to something like

```
await this.store.query("person", { query });
```

I'll follow this up with an implementation PR.