### PR TITLE
Track recently viewed projects

### DIFF
--- a/internal/api/v2/documents.go
+++ b/internal/api/v2/documents.go
@@ -968,9 +968,9 @@ func updateRecentlyViewedDocs(
 		docs = append(docs, dd)
 	}
 
-	// Trim recently viewed documents to a length of 5.
-	if len(docs) > 10 {
-		docs = docs[:10]
+	// Trim recently viewed documents to a length of 11.
+	if len(docs) > 11 {
+		docs = docs[:11]
 	}
 
 	// Update user.

--- a/internal/api/v2/me_recently_viewed_docs.go
+++ b/internal/api/v2/me_recently_viewed_docs.go
@@ -45,7 +45,7 @@ func MeRecentlyViewedDocsHandler(srv server.Server) http.Handler {
 			if err := u.FirstOrCreate(srv.DB); err != nil {
 				errResp(
 					http.StatusInternalServerError,
-					"Error authorizing the request",
+					"Error finding recently viewed documents",
 					"error finding or creating user",
 					err,
 				)

--- a/internal/api/v2/me_recently_viewed_docs.go
+++ b/internal/api/v2/me_recently_viewed_docs.go
@@ -11,8 +11,9 @@ import (
 )
 
 type recentlyViewedDoc struct {
-	ID      string `json:"id"`
-	IsDraft bool   `json:"isDraft"`
+	ID         string `json:"id"`
+	IsDraft    bool   `json:"isDraft"`
+	ViewedTime int64  `json:"viewedTime"`
 }
 
 func MeRecentlyViewedDocsHandler(srv server.Server) http.Handler {
@@ -97,8 +98,9 @@ func MeRecentlyViewedDocsHandler(srv server.Server) http.Handler {
 				}
 
 				res = append(res, recentlyViewedDoc{
-					ID:      doc.GoogleFileID,
-					IsDraft: isDraft,
+					ID:         doc.GoogleFileID,
+					IsDraft:    isDraft,
+					ViewedTime: d.ViewedAt.Unix(),
 				})
 			}
 

--- a/internal/api/v2/me_recently_viewed_projects.go
+++ b/internal/api/v2/me_recently_viewed_projects.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/hashicorp-forge/hermes/internal/server"
+	"github.com/hashicorp-forge/hermes/pkg/models"
+)
+
+type recentlyViewedProject struct {
+	ID int `json:"id"`
+}
+
+func MeRecentlyViewedProjectsHandler(srv server.Server) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		errResp := func(
+			httpCode int, userErrMsg, logErrMsg string, err error,
+			extraArgs ...interface{}) {
+			respondError(w, r, srv.Logger, httpCode, userErrMsg, logErrMsg, err,
+				extraArgs...)
+		}
+
+		// Authorize request.
+		userEmail := r.Context().Value("userEmail").(string)
+		if userEmail == "" {
+			errResp(
+				http.StatusUnauthorized,
+				"No authorization information for request",
+				"no user email found in request context",
+				nil,
+			)
+			return
+		}
+
+		switch r.Method {
+		case "GET":
+			// Find or create user.
+			u := models.User{
+				EmailAddress: userEmail,
+			}
+			if err := u.FirstOrCreate(srv.DB); err != nil {
+				errResp(
+					http.StatusInternalServerError,
+					"Error finding recently viewed projects",
+					"error finding or creating user",
+					err,
+				)
+				return
+			}
+
+			// Get recently viewed projects for the user.
+			var rvps []models.RecentlyViewedProject
+			if err := srv.DB.Where(&models.RecentlyViewedProject{UserID: int(u.ID)}).
+				Order("viewed_at desc").
+				Find(&rvps).Error; err != nil {
+
+				errResp(
+					http.StatusInternalServerError,
+					"Error finding recently viewed projects",
+					"error finding recently viewed projects in database",
+					err,
+				)
+				return
+			}
+
+			// Build response.
+			var res []recentlyViewedProject
+			for _, p := range rvps {
+				res = append(res, recentlyViewedProject{
+					ID: p.ProjectID,
+				})
+			}
+
+			// Write response.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			enc := json.NewEncoder(w)
+			if err := enc.Encode(res); err != nil {
+				errResp(
+					http.StatusInternalServerError,
+					"Error finding recently viewed projects",
+					"error encoding response to JSON",
+					err,
+				)
+				return
+			}
+
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+	})
+}

