### PR TITLE
Fix bug when re-adding approvers

### DIFF
--- a/pkg/models/document.go
+++ b/pkg/models/document.go
@@ -667,6 +667,7 @@ func (d *Document) replaceAssocations(db *gorm.DB) error {
 	if err := db.
 		Session(&gorm.Session{SkipHooks: true}).
 		Model(&d).
+		Unscoped().
 		Association("Approvers").
 		Replace(d.Approvers); err != nil {
 		return err


### PR DESCRIPTION
Re-adding a document approver wasn't making it correctly to the database (because the record's `deleted_at` was set) - this PR fixes the bug.