### PR TITLE
Fix breaking `searchIndex` bug

### DIFF
--- a/web/app/services/algolia.ts
+++ b/web/app/services/algolia.ts
@@ -207,14 +207,7 @@ export default class AlgoliaService extends Service {
       params: AlgoliaSearchParams,
     ): Promise<SearchResponse<unknown>> => {
       let index: SearchIndex = this.client.initIndex(indexName);
-
-      let newParams = { ...params };
-
-      newParams.data = {
-        indexName,
-      };
-
-      return await index.search(query, newParams);
+      return await index.search(query, params);
     },
   );
 

--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -32,6 +32,8 @@ export default function (mirageConfig) {
        * Reviews the request and determines how to respond.
        */
       const handleAlgoliaRequest = (schema, request) => {
+        const indexName = request.url.split("indexes/")[1].split("/")[0];
+
         const requestBody = JSON.parse(request.requestBody);
         if (requestBody) {
           console.log("requestBody", requestBody);
@@ -90,10 +92,6 @@ export default function (mirageConfig) {
              * Typically, this is a query for a document, project or product,
              * but sometimes it's a query by some optionalFilters.
              */
-
-            // The algolia `searchIndex` method includes an indexName.
-            const { indexName } = requestBody;
-
             if (indexName?.includes("projects")) {
               const projects = schema.projects
                 .all()

--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -33,8 +33,8 @@ export default function (mirageConfig) {
        */
       const handleAlgoliaRequest = (schema, request) => {
         const indexName = request.url.split("indexes/")[1].split("/")[0];
-
         const requestBody = JSON.parse(request.requestBody);
+
         if (requestBody) {
           console.log("requestBody", requestBody);
           const { facetQuery, query } = requestBody;
@@ -96,7 +96,6 @@ export default function (mirageConfig) {
               const projects = schema.projects
                 .all()
                 .models.filter((project) => {
-                  console.log("project", project);
                   return (
                     project.attrs.title
                       .toLowerCase()


### PR DESCRIPTION
Fixes a breaking Algolia bug introduced in #593. I mistakenly added metadata to the query instead of parsing the index through the request itself. 