### PR TITLE
Post-publish: Set `draftWasPublished` sooner

### DIFF
--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -715,9 +715,9 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
       this.refreshRoute();
 
       this.status = "In-Review";
+      this.draftWasPublished = true;
 
       await this.waitForDocNumber.perform();
-      this.draftWasPublished = true;
       this.requestReviewModalIsShown = false;
       this.docPublishedModalIsShown = true;
     } catch (error: unknown) {


### PR DESCRIPTION
Sets `draftWasPublished` attribute sooner so the UI updates more elegantly. Makes it so the `inverted` DocStatus badge isn't briefly visible when moving a draft into in review.