### PR TITLE
Fix service import; sidebar cleanup

### DIFF
--- a/web/app/components/document/index.ts
+++ b/web/app/components/document/index.ts
@@ -2,7 +2,6 @@ import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 import { dropTask } from "ember-concurrency";
 import { HermesDocument } from "hermes/types/document";
-import { AuthenticatedUser } from "hermes/services/authenticated-user";
 import ConfigService from "hermes/services/config";
 import FetchService from "hermes/services/fetch";
 import RouterService from "@ember/routing/router-service";
@@ -11,6 +10,7 @@ import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { HermesDocumentType } from "hermes/types/document-type";
 import HermesFlashMessagesService from "hermes/services/flash-messages";
+import AuthenticatedUserService from "hermes/services/authenticated-user";
 
 interface DocumentIndexComponentSignature {
   Args: {
@@ -21,7 +21,7 @@ interface DocumentIndexComponentSignature {
 }
 
 export default class DocumentIndexComponent extends Component<DocumentIndexComponentSignature> {
-  @service declare authenticatedUser: AuthenticatedUser;
+  @service declare authenticatedUser: AuthenticatedUserService;
   @service("config") declare configSvc: ConfigService;
   @service("fetch") declare fetchSvc: FetchService;
   @service declare router: RouterService;

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -418,7 +418,7 @@
                     this.requestChanges.isRunning
                     this.hasApproved
                   )}}
-                  {{on "click" (perform this.approve @profile.email)}}
+                  {{on "click" (perform this.approve)}}
                 />
                 {{#if (eq @document.docType "FRD")}}
                   <Hds::Button
@@ -432,7 +432,7 @@
                       this.requestChanges.isRunning
                       this.hasRequestedChanges
                     )}}
-                    {{on "click" (perform this.requestChanges @profile.email)}}
+                    {{on "click" (perform this.requestChanges)}}
                   />
                 {{/if}}
               </div>


### PR DESCRIPTION
Fixes the import and type of the Document component's AuthenticatedUser service. (The previous code was showing a Glint warning.)

Also removes unnecessary arguments from the `approve` and `requestChanges` calls. Reference: https://github.com/hashicorp-forge/hermes/blob/main/web/app/components/document/sidebar.ts#L869-L908