### PR TITLE
Add ProjectsIndexName to web config

### DIFF
--- a/web/app/config/environment.d.ts
+++ b/web/app/config/environment.d.ts
@@ -15,6 +15,7 @@ export interface HermesConfig {
     docsIndexName: string;
     draftsIndexName: string;
     internalIndexName: string;
+    projectsIndexName: string;
   };
   createDocsAsUser: boolean;
   featureFlags: Record<string, boolean>;

--- a/web/app/services/config.ts
+++ b/web/app/services/config.ts
@@ -6,6 +6,7 @@ export default class ConfigService extends Service {
     algolia_docs_index_name: config.algolia.docsIndexName,
     algolia_drafts_index_name: config.algolia.draftsIndexName,
     algolia_internal_index_name: config.algolia.internalIndexName,
+    algolia_projects_index_name: config.algolia.projectsIndexName,
     api_version: "v1",
     create_docs_as_user: config.createDocsAsUser,
     feature_flags: config.featureFlags,

--- a/web/config/environment.js
+++ b/web/config/environment.js
@@ -46,6 +46,7 @@ module.exports = function (environment) {
       docsIndexName: getEnv("ALGOLIA_DOCS_INDEX_NAME", "docs"),
       draftsIndexName: getEnv("ALGOLIA_DRAFTS_INDEX_NAME", "drafts"),
       internalIndexName: getEnv("ALGOLIA_INTERNAL_INDEX_NAME", "internal"),
+      projectsIndexName: getEnv("ALGOLIA_PROJECTS_INDEX_NAME", "projects"),
       apiKey: getEnv("ALGOLIA_SEARCH_API_KEY"),
     },
 

--- a/web/mirage/utils.ts
+++ b/web/mirage/utils.ts
@@ -43,6 +43,7 @@ export const TEST_WEB_CONFIG = {
   algolia_docs_index_name: config.algolia.docsIndexName,
   algolia_drafts_index_name: config.algolia.draftsIndexName,
   algolia_internal_index_name: config.algolia.internalIndexName,
+  algolia_projects_index_name: config.algolia.projectsIndexName,
   api_version: "v1",
   feature_flags: {},
   jira_url: TEST_JIRA_WORKSPACE_URL,

--- a/web/web.go
+++ b/web/web.go
@@ -58,6 +58,7 @@ type ConfigResponse struct {
 	AlgoliaDocsIndexName     string          `json:"algolia_docs_index_name"`
 	AlgoliaDraftsIndexName   string          `json:"algolia_drafts_index_name"`
 	AlgoliaInternalIndexName string          `json:"algolia_internal_index_name"`
+	AlgoliaProjectsIndexName string          `json:"algolia_projects_index_name"`
 	CreateDocsAsUser         bool            `json:"create_docs_as_user"`
 	FeatureFlags             map[string]bool `json:"feature_flags"`
 	GoogleAnalyticsTagID     string          `json:"google_analytics_tag_id"`
@@ -129,6 +130,7 @@ func ConfigHandler(
 			AlgoliaDocsIndexName:     cfg.Algolia.DocsIndexName,
 			AlgoliaDraftsIndexName:   cfg.Algolia.DraftsIndexName,
 			AlgoliaInternalIndexName: cfg.Algolia.InternalIndexName,
+			AlgoliaProjectsIndexName: cfg.Algolia.ProjectsIndexName,
 			CreateDocsAsUser:         createDocsAsUser,
 			FeatureFlags:             featureFlags,
 			GoogleAnalyticsTagID:     cfg.GoogleAnalyticsTagID,


### PR DESCRIPTION
Adds/configures the projects index name to the web config response. This will allow us to query projects using Algolia.