### PR TITLE
Improve (locked) document error handling

### DIFF
--- a/web/app/components/document/index.hbs
+++ b/web/app/components/document/index.hbs
@@ -11,7 +11,6 @@
         @profile={{this.authenticatedUser.info}}
         @document={{@document}}
         @docType={{@docType}}
-        @deleteDraft={{perform this.deleteDraft}}
         @isCollapsed={{this.sidebarIsCollapsed}}
         @toggleCollapsed={{this.toggleSidebarCollapsedState}}
       />

--- a/web/app/components/document/index.ts
+++ b/web/app/components/document/index.ts
@@ -1,15 +1,9 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
-import { dropTask } from "ember-concurrency";
 import { HermesDocument } from "hermes/types/document";
-import ConfigService from "hermes/services/config";
-import FetchService from "hermes/services/fetch";
-import RouterService from "@ember/routing/router-service";
-import RecentlyViewedDocsService from "hermes/services/recently-viewed-docs";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { HermesDocumentType } from "hermes/types/document-type";
-import HermesFlashMessagesService from "hermes/services/flash-messages";
 import AuthenticatedUserService from "hermes/services/authenticated-user";
 
 interface DocumentIndexComponentSignature {
@@ -22,51 +16,10 @@ interface DocumentIndexComponentSignature {
 
 export default class DocumentIndexComponent extends Component<DocumentIndexComponentSignature> {
   @service declare authenticatedUser: AuthenticatedUserService;
-  @service("config") declare configSvc: ConfigService;
-  @service("fetch") declare fetchSvc: FetchService;
-  @service declare router: RouterService;
-  @service declare flashMessages: HermesFlashMessagesService;
-  @service("recently-viewed-docs")
-  declare viewedDocs: RecentlyViewedDocsService;
-
   @tracked sidebarIsCollapsed = false;
 
   @action protected toggleSidebarCollapsedState() {
     this.sidebarIsCollapsed = !this.sidebarIsCollapsed;
-  }
-
-  protected deleteDraft = dropTask(async (docID: string) => {
-    try {
-      let fetchResponse = await this.fetchSvc.fetch(
-        `/api/${this.configSvc.config.api_version}/drafts/` + docID,
-        {
-          method: "DELETE",
-          headers: { "Content-Type": "application/json" },
-        },
-      );
-
-      if (!fetchResponse?.ok) {
-        this.showError(fetchResponse?.statusText);
-      } else {
-        void this.viewedDocs.fetchAll.perform();
-
-        this.flashMessages.add({
-          message: "Document draft deleted",
-          title: "Done!",
-        });
-
-        this.router.transitionTo("authenticated.my.documents");
-      }
-    } catch (e) {
-      this.showError(e);
-      throw e;
-    }
-  });
-
-  protected showError(e?: unknown) {
-    this.flashMessages.critical((e as any).message, {
-      title: "Error deleting draft",
-    });
   }
 }
 

--- a/web/app/components/document/modal.hbs
+++ b/web/app/components/document/modal.hbs
@@ -17,6 +17,7 @@
 
     {{#if this.errorIsShown}}
       <ModalAlertError
+        data-test-modal-error
         @onDismiss={{this.resetErrors}}
         @title={{this.errorTitle}}
         @description={{this.errorDescription}}

--- a/web/app/components/document/modal.ts
+++ b/web/app/components/document/modal.ts
@@ -70,8 +70,10 @@ export default class DocumentModalComponent extends Component<DocumentModalCompo
     try {
       this.taskIsRunning = true;
       await this.args.task();
+      console.log("one");
       this.args.close();
     } catch (error: unknown) {
+      console.log("two");
       this.taskIsRunning = false;
       if (this.args.errorTitle) {
         this.showError(this.args.errorTitle, error);

--- a/web/app/components/document/modal.ts
+++ b/web/app/components/document/modal.ts
@@ -70,10 +70,8 @@ export default class DocumentModalComponent extends Component<DocumentModalCompo
     try {
       this.taskIsRunning = true;
       await this.args.task();
-      console.log("one");
       this.args.close();
     } catch (error: unknown) {
-      console.log("two");
       this.taskIsRunning = false;
       if (this.args.errorTitle) {
         this.showError(this.args.errorTitle, error);

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -438,6 +438,7 @@
           {{#if this.isApprover}}
             <div class="gap-2 px-3">
               <Hds::Button
+                data-test-approve-button
                 @text={{this.approveButtonText}}
                 @size="medium"
                 @color="primary"

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -424,6 +424,7 @@
                 {{on "click" (set this "requestReviewModalIsShown" true)}}
               />
               <Hds::Button
+                data-test-delete-draft-button
                 @text="Delete"
                 @size="medium"
                 @color="critical"
@@ -453,6 +454,7 @@
               />
               {{#if (eq @document.docType "FRD")}}
                 <Hds::Button
+                  data-test-reject-frd-button
                   @text={{this.requestChangesButtonText}}
                   @size="medium"
                   @color="secondary"

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -345,10 +345,26 @@
             {{/each}}
           </ol>
         {{else}}
-          <Document::Sidebar::EmptyStateAddButton
-            @isReadOnly={{this.isDraft}}
-            @action={{this.showProjectsModal}}
-          />
+          {{#if this.projectsErrorIsShown}}
+            <div class="h-16">
+              <div class="failed-to-load-text">
+                Failed to load
+              </div>
+              <Hds::Button
+                data-test-document-projects-error-button
+                @color="secondary"
+                @size="small"
+                @text="Retry"
+                @icon="reload"
+                {{on "click" (perform this.loadRelatedProjects)}}
+              />
+            </div>
+          {{else}}
+            <Document::Sidebar::EmptyStateAddButton
+              @isReadOnly={{this.isDraft}}
+              @action={{this.showProjectsModal}}
+            />
+          {{/if}}
         {{/if}}
       </div>
 

--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -161,6 +161,13 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
    */
   @tracked protected approversAreShown = true;
 
+  /**
+   * Whether an error is shown in the projects section.
+   * True when the `loadRelatedProjects` task fails.
+   * Reset when the user retries the request.
+   */
+  @tracked protected projectsErrorIsShown = false;
+
   @tracked userHasScrolled = false;
   @tracked _body: HTMLElement | null = null;
 
@@ -535,17 +542,20 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
    * rich information in the list.
    */
   protected loadRelatedProjects = task(async () => {
-    const projectPromises = this.args.document.projects?.map((project) => {
-      return this.fetchSvc
-        .fetch(`/api/${this.configSvc.config.api_version}/projects/${project}`)
-        .then((response) => response?.json());
-    });
+    this.projectsErrorIsShown = false;
 
     try {
+      const projectPromises = this.args.document.projects?.map((project) => {
+        return this.fetchSvc
+          .fetch(
+            `/api/${this.configSvc.config.api_version}/projects/${project}`,
+          )
+          .then((response) => response?.json());
+      });
       const projects = await Promise.all(projectPromises ?? []);
       this._projects = projects;
     } catch (error) {
-      // TODO: Trigger a UI state with retry button
+      this.projectsErrorIsShown = true;
     }
   });
 

--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -1001,8 +1001,9 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
 
       this.maybeLockDoc(e);
       this.showFlashError(e, "Unable to change document status");
+    } finally {
+      this.refreshRoute();
     }
-    this.refreshRoute();
   });
 
   /**
@@ -1063,8 +1064,9 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
       const e = error as Error;
       this.maybeLockDoc(e);
       this.showFlashError(e, "Unable to remove project");
+    } finally {
+      this.refreshRoute();
     }
-    this.refreshRoute();
   });
 
   /**

--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -570,7 +570,7 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
 
           shareButton.classList.add("out");
 
-          void this.fetchSvc.fetch(
+          const fetchPromise = this.fetchSvc.fetch(
             `/api/${this.configSvc.config.api_version}/drafts/${this.docID}/shareable`,
             {
               method: "PUT",
@@ -581,8 +581,7 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
             },
           );
 
-          // Give time for the link icon to animate out
-          await timeout(Ember.testing ? 0 : 300);
+          await Promise.all([fetchPromise, timeout(Ember.testing ? 0 : 300)]);
 
           // With the animation done, we can now remove the button.
           this._docIsShareable = false;

--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -501,12 +501,7 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
   }
 
   @action maybeShowFlashError(error: Error, title: string) {
-    /**
-     * When the FetchService receives a non-401 error response,
-     * it returns a message starting with "Bad response ([ErrorCode])".
-     * We check for 423 responses and set `docIsLocked` accordingly.
-     */
-    if (error.message.startsWith("Bad response (423)")) {
+    if (this.fetchSvc.getErrorCode(error) === 423) {
       this.docIsLocked = true;
     }
 

--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -67,10 +67,11 @@ const SHARE_BUTTON_SELECTOR = "#sidebar-header-copy-url-button";
 export default class DocumentSidebarComponent extends Component<DocumentSidebarComponentSignature> {
   @service("config") declare configSvc: ConfigService;
   @service("fetch") declare fetchSvc: FetchService;
+  @service("recently-viewed-docs")
+  declare viewedDocs: RecentlyViewedDocsService;
   @service declare router: RouterService;
   @service declare session: SessionService;
   @service declare flashMessages: HermesFlashMessagesService;
-  declare viewedDocs: RecentlyViewedDocsService;
 
   @tracked deleteModalIsShown = false;
   @tracked requestReviewModalIsShown = false;

--- a/web/app/components/modal-alert-error.hbs
+++ b/web/app/components/modal-alert-error.hbs
@@ -4,6 +4,7 @@
   @icon={{false}}
   @onDismiss={{@onDismiss}}
   class="mt-3"
+  ...attributes
   as |A|
 >
   <A.Title>{{@title}}</A.Title>

--- a/web/app/components/modal-alert-error.ts
+++ b/web/app/components/modal-alert-error.ts
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 
 interface ModalAlertErrorComponentSignature {
+  Element: HTMLDivElement;
   Args: {
     onDismiss: () => void;
     title: string;

--- a/web/app/services/fetch.ts
+++ b/web/app/services/fetch.ts
@@ -39,7 +39,6 @@ export default class FetchService extends Service {
 
     try {
       const resp = await fetch(url, options);
-
       // if it's a poll call, tell the SessionService if the response was a 401
       if (isPollCall) {
         this.session.pollResponseIs401 = resp.status === 401;
@@ -50,8 +49,11 @@ export default class FetchService extends Service {
           // handle poll-call failures via the session service
           return;
         }
+
         const errText = await resp.text();
-        throw new Error(`Bad response: ${errText}`);
+
+        // Include status so the caller can triage it.
+        throw new Error(`Bad response (${resp.status}): ${errText}`);
       }
 
       return resp;

--- a/web/app/services/fetch.ts
+++ b/web/app/services/fetch.ts
@@ -12,7 +12,7 @@ interface FetchOptions {
   body?: string;
 }
 
-const BAD_RESPONSE_LABEL = "Bad response - ";
+export const BAD_RESPONSE_LABEL = "Bad response - ";
 
 export default class FetchService extends Service {
   @service("config") declare configSvc: ConfigService;

--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -719,6 +719,12 @@ export default function (mirageConfig) {
               description:
                 "Summarize a problem statement and outline a phased approach to addressing it.",
             },
+            {
+              name: "FRD",
+              longName: "Funding Request",
+              description:
+                "Capture a budget request, along with the business justification and expected returns.",
+            },
           ]);
         } else {
           return new Response(

--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -496,8 +496,15 @@ export default function (mirageConfig) {
       });
 
       // Determine if a draft is shareable
-      this.get("/drafts/:document_id/shareable", () => {
-        return new Response(200, {}, { isShareable: false });
+      this.get("/drafts/:document_id/shareable", (schema, request) => {
+        const document = schema.document.findBy({
+          objectID: request.params.document_id,
+        });
+        return new Response(
+          200,
+          {},
+          { isShareable: document.attrs.isShareable },
+        );
       });
 
       // Update whether a draft is shareable.

--- a/web/mirage/factories/document.ts
+++ b/web/mirage/factories/document.ts
@@ -31,6 +31,7 @@ export default Factory.extend({
   modifiedTime: 1,
   createdTime: 1,
   appCreated: true,
+  isShareable: false,
   isDraft: true,
   docNumber() {
     // @ts-ignore - Mirage types are wrong

--- a/web/tests/acceptance/authenticated/document-test.ts
+++ b/web/tests/acceptance/authenticated/document-test.ts
@@ -239,6 +239,14 @@ module("Acceptance | authenticated/document", function (hooks) {
         "Test Product 0",
         "The document product is updated to the selected product",
       );
+
+    const doc = this.server.schema.document.find(docID);
+
+    assert.equal(
+      doc.attrs.product,
+      "Test Product 0",
+      "the product is updated in the back end",
+    );
   });
 
   test("a published doc's productArea can't be changed ", async function (this: AuthenticatedDocumentRouteTestContext, assert) {
@@ -1409,6 +1417,16 @@ module("Acceptance | authenticated/document", function (hooks) {
 
     assert.dom(FLASH_MESSAGE_SELECTOR).containsText(errorMessage);
   });
+
+  test("it shows an error when changing draft visibility fails", async function (this: AuthenticatedDocumentRouteTestContext, assert) {});
+
+  test("it shows an error when changing a draft's product area fails", async function (this: AuthenticatedDocumentRouteTestContext, assert) {});
+
+  test("it shows an error when changing a document's status fails", async function (this: AuthenticatedDocumentRouteTestContext, assert) {});
+
+  test("it shows an error when removing a document from a project fails", async function (this: AuthenticatedDocumentRouteTestContext, assert) {});
+
+  test("it shows an error when adding a document to a project fails", async function (this: AuthenticatedDocumentRouteTestContext, assert) {});
 
   test("the document locks when a 423 error is returned", async function (this: AuthenticatedDocumentRouteTestContext, assert) {
     /**

--- a/web/tests/acceptance/authenticated/document-test.ts
+++ b/web/tests/acceptance/authenticated/document-test.ts
@@ -1480,12 +1480,10 @@ module("Acceptance | authenticated/document", function (hooks) {
 
   test("the document locks when a 423 error is returned", async function (this: AuthenticatedDocumentRouteTestContext, assert) {
     /**
-     * 423s are caught anytime the document shows an error flash message,
-     * which is the case for all important actions. This test demonstrates
-     * the "failed to approve" case, but the behavior is the same for
-     * all other actions.
+     * 423s are caught anytime the document handles an important error.
+     * This test demonstrates the "failed to approve" case, but the behavior
+     * is the same for all other actions.
      */
-
     this.server.create("document", {
       objectID: 1,
       isDraft: false,
@@ -1494,7 +1492,6 @@ module("Acceptance | authenticated/document", function (hooks) {
       approvers: [TEST_USER_EMAIL],
     });
 
-    // Set ourselves up for failure
     this.server.post("/approvals/:document_id", () => {
       return new Response(423, {}, "Locked");
     });

--- a/web/tests/acceptance/authenticated/document-test.ts
+++ b/web/tests/acceptance/authenticated/document-test.ts
@@ -1142,6 +1142,38 @@ module("Acceptance | authenticated/document", function (hooks) {
     assert.true(document.projects.length === 0);
   });
 
+  test("it shows an error when patching a document fails", async function (this: AuthenticatedDocumentRouteTestContext, assert) {
+    // Set ourselves up for failure
+    this.server.patch("/documents/:document_id", () => {
+      return new Response(500, {}, "Internal Server Error");
+    });
+
+    this.server.create("document", {
+      objectID: 1,
+      title: "Test Document",
+      isDraft: true,
+    });
+
+    await visit("/document/1?draft=true");
+
+    // Try changing the title
+    await click(`${TITLE_SELECTOR} button`);
+    await fillIn(`${TITLE_SELECTOR} textarea`, "New Title");
+    await triggerKeyEvent(`${TITLE_SELECTOR} textarea`, "keydown", "Enter");
+
+    assert.dom(FLASH_MESSAGE_SELECTOR).containsText("Internal Server Error");
+  });
+
+  test("it shows an error when requesting a review fails", async function (this: AuthenticatedDocumentRouteTestContext, assert) {});
+
+  test("it shows an error when deleting a draft fails", async function (this: AuthenticatedDocumentRouteTestContext, assert) {});
+
+  test("it shows an error when approving a document fails", async function (this: AuthenticatedDocumentRouteTestContext, assert) {});
+
+  test("it shows an error when rejecting an FRD fails", async function (this: AuthenticatedDocumentRouteTestContext, assert) {});
+
+  test("it shows an error when changing the status of a document fails", async function (this: AuthenticatedDocumentRouteTestContext, assert) {});
+
   test("the document locks when a 423 error is returned", async function (this: AuthenticatedDocumentRouteTestContext, assert) {
     /**
      * 423s are caught anytime the document shows an error flash message,

--- a/web/tests/unit/services/fetch-test.ts
+++ b/web/tests/unit/services/fetch-test.ts
@@ -1,0 +1,47 @@
+import { module, test } from "qunit";
+import { setupTest } from "ember-qunit";
+import FetchService, { BAD_RESPONSE_LABEL } from "hermes/services/fetch";
+
+module("Unit | Service | fetch", function (hooks) {
+  setupTest(hooks);
+
+  test("the getErrorCode method words", function (assert) {
+    const fetchSvc = this.owner.lookup("service:fetch") as FetchService;
+
+    const generateError = (code: number) => {
+      return new Error(`${BAD_RESPONSE_LABEL}${code}: some message`);
+    };
+
+    let error = generateError(400);
+
+    assert.equal(fetchSvc.getErrorCode(error), 400);
+
+    error = generateError(500);
+
+    assert.equal(fetchSvc.getErrorCode(error), 500);
+
+    error = new Error("error - 404: some message");
+
+    assert.equal(
+      fetchSvc.getErrorCode(error),
+      undefined,
+      "incorrectly formatted errors are ignored",
+    );
+
+    error = new Error(`${BAD_RESPONSE_LABEL}z404: some message`);
+
+    assert.equal(
+      fetchSvc.getErrorCode(error),
+      undefined,
+      "non-numeric error codes are ignored",
+    );
+
+    error = new Error();
+
+    assert.equal(
+      fetchSvc.getErrorCode(error),
+      undefined,
+      "errors without a message are ignored",
+    );
+  });
+});


### PR DESCRIPTION
Refactors and tests document error states. Adds functionality to lock a document if the server returns a 423 on a task.