--- a/internal/api/v2/me_recently_viewed_projects.go
+++ b/internal/api/v2/me_recently_viewed_projects.go
@@ -9,7 +9,8 @@ import (
 )
 
 type recentlyViewedProject struct {
-	ID int `json:"id"`
+	ID         int   `json:"id"`
+	ViewedTime int64 `json:"viewedTime"`
 }
 
 func MeRecentlyViewedProjectsHandler(srv server.Server) http.Handler {
@@ -68,7 +69,8 @@ func MeRecentlyViewedProjectsHandler(srv server.Server) http.Handler {
 			var res []recentlyViewedProject
 			for _, p := range rvps {
 				res = append(res, recentlyViewedProject{
-					ID: p.ProjectID,
+					ID:         p.ProjectID,
+					ViewedTime: p.ViewedAt.Unix(),
 				})
 			}
 

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -380,6 +380,8 @@ func (c *Command) Run(args []string) int {
 		{"/api/v2/jira/issue/picker", apiv2.JiraIssuePickerHandler(srv)},
 		{"/api/v2/me", apiv2.MeHandler(srv)},
 		{"/api/v2/me/recently-viewed-docs", apiv2.MeRecentlyViewedDocsHandler(srv)},
+		{"/api/v2/me/recently-viewed-projects",
+			apiv2.MeRecentlyViewedProjectsHandler(srv)},
 		{"/api/v2/me/subscriptions", apiv2.MeSubscriptionsHandler(srv)},
 		{"/api/v2/people", apiv2.PeopleDataHandler(srv)},
 		{"/api/v2/products", apiv2.ProductsHandler(srv)},

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -53,6 +53,15 @@ func NewDB(cfg config.Postgres) (*gorm.DB, error) {
 			"error setting up RecentlyViewedDocs join table: %w", err)
 	}
 
+	if err := db.SetupJoinTable(
+		models.User{},
+		"RecentlyViewedProjects",
+		&models.RecentlyViewedProject{},
+	); err != nil {
+		return nil, fmt.Errorf(
+			"error setting up RecentlyViewedProjects join table: %w", err)
+	}
+
 	// Automatically migrate models.
 	// TODO: move to manually migrating models with a separate command.
 	if err := db.AutoMigrate(

--- a/web/app/routes/authenticated/projects/project.ts
+++ b/web/app/routes/authenticated/projects/project.ts
@@ -14,6 +14,14 @@ export default class AuthenticatedProjectsProjectRoute extends Route {
     const projectPromise = this.fetchSvc
       .fetch(
         `/api/${this.configSvc.config.api_version}/projects/${params.project_id}`,
+        {
+          method: "GET",
+          headers: {
+            // We set this header to differentiate between project views and
+            // requests to only retrieve project metadata.
+            "Add-To-Recently-Viewed": "true",
+          },
+        },
       )
       .then((response) => response?.json());
 


### PR DESCRIPTION
This PR starts tracking recently viewed projects in the database (10 per user). A new API is available to get a user's most recently viewed projects.

### New API

- `/api/v2/me/recently-viewed-projects`

```sh
$ curl http://localhost:8000/api/v2/me/recently-viewed-projects
[{"id":2,"viewedTime":1707414928},{"id":5,"viewedTime":1707359305},{"id":4,"viewedTime":1707357128},{"id":6,"viewedTime":1707357090}]
```