### PR TITLE
Allow doc approvers to remove themselves as an approver

### DIFF
--- a/internal/api/v2/documents_test.go
+++ b/internal/api/v2/documents_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"testing"
 
+	"github.com/hashicorp-forge/hermes/pkg/document"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -56,6 +57,129 @@ func TestParseDocumentIDFromURLPath(t *testing.T) {
 				assert.NoError(err)
 				assert.Equal(c.wantDocID, docID)
 				assert.Equal(c.wantReqType, reqType)
+			}
+		})
+	}
+}
+
+func TestAuthorizeDocumentPatchRequest(t *testing.T) {
+	cases := map[string]struct {
+		userEmail string
+		doc       document.Document
+		req       DocumentPatchRequest
+		shouldErr bool
+	}{
+		"owner should be authorized": {
+			userEmail: "owner@example.com",
+			doc: document.Document{
+				Owners: []string{"owner@example.com"},
+			},
+			req:       DocumentPatchRequest{},
+			shouldErr: false,
+		},
+		"not owner should not be authorized": {
+			userEmail: "not.owner@example.com",
+			doc: document.Document{
+				Owners: []string{"owner@example.com"},
+			},
+			req:       DocumentPatchRequest{},
+			shouldErr: true,
+		},
+		"approver should be authorized with valid patch request": {
+			userEmail: "approver2@example.com",
+			doc: document.Document{
+				Approvers: []string{
+					"approver1@example.com",
+					"approver2@example.com",
+					"approver3@example.com",
+				},
+				Owners: []string{"owner@example.com"},
+			},
+			req: DocumentPatchRequest{
+				Approvers: &[]string{
+					"approver1@example.com",
+					"approver3@example.com",
+				},
+			},
+			shouldErr: false,
+		},
+		"approver should not be authorized when removing another approver": {
+			userEmail: "approver2@example.com",
+			doc: document.Document{
+				Approvers: []string{
+					"approver1@example.com",
+					"approver2@example.com",
+					"approver3@example.com",
+				},
+				Owners: []string{"owner@example.com"},
+			},
+			req: DocumentPatchRequest{
+				Approvers: &[]string{
+					"approver1@example.com",
+					"approver2@example.com",
+				},
+			},
+			shouldErr: true,
+		},
+		"approver should not be authorized an empty patch request": {
+			userEmail: "approver@example.com",
+			doc: document.Document{
+				Approvers: []string{"approver@example.com"},
+				Owners:    []string{"owner@example.com"},
+			},
+			req:       DocumentPatchRequest{},
+			shouldErr: true,
+		},
+		"approver should not be authorized when trying to patch another field too": {
+			userEmail: "approver2@example.com",
+			doc: document.Document{
+				Approvers: []string{
+					"approver1@example.com",
+					"approver2@example.com",
+					"approver3@example.com",
+				},
+				Owners: []string{"owner@example.com"},
+			},
+			req: DocumentPatchRequest{
+				Approvers: &[]string{
+					"approver1@example.com",
+					"approver3@example.com",
+				},
+				Contributors: &[]string{
+					"approver2@example.com",
+				},
+			},
+			shouldErr: true,
+		},
+		"approver should not be authorized by putting other approvers in request": {
+			userEmail: "approver2@example.com",
+			doc: document.Document{
+				Approvers: []string{
+					"approver1@example.com",
+					"approver2@example.com",
+					"approver3@example.com",
+				},
+				Owners: []string{"owner@example.com"},
+			},
+			req: DocumentPatchRequest{
+				Approvers: &[]string{
+					"approver4@example.com",
+					"approver5@example.com",
+				},
+			},
+			shouldErr: true,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			err := authorizeDocumentPatchRequest(c.userEmail, c.doc, c.req)
+
+			if c.shouldErr {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
 			}
 		})
 	}

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -1,5 +1,18 @@
 package helpers
 
+// RemoveStringSliceDuplicates removes duplicate strings from a string slice.
+func RemoveStringSliceDuplicates(in []string) []string {
+	keys := make(map[string]bool)
+	out := []string{}
+	for _, s := range in {
+		if _, seen := keys[s]; !seen {
+			keys[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
 // StringSliceContains returns true if a string is present in a slice of
 // strings.
 func StringSliceContains(values []string, s string) bool {

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -1,0 +1,60 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveStringSliceDuplicates(t *testing.T) {
+	type testCase struct {
+		input []string
+		want  []string
+	}
+
+	testCases := []testCase{
+		{
+			input: []string{"hello", "world", "hello", "gopher"},
+			want:  []string{"hello", "world", "gopher"},
+		},
+		{
+			input: []string{"hello"},
+			want:  []string{"hello"},
+		},
+		{
+			input: nil,
+			want:  []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := RemoveStringSliceDuplicates(tc.input)
+		assert.Equal(t, tc.want, got)
+	}
+}
+
+func TestStringSliceContains(t *testing.T) {
+	type testCase struct {
+		values []string
+		s      string
+		want   bool
+	}
+
+	testCases := []testCase{
+		{
+			values: []string{"hello", "world", "gopher"},
+			s:      "world",
+			want:   true,
+		},
+		{
+			values: []string{"hello", "world", "gopher"},
+			s:      "foo",
+			want:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		got := StringSliceContains(tc.values, tc.s)
+		assert.Equal(t, tc.want, got)
+	}
+}


### PR DESCRIPTION
This PR allows a document approver to remove themselves as an approver. It does this by modifying the authorization code for a document PATCH request to only allow this case for doc approvers (tests included). It also adds a few tests for some miscellaneous helpers.