### PR TITLE
Move Mirage `utils` out of app directory

### DIFF
--- a/web/app/utils/hermes-urls.ts
+++ b/web/app/utils/hermes-urls.ts
@@ -1,14 +1,2 @@
 export const HERMES_GITHUB_REPO_URL =
   "https://github.com/hashicorp-forge/hermes";
-
-/**
- * These values are loaded by the Mirage in acceptance tests.
- *
- * To mock them in rendering tests, set them directly on the service, e.g.,
- * let mockConfigSvc = this.owner.lookup("service:config") as ConfigService;
- * mockConfigSvc.config.support_link_url = SUPPORT_URL;
- */
-export const TEST_SUPPORT_URL = "https://config-loaded-support-link.com";
-export const TEST_SHORT_LINK_BASE_URL =
-  "https://config-loaded-short-link-base-url.com";
-export const TEST_JIRA_WORKSPACE_URL = "https://hashicorp.atlassian.net";

--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -11,7 +11,7 @@ import {
   TEST_USER_EMAIL,
   TEST_USER_NAME,
   TEST_USER_GIVEN_NAME,
-} from "../mirage/mirage-utils";
+} from "../mirage/utils";
 
 export default function (mirageConfig) {
   let finalConfig = {

--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -11,7 +11,7 @@ import {
   TEST_USER_EMAIL,
   TEST_USER_NAME,
   TEST_USER_GIVEN_NAME,
-} from "hermes/utils/mirage-utils";
+} from "../mirage/mirage-utils";
 
 export default function (mirageConfig) {
   let finalConfig = {

--- a/web/mirage/factories/document.ts
+++ b/web/mirage/factories/document.ts
@@ -1,5 +1,5 @@
 import { Factory } from "miragejs";
-import { TEST_USER_EMAIL, TEST_USER_PHOTO } from "hermes/utils/mirage-utils";
+import { TEST_USER_EMAIL, TEST_USER_PHOTO } from "../mirage-utils";
 
 export function getTestDocNumber(product: string) {
   let abbreviation = "";

--- a/web/mirage/factories/document.ts
+++ b/web/mirage/factories/document.ts
@@ -1,5 +1,5 @@
 import { Factory } from "miragejs";
-import { TEST_USER_EMAIL, TEST_USER_PHOTO } from "../mirage-utils";
+import { TEST_USER_EMAIL, TEST_USER_PHOTO } from "../utils";
 
 export function getTestDocNumber(product: string) {
   let abbreviation = "";

--- a/web/mirage/factories/jira-issue.ts
+++ b/web/mirage/factories/jira-issue.ts
@@ -9,7 +9,7 @@ import {
   TEST_JIRA_ISSUE_STATUS,
   TEST_JIRA_ISSUE_URL,
   TEST_JIRA_ISSUE_SUMMARY,
-} from "hermes/utils/mirage-utils";
+} from "../mirage-utils";
 
 export default Factory.extend({
   id: (i) => i, // mirage only

--- a/web/mirage/factories/jira-issue.ts
+++ b/web/mirage/factories/jira-issue.ts
@@ -9,7 +9,7 @@ import {
   TEST_JIRA_ISSUE_STATUS,
   TEST_JIRA_ISSUE_URL,
   TEST_JIRA_ISSUE_SUMMARY,
-} from "../mirage-utils";
+} from "../utils";
 
 export default Factory.extend({
   id: (i) => i, // mirage only

--- a/web/mirage/factories/jira-picker-result.ts
+++ b/web/mirage/factories/jira-picker-result.ts
@@ -3,7 +3,7 @@ import {
   TEST_JIRA_ISSUE_SUMMARY,
   TEST_JIRA_ISSUE_URL,
   TEST_JIRA_ISSUE_TYPE_IMAGE,
-} from "hermes/utils/mirage-utils";
+} from "../mirage-utils";
 
 export default Factory.extend({
   id: (i) => i, // Mirage-only

--- a/web/mirage/factories/jira-picker-result.ts
+++ b/web/mirage/factories/jira-picker-result.ts
@@ -3,7 +3,7 @@ import {
   TEST_JIRA_ISSUE_SUMMARY,
   TEST_JIRA_ISSUE_URL,
   TEST_JIRA_ISSUE_TYPE_IMAGE,
-} from "../mirage-utils";
+} from "../utils";
 
 export default Factory.extend({
   id: (i) => i, // Mirage-only

--- a/web/mirage/factories/me.ts
+++ b/web/mirage/factories/me.ts
@@ -3,7 +3,7 @@ import {
   TEST_USER_EMAIL,
   TEST_USER_NAME,
   TEST_USER_GIVEN_NAME,
-} from "../mirage-utils";
+} from "../utils";
 
 export default Factory.extend({
   id: "123456789",

--- a/web/mirage/factories/me.ts
+++ b/web/mirage/factories/me.ts
@@ -3,7 +3,7 @@ import {
   TEST_USER_EMAIL,
   TEST_USER_NAME,
   TEST_USER_GIVEN_NAME,
-} from "hermes/utils/mirage-utils";
+} from "../mirage-utils";
 
 export default Factory.extend({
   id: "123456789",

--- a/web/mirage/factories/project.ts
+++ b/web/mirage/factories/project.ts
@@ -1,6 +1,6 @@
 import { Factory, ModelInstance, Server } from "miragejs";
 import { HermesProject } from "hermes/types/project";
-import { TEST_USER_EMAIL } from "hermes/utils/mirage-utils";
+import { TEST_USER_EMAIL } from "../mirage-utils";
 
 export default Factory.extend({
   id: (i: number) => i,

--- a/web/mirage/factories/project.ts
+++ b/web/mirage/factories/project.ts
@@ -1,6 +1,6 @@
 import { Factory, ModelInstance, Server } from "miragejs";
 import { HermesProject } from "hermes/types/project";
-import { TEST_USER_EMAIL } from "../mirage-utils";
+import { TEST_USER_EMAIL } from "../utils";
 
 export default Factory.extend({
   id: (i: number) => i,

--- a/web/mirage/factories/related-hermes-document.ts
+++ b/web/mirage/factories/related-hermes-document.ts
@@ -1,5 +1,5 @@
 import { Factory } from "miragejs";
-import { TEST_USER_EMAIL, TEST_USER_PHOTO } from "../mirage-utils";
+import { TEST_USER_EMAIL, TEST_USER_PHOTO } from "../utils";
 
 export default Factory.extend({
   id: (i) => `doc-${i}`,

--- a/web/mirage/factories/related-hermes-document.ts
+++ b/web/mirage/factories/related-hermes-document.ts
@@ -1,5 +1,5 @@
 import { Factory } from "miragejs";
-import { TEST_USER_EMAIL, TEST_USER_PHOTO } from "hermes/utils/mirage-utils";
+import { TEST_USER_EMAIL, TEST_USER_PHOTO } from "../mirage-utils";
 
 export default Factory.extend({
   id: (i) => `doc-${i}`,

--- a/web/mirage/mirage-utils.ts
+++ b/web/mirage/mirage-utils.ts
@@ -1,13 +1,7 @@
 import { MirageTestContext } from "ember-cli-mirage/test-support";
-import { HermesConfig } from "hermes/config/environment";
 import AuthenticatedUserService from "hermes/services/authenticated-user";
 import ConfigService from "hermes/services/config";
-import config from "../config/environment";
-import {
-  TEST_JIRA_WORKSPACE_URL,
-  TEST_SHORT_LINK_BASE_URL,
-  TEST_SUPPORT_URL,
-} from "./hermes-urls";
+import config from "../app/config/environment";
 
 export const TEST_USER_NAME = "Test user";
 export const TEST_USER_EMAIL = "testuser@hashicorp.com";
@@ -29,6 +23,18 @@ export const TEST_JIRA_ISSUE_TYPE = "Task";
 export const TEST_JIRA_ISSUE_TYPE_IMAGE = "test-jira-issue-type-image.com";
 export const TEST_JIRA_PRIORITY = "Medium";
 export const TEST_JIRA_PRIORITY_IMAGE = "https://test-jira-priority-image.com";
+
+/**
+ * These values are loaded by the Mirage in acceptance tests.
+ *
+ * To mock them in rendering tests, set them directly on the service, e.g.,
+ * let mockConfigSvc = this.owner.lookup("service:config") as ConfigService;
+ * mockConfigSvc.config.support_link_url = SUPPORT_URL;
+ */
+export const TEST_SUPPORT_URL = "https://config-loaded-support-link.com";
+export const TEST_SHORT_LINK_BASE_URL =
+  "https://config-loaded-short-link-base-url.com";
+export const TEST_JIRA_WORKSPACE_URL = "https://hashicorp.atlassian.net";
 
 export const TEST_WEB_CONFIG = {
   algolia_docs_index_name: config.algolia.docsIndexName,

--- a/web/mirage/utils.ts
+++ b/web/mirage/utils.ts
@@ -1,7 +1,7 @@
 import { MirageTestContext } from "ember-cli-mirage/test-support";
 import AuthenticatedUserService from "hermes/services/authenticated-user";
 import ConfigService from "hermes/services/config";
-import config from "../app/config/environment";
+import config from "hermes/config/environment";
 
 export const TEST_USER_NAME = "Test user";
 export const TEST_USER_EMAIL = "testuser@hashicorp.com";

--- a/web/tests/acceptance/application-test.ts
+++ b/web/tests/acceptance/application-test.ts
@@ -7,7 +7,7 @@ import {
 } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import SessionService from "hermes/services/session";
-import { TEST_SUPPORT_URL } from "hermes/utils/hermes-urls";
+import { TEST_SUPPORT_URL } from "hermes/mirage/mirage-utils";
 
 module("Acceptance | application", function (hooks) {
   setupApplicationTest(hooks);

--- a/web/tests/acceptance/application-test.ts
+++ b/web/tests/acceptance/application-test.ts
@@ -7,7 +7,7 @@ import {
 } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import SessionService from "hermes/services/session";
-import { TEST_SUPPORT_URL } from "hermes/mirage/mirage-utils";
+import { TEST_SUPPORT_URL } from "hermes/mirage/utils";
 
 module("Acceptance | application", function (hooks) {
   setupApplicationTest(hooks);

--- a/web/tests/acceptance/authenticated/document-test.ts
+++ b/web/tests/acceptance/authenticated/document-test.ts
@@ -22,12 +22,12 @@ import {
 } from "hermes/components/document/sidebar";
 import { capitalize } from "@ember/string";
 import window from "ember-window-mock";
-import { TEST_SHORT_LINK_BASE_URL } from "hermes/utils/hermes-urls";
+import { TEST_SHORT_LINK_BASE_URL } from "hermes/mirage/mirage-utils";
 import {
   TEST_USER_2_EMAIL,
   TEST_USER_3_EMAIL,
   TEST_USER_EMAIL,
-} from "hermes/utils/mirage-utils";
+} from "hermes/mirage/mirage-utils";
 import { current } from "ember-animated/.";
 
 const ADD_RELATED_RESOURCE_BUTTON_SELECTOR =

--- a/web/tests/acceptance/authenticated/document-test.ts
+++ b/web/tests/acceptance/authenticated/document-test.ts
@@ -22,12 +22,12 @@ import {
 } from "hermes/components/document/sidebar";
 import { capitalize } from "@ember/string";
 import window from "ember-window-mock";
-import { TEST_SHORT_LINK_BASE_URL } from "hermes/mirage/mirage-utils";
+import { TEST_SHORT_LINK_BASE_URL } from "hermes/mirage/utils";
 import {
   TEST_USER_2_EMAIL,
   TEST_USER_3_EMAIL,
   TEST_USER_EMAIL,
-} from "hermes/mirage/mirage-utils";
+} from "hermes/mirage/utils";
 import { current } from "ember-animated/.";
 
 const ADD_RELATED_RESOURCE_BUTTON_SELECTOR =

--- a/web/tests/acceptance/authenticated/my/documents-test.ts
+++ b/web/tests/acceptance/authenticated/my/documents-test.ts
@@ -4,7 +4,7 @@ import { module, test } from "qunit";
 import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
-import { TEST_USER_2_EMAIL, TEST_USER_EMAIL } from "hermes/utils/mirage-utils";
+import { TEST_USER_2_EMAIL, TEST_USER_EMAIL } from "hermes/mirage/mirage-utils";
 
 const SORTABLE_HEADER = "[data-test-attribute=modifiedTime]";
 const OWNER_FILTER = "[data-test-owner-filter]";

--- a/web/tests/acceptance/authenticated/my/documents-test.ts
+++ b/web/tests/acceptance/authenticated/my/documents-test.ts
@@ -4,7 +4,7 @@ import { module, test } from "qunit";
 import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
-import { TEST_USER_2_EMAIL, TEST_USER_EMAIL } from "hermes/mirage/mirage-utils";
+import { TEST_USER_2_EMAIL, TEST_USER_EMAIL } from "hermes/mirage/utils";
 
 const SORTABLE_HEADER = "[data-test-attribute=modifiedTime]";
 const OWNER_FILTER = "[data-test-owner-filter]";

--- a/web/tests/acceptance/authenticated/new/doc-test.ts
+++ b/web/tests/acceptance/authenticated/new/doc-test.ts
@@ -15,7 +15,7 @@ import { Response } from "miragejs";
 import RouterService from "@ember/routing/router-service";
 import window from "ember-window-mock";
 import { DRAFT_CREATED_LOCAL_STORAGE_KEY } from "hermes/components/modals/draft-created";
-import { TEST_WEB_CONFIG } from "hermes/mirage/mirage-utils";
+import { TEST_WEB_CONFIG } from "hermes/mirage/utils";
 
 // Selectors
 const DOC_FORM = "[data-test-new-doc-form]";

--- a/web/tests/acceptance/authenticated/new/doc-test.ts
+++ b/web/tests/acceptance/authenticated/new/doc-test.ts
@@ -15,7 +15,7 @@ import { Response } from "miragejs";
 import RouterService from "@ember/routing/router-service";
 import window from "ember-window-mock";
 import { DRAFT_CREATED_LOCAL_STORAGE_KEY } from "hermes/components/modals/draft-created";
-import { TEST_WEB_CONFIG } from "hermes/utils/mirage-utils";
+import { TEST_WEB_CONFIG } from "hermes/mirage/mirage-utils";
 
 // Selectors
 const DOC_FORM = "[data-test-new-doc-form]";

--- a/web/tests/acceptance/authenticated/new/project-test.ts
+++ b/web/tests/acceptance/authenticated/new/project-test.ts
@@ -3,7 +3,7 @@ import { click, currentURL, fillIn, visit, waitFor } from "@ember/test-helpers";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { setupApplicationTest } from "ember-qunit";
 import { authenticateSession } from "ember-simple-auth/test-support";
-import { TEST_WEB_CONFIG } from "hermes/utils/mirage-utils";
+import { TEST_WEB_CONFIG } from "hermes/mirage/mirage-utils";
 import { Response } from "miragejs";
 import { module, test } from "qunit";
 

--- a/web/tests/acceptance/authenticated/new/project-test.ts
+++ b/web/tests/acceptance/authenticated/new/project-test.ts
@@ -3,7 +3,7 @@ import { click, currentURL, fillIn, visit, waitFor } from "@ember/test-helpers";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { setupApplicationTest } from "ember-qunit";
 import { authenticateSession } from "ember-simple-auth/test-support";
-import { TEST_WEB_CONFIG } from "hermes/mirage/mirage-utils";
+import { TEST_WEB_CONFIG } from "hermes/mirage/utils";
 import { Response } from "miragejs";
 import { module, test } from "qunit";
 

--- a/web/tests/acceptance/authenticated/projects/project-test.ts
+++ b/web/tests/acceptance/authenticated/projects/project-test.ts
@@ -16,7 +16,7 @@ import {
   TEST_USER_EMAIL,
   TEST_USER_PHOTO,
   TEST_WEB_CONFIG,
-} from "hermes/mirage/mirage-utils";
+} from "hermes/mirage/utils";
 import MockDate from "mockdate";
 import { DEFAULT_MOCK_DATE } from "hermes/utils/mockdate/dates";
 

--- a/web/tests/acceptance/authenticated/projects/project-test.ts
+++ b/web/tests/acceptance/authenticated/projects/project-test.ts
@@ -16,7 +16,7 @@ import {
   TEST_USER_EMAIL,
   TEST_USER_PHOTO,
   TEST_WEB_CONFIG,
-} from "hermes/utils/mirage-utils";
+} from "hermes/mirage/mirage-utils";
 import MockDate from "mockdate";
 import { DEFAULT_MOCK_DATE } from "hermes/utils/mockdate/dates";
 

--- a/web/tests/integration/components/custom-editable-field-test.ts
+++ b/web/tests/integration/components/custom-editable-field-test.ts
@@ -4,7 +4,7 @@ import { click, fillIn, find, findAll, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { HermesDocument, HermesUser } from "hermes/types/document";
-import { authenticateTestUser } from "hermes/mirage/mirage-utils";
+import { authenticateTestUser } from "hermes/mirage/utils";
 
 interface CustomEditableFieldComponentTestContext extends MirageTestContext {
   attributes: any;

--- a/web/tests/integration/components/custom-editable-field-test.ts
+++ b/web/tests/integration/components/custom-editable-field-test.ts
@@ -4,7 +4,7 @@ import { click, fillIn, find, findAll, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { HermesDocument, HermesUser } from "hermes/types/document";
-import { authenticateTestUser } from "hermes/utils/mirage-utils";
+import { authenticateTestUser } from "hermes/mirage/mirage-utils";
 
 interface CustomEditableFieldComponentTestContext extends MirageTestContext {
   attributes: any;

--- a/web/tests/integration/components/dashboard/docs-awaiting-review-test.ts
+++ b/web/tests/integration/components/dashboard/docs-awaiting-review-test.ts
@@ -4,7 +4,7 @@ import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { click, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { HermesDocument } from "hermes/types/document";
-import { TEST_USER_EMAIL } from "hermes/utils/mirage-utils";
+import { TEST_USER_EMAIL } from "hermes/mirage/mirage-utils";
 
 const DOCS_AWAITING_REVIEW_COUNT_SELECTOR =
   "[data-test-docs-awaiting-review-count]";

--- a/web/tests/integration/components/dashboard/docs-awaiting-review-test.ts
+++ b/web/tests/integration/components/dashboard/docs-awaiting-review-test.ts
@@ -4,7 +4,7 @@ import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { click, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { HermesDocument } from "hermes/types/document";
-import { TEST_USER_EMAIL } from "hermes/mirage/mirage-utils";
+import { TEST_USER_EMAIL } from "hermes/mirage/utils";
 
 const DOCS_AWAITING_REVIEW_COUNT_SELECTOR =
   "[data-test-docs-awaiting-review-count]";

--- a/web/tests/integration/components/dashboard/docs-awaiting-review/doc-test.ts
+++ b/web/tests/integration/components/dashboard/docs-awaiting-review/doc-test.ts
@@ -4,7 +4,7 @@ import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { find, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { HermesDocument } from "hermes/types/document";
-import { TEST_USER_2_EMAIL, TEST_USER_EMAIL } from "hermes/utils/mirage-utils";
+import { TEST_USER_2_EMAIL, TEST_USER_EMAIL } from "hermes/mirage/mirage-utils";
 
 const DOC_AWAITING_REVIEW_LINK_SELECTOR =
   "[data-test-doc-awaiting-review-link]";

--- a/web/tests/integration/components/dashboard/docs-awaiting-review/doc-test.ts
+++ b/web/tests/integration/components/dashboard/docs-awaiting-review/doc-test.ts
@@ -4,7 +4,7 @@ import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { find, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { HermesDocument } from "hermes/types/document";
-import { TEST_USER_2_EMAIL, TEST_USER_EMAIL } from "hermes/mirage/mirage-utils";
+import { TEST_USER_2_EMAIL, TEST_USER_EMAIL } from "hermes/mirage/utils";
 
 const DOC_AWAITING_REVIEW_LINK_SELECTOR =
   "[data-test-doc-awaiting-review-link]";

--- a/web/tests/integration/components/doc/thumbnail-test.ts
+++ b/web/tests/integration/components/doc/thumbnail-test.ts
@@ -7,7 +7,6 @@ import { setupProductIndex } from "hermes/tests/mirage-helpers/utils";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import ConfigService from "hermes/services/config";
 import { Response } from "miragejs";
-import { setFeatureFlag } from "hermes/utils/mirage-utils";
 
 const THUMBNAIL = "[data-test-doc-thumbnail]";
 const PRODUCT_BADGE = "[data-test-doc-thumbnail-product-badge]";

--- a/web/tests/integration/components/doc/tile-medium-test.ts
+++ b/web/tests/integration/components/doc/tile-medium-test.ts
@@ -5,7 +5,7 @@ import { setupRenderingTest } from "ember-qunit";
 import { module, test } from "qunit";
 import { RelatedHermesDocument } from "hermes/components/related-resources";
 import { HermesDocument } from "hermes/types/document";
-import { TEST_USER_EMAIL, TEST_USER_PHOTO } from "hermes/utils/mirage-utils";
+import { TEST_USER_EMAIL, TEST_USER_PHOTO } from "hermes/mirage/mirage-utils";
 
 const AVATAR_LINK = "[data-test-document-owner-avatar]";
 const AVATAR_IMAGE = `${AVATAR_LINK} img`;

--- a/web/tests/integration/components/doc/tile-medium-test.ts
+++ b/web/tests/integration/components/doc/tile-medium-test.ts
@@ -5,7 +5,7 @@ import { setupRenderingTest } from "ember-qunit";
 import { module, test } from "qunit";
 import { RelatedHermesDocument } from "hermes/components/related-resources";
 import { HermesDocument } from "hermes/types/document";
-import { TEST_USER_EMAIL, TEST_USER_PHOTO } from "hermes/mirage/mirage-utils";
+import { TEST_USER_EMAIL, TEST_USER_PHOTO } from "hermes/mirage/utils";
 
 const AVATAR_LINK = "[data-test-document-owner-avatar]";
 const AVATAR_IMAGE = `${AVATAR_LINK} img`;

--- a/web/tests/integration/components/document/sidebar-test.ts
+++ b/web/tests/integration/components/document/sidebar-test.ts
@@ -9,7 +9,7 @@ import AuthenticatedUserService, {
 } from "hermes/services/authenticated-user";
 import { HermesDocument } from "hermes/types/document";
 import { HermesDocumentType } from "hermes/types/document-type";
-import { TEST_USER_2_EMAIL, TEST_USER_EMAIL } from "hermes/utils/mirage-utils";
+import { TEST_USER_2_EMAIL, TEST_USER_EMAIL } from "hermes/mirage/mirage-utils";
 
 const SUMMARY_CONTAINER = "[data-test-document-summary]";
 const SUMMARY_EMPTY_STATE = `${SUMMARY_CONTAINER} .empty-state-text`;

--- a/web/tests/integration/components/document/sidebar-test.ts
+++ b/web/tests/integration/components/document/sidebar-test.ts
@@ -9,7 +9,7 @@ import AuthenticatedUserService, {
 } from "hermes/services/authenticated-user";
 import { HermesDocument } from "hermes/types/document";
 import { HermesDocumentType } from "hermes/types/document-type";
-import { TEST_USER_2_EMAIL, TEST_USER_EMAIL } from "hermes/mirage/mirage-utils";
+import { TEST_USER_2_EMAIL, TEST_USER_EMAIL } from "hermes/mirage/utils";
 
 const SUMMARY_CONTAINER = "[data-test-document-summary]";
 const SUMMARY_EMPTY_STATE = `${SUMMARY_CONTAINER} .empty-state-text`;

--- a/web/tests/integration/components/editable-field-test.ts
+++ b/web/tests/integration/components/editable-field-test.ts
@@ -2,7 +2,7 @@ import { click, fillIn, render, triggerKeyEvent } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { MirageTestContext } from "ember-cli-mirage/test-support";
 import { setupRenderingTest } from "ember-qunit";
-import { authenticateTestUser } from "hermes/utils/mirage-utils";
+import { authenticateTestUser } from "hermes/mirage/mirage-utils";
 import { module, test } from "qunit";
 
 const EDITABLE_FIELD = ".editable-field";

--- a/web/tests/integration/components/editable-field-test.ts
+++ b/web/tests/integration/components/editable-field-test.ts
@@ -2,7 +2,7 @@ import { click, fillIn, render, triggerKeyEvent } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { MirageTestContext } from "ember-cli-mirage/test-support";
 import { setupRenderingTest } from "ember-qunit";
-import { authenticateTestUser } from "hermes/mirage/mirage-utils";
+import { authenticateTestUser } from "hermes/mirage/utils";
 import { module, test } from "qunit";
 
 const EDITABLE_FIELD = ".editable-field";

--- a/web/tests/integration/components/editable-field/read-value-test.ts
+++ b/web/tests/integration/components/editable-field/read-value-test.ts
@@ -3,7 +3,7 @@ import { hbs } from "ember-cli-htmlbars";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { setupRenderingTest } from "ember-qunit";
 import { HermesUser } from "hermes/types/document";
-import { authenticateTestUser } from "hermes/mirage/mirage-utils";
+import { authenticateTestUser } from "hermes/mirage/utils";
 import { module, test } from "qunit";
 
 interface EditableFieldReadValueComponentTestContext extends MirageTestContext {

--- a/web/tests/integration/components/editable-field/read-value-test.ts
+++ b/web/tests/integration/components/editable-field/read-value-test.ts
@@ -3,7 +3,7 @@ import { hbs } from "ember-cli-htmlbars";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { setupRenderingTest } from "ember-qunit";
 import { HermesUser } from "hermes/types/document";
-import { authenticateTestUser } from "hermes/utils/mirage-utils";
+import { authenticateTestUser } from "hermes/mirage/mirage-utils";
 import { module, test } from "qunit";
 
 interface EditableFieldReadValueComponentTestContext extends MirageTestContext {

--- a/web/tests/integration/components/header/nav-test.ts
+++ b/web/tests/integration/components/header/nav-test.ts
@@ -12,7 +12,7 @@ import {
   TEST_USER_2_EMAIL,
   TEST_USER_2_GIVEN_NAME,
   TEST_USER_2_NAME,
-} from "hermes/utils/mirage-utils";
+} from "hermes/mirage/mirage-utils";
 
 const SUPPORT_URL = "https://example.com/support";
 const USER_MENU_TOGGLE_SELECTOR = "[data-test-user-menu-toggle]";

--- a/web/tests/integration/components/header/nav-test.ts
+++ b/web/tests/integration/components/header/nav-test.ts
@@ -12,7 +12,7 @@ import {
   TEST_USER_2_EMAIL,
   TEST_USER_2_GIVEN_NAME,
   TEST_USER_2_NAME,
-} from "hermes/mirage/mirage-utils";
+} from "hermes/mirage/utils";
 
 const SUPPORT_URL = "https://example.com/support";
 const USER_MENU_TOGGLE_SELECTOR = "[data-test-user-menu-toggle]";

--- a/web/tests/integration/components/header/search-test.ts
+++ b/web/tests/integration/components/header/search-test.ts
@@ -4,7 +4,7 @@ import { hbs } from "ember-cli-htmlbars";
 import { click, fillIn, render, triggerKeyEvent } from "@ember/test-helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
 import { MirageTestContext } from "ember-cli-mirage/test-support";
-import { authenticateTestUser } from "hermes/utils/mirage-utils";
+import { authenticateTestUser } from "hermes/mirage/mirage-utils";
 
 const KEYBOARD_SHORTCUT_SELECTOR = ".global-search-shortcut-affordance";
 const SEARCH_INPUT_SELECTOR = "[data-test-global-search-input]";

--- a/web/tests/integration/components/header/search-test.ts
+++ b/web/tests/integration/components/header/search-test.ts
@@ -4,7 +4,7 @@ import { hbs } from "ember-cli-htmlbars";
 import { click, fillIn, render, triggerKeyEvent } from "@ember/test-helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
 import { MirageTestContext } from "ember-cli-mirage/test-support";
-import { authenticateTestUser } from "hermes/mirage/mirage-utils";
+import { authenticateTestUser } from "hermes/mirage/utils";
 
 const KEYBOARD_SHORTCUT_SELECTOR = ".global-search-shortcut-affordance";
 const SEARCH_INPUT_SELECTOR = "[data-test-global-search-input]";

--- a/web/tests/integration/components/inputs/people-select-test.ts
+++ b/web/tests/integration/components/inputs/people-select-test.ts
@@ -6,7 +6,7 @@ import { setupMirage } from "ember-cli-mirage/test-support";
 import { MirageTestContext } from "ember-cli-mirage/test-support";
 import { HermesUser } from "hermes/types/document";
 import FetchService from "hermes/services/fetch";
-import { authenticateTestUser } from "hermes/utils/mirage-utils";
+import { authenticateTestUser } from "hermes/mirage/mirage-utils";
 
 interface PeopleSelectContext extends MirageTestContext {
   people: HermesUser[];

--- a/web/tests/integration/components/inputs/people-select-test.ts
+++ b/web/tests/integration/components/inputs/people-select-test.ts
@@ -6,7 +6,7 @@ import { setupMirage } from "ember-cli-mirage/test-support";
 import { MirageTestContext } from "ember-cli-mirage/test-support";
 import { HermesUser } from "hermes/types/document";
 import FetchService from "hermes/services/fetch";
-import { authenticateTestUser } from "hermes/mirage/mirage-utils";
+import { authenticateTestUser } from "hermes/mirage/utils";
 
 interface PeopleSelectContext extends MirageTestContext {
   people: HermesUser[];

--- a/web/tests/integration/components/my/docs-test.ts
+++ b/web/tests/integration/components/my/docs-test.ts
@@ -6,7 +6,7 @@ import { HermesDocument } from "hermes/types/document";
 import { module, test } from "qunit";
 import MockDate from "mockdate";
 import { DEFAULT_MOCK_DATE } from "hermes/utils/mockdate/dates";
-import { authenticateTestUser } from "hermes/mirage/mirage-utils";
+import { authenticateTestUser } from "hermes/mirage/utils";
 import { SortDirection } from "hermes/components/table/sortable-header";
 
 const PAGINATION = "[data-test-pagination]";

--- a/web/tests/integration/components/my/docs-test.ts
+++ b/web/tests/integration/components/my/docs-test.ts
@@ -6,7 +6,7 @@ import { HermesDocument } from "hermes/types/document";
 import { module, test } from "qunit";
 import MockDate from "mockdate";
 import { DEFAULT_MOCK_DATE } from "hermes/utils/mockdate/dates";
-import { authenticateTestUser } from "hermes/utils/mirage-utils";
+import { authenticateTestUser } from "hermes/mirage/mirage-utils";
 import { SortDirection } from "hermes/components/table/sortable-header";
 
 const PAGINATION = "[data-test-pagination]";

--- a/web/tests/integration/components/my/header-test.ts
+++ b/web/tests/integration/components/my/header-test.ts
@@ -6,7 +6,7 @@ import {
   TEST_USER_EMAIL,
   TEST_USER_NAME,
   authenticateTestUser,
-} from "hermes/utils/mirage-utils";
+} from "hermes/mirage/mirage-utils";
 import { module, test } from "qunit";
 
 const AVATAR = "[data-test-avatar]";

--- a/web/tests/integration/components/my/header-test.ts
+++ b/web/tests/integration/components/my/header-test.ts
@@ -6,7 +6,7 @@ import {
   TEST_USER_EMAIL,
   TEST_USER_NAME,
   authenticateTestUser,
-} from "hermes/mirage/mirage-utils";
+} from "hermes/mirage/utils";
 import { module, test } from "qunit";
 
 const AVATAR = "[data-test-avatar]";

--- a/web/tests/integration/components/person-test.ts
+++ b/web/tests/integration/components/person-test.ts
@@ -6,7 +6,7 @@ import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import {
   TEST_USER_EMAIL,
   authenticateTestUser,
-} from "hermes/utils/mirage-utils";
+} from "hermes/mirage/mirage-utils";
 
 const APPROVED_BADGE = "[data-test-person-approved-badge]";
 

--- a/web/tests/integration/components/person-test.ts
+++ b/web/tests/integration/components/person-test.ts
@@ -3,10 +3,7 @@ import { setupRenderingTest } from "ember-qunit";
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
-import {
-  TEST_USER_EMAIL,
-  authenticateTestUser,
-} from "hermes/mirage/mirage-utils";
+import { TEST_USER_EMAIL, authenticateTestUser } from "hermes/mirage/utils";
 
 const APPROVED_BADGE = "[data-test-person-approved-badge]";
 

--- a/web/tests/integration/components/product/avatar-test.ts
+++ b/web/tests/integration/components/product/avatar-test.ts
@@ -4,7 +4,6 @@ import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { setupRenderingTest } from "ember-qunit";
 import ConfigService from "hermes/services/config";
 import { setupProductIndex } from "hermes/tests/mirage-helpers/utils";
-import { setFeatureFlag } from "hermes/utils/mirage-utils";
 import { module, test } from "qunit";
 
 const AVATAR = "[data-test-product-avatar]";

--- a/web/tests/integration/components/project/jira-widget-test.ts
+++ b/web/tests/integration/components/project/jira-widget-test.ts
@@ -7,8 +7,8 @@ import { JiraIssue, JiraPickerResult } from "hermes/types/project";
 import {
   TEST_JIRA_ISSUE_SUMMARY,
   setWebConfig,
-} from "hermes/utils/mirage-utils";
-import { TEST_JIRA_WORKSPACE_URL } from "hermes/utils/hermes-urls";
+} from "hermes/mirage/mirage-utils";
+import { TEST_JIRA_WORKSPACE_URL } from "hermes/mirage/mirage-utils";
 
 const JIRA_ICON = "[data-test-jira-icon]";
 const ADD_JIRA_INPUT = "[data-test-add-jira-input]";

--- a/web/tests/integration/components/project/jira-widget-test.ts
+++ b/web/tests/integration/components/project/jira-widget-test.ts
@@ -4,11 +4,8 @@ import { setupRenderingTest } from "ember-qunit";
 import { click, fillIn, find, render, waitFor } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { JiraIssue, JiraPickerResult } from "hermes/types/project";
-import {
-  TEST_JIRA_ISSUE_SUMMARY,
-  setWebConfig,
-} from "hermes/mirage/mirage-utils";
-import { TEST_JIRA_WORKSPACE_URL } from "hermes/mirage/mirage-utils";
+import { TEST_JIRA_ISSUE_SUMMARY, setWebConfig } from "hermes/mirage/utils";
+import { TEST_JIRA_WORKSPACE_URL } from "hermes/mirage/utils";
 
 const JIRA_ICON = "[data-test-jira-icon]";
 const ADD_JIRA_INPUT = "[data-test-add-jira-input]";

--- a/web/tests/integration/components/table/row-test.ts
+++ b/web/tests/integration/components/table/row-test.ts
@@ -4,7 +4,7 @@ import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { setupRenderingTest } from "ember-qunit";
 import { TimeColumn } from "hermes/components/table/row";
 import { HermesDocument } from "hermes/types/document";
-import { authenticateTestUser } from "hermes/utils/mirage-utils";
+import { authenticateTestUser } from "hermes/mirage/mirage-utils";
 import { module, test } from "qunit";
 import MockDate from "mockdate";
 import { DEFAULT_MOCK_DATE } from "hermes/utils/mockdate/dates";

--- a/web/tests/integration/components/table/row-test.ts
+++ b/web/tests/integration/components/table/row-test.ts
@@ -4,7 +4,7 @@ import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { setupRenderingTest } from "ember-qunit";
 import { TimeColumn } from "hermes/components/table/row";
 import { HermesDocument } from "hermes/types/document";
-import { authenticateTestUser } from "hermes/mirage/mirage-utils";
+import { authenticateTestUser } from "hermes/mirage/utils";
 import { module, test } from "qunit";
 import MockDate from "mockdate";
 import { DEFAULT_MOCK_DATE } from "hermes/utils/mockdate/dates";

--- a/web/tests/integration/helpers/has-approved-doc-test.ts
+++ b/web/tests/integration/helpers/has-approved-doc-test.ts
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { TEST_USER_EMAIL } from "hermes/mirage/mirage-utils";
+import { TEST_USER_EMAIL } from "hermes/mirage/utils";
 
 module("Integration | Helper | has-approved-doc", function (hooks) {
   setupRenderingTest(hooks);

--- a/web/tests/integration/helpers/has-approved-doc-test.ts
+++ b/web/tests/integration/helpers/has-approved-doc-test.ts
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { TEST_USER_EMAIL } from "hermes/utils/mirage-utils";
+import { TEST_USER_EMAIL } from "hermes/mirage/mirage-utils";
 
 module("Integration | Helper | has-approved-doc", function (hooks) {
   setupRenderingTest(hooks);

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -30,6 +30,6 @@
     "node_modules/@gavant/glint-template-types/types/ember-render-modifiers/*",
     "node_modules/@gavant/glint-template-types/types/ember-truth-helpers/*",
     "node_modules/@gavant/glint-template-types/types/ember-power-select/**/*",
-    "mirage/mirage-utils.ts"
+    "mirage/utils.ts"
   ]
 }

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -29,6 +29,7 @@
     "node_modules/@gavant/glint-template-types/types/ember-on-helper/on-document.d.ts",
     "node_modules/@gavant/glint-template-types/types/ember-render-modifiers/*",
     "node_modules/@gavant/glint-template-types/types/ember-truth-helpers/*",
-    "node_modules/@gavant/glint-template-types/types/ember-power-select/**/*"
+    "node_modules/@gavant/glint-template-types/types/ember-power-select/**/*",
+    "mirage/mirage-utils.ts"
   ]
 }


### PR DESCRIPTION
Moves the Mirage utils from the `app/utils` folder and into the `mirage` directory. Also moves test-only URLs out of `app/utils/hermes-urls` and into the Mirage `utils` file.