### PR TITLE
Increase z-index of visibility toggle

### DIFF
--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -115,7 +115,7 @@
                 <dd.ToggleAction
                   data-test-draft-visibility-toggle
                   data-test-icon={{this.draftVisibilityIcon}}
-                  class="quarternary-button draft-visibility-button flex items-center"
+                  class="quarternary-button draft-visibility-button z-10 flex items-center"
                   {{tooltip
                     this.toggleDraftVisibilityTooltipText
                     placement="bottom"


### PR DESCRIPTION
Fixes a visual bug causing the Draft Visibility toggle's focus ring to look funky.