### PR TITLE
Search bugfix: Use correct ID attribute

### DIFF
--- a/web/app/components/header/search.hbs
+++ b/web/app/components/header/search.hbs
@@ -110,13 +110,12 @@
           }}
             {{#if dd.attrs.hit}}
               {{! Project result }}
-              {{log "hit" dd.attrs.hit}}
               <li>
                 <dd.LinkTo
                   data-test-project-hit
                   class="flex items-center gap-2 px-3"
                   @route="authenticated.projects.project"
-                  @model={{dd.attrs.hit.id}}
+                  @model={{dd.attrs.hit.objectID}}
                 >
                   <div class="mt-px flex shrink-0 px-0.5">
                     <Project::StatusIcon @status={{dd.attrs.hit.status}} />

--- a/web/mirage/config.ts
+++ b/web/mirage/config.ts
@@ -106,7 +106,18 @@ export default function (mirageConfig) {
                   );
                 });
 
-              return new Response(200, {}, { hits: projects });
+              return new Response(
+                200,
+                {},
+                {
+                  hits: projects.map((project) => {
+                    return {
+                      ...project.attrs,
+                      objectID: project.attrs.id,
+                    };
+                  }),
+                },
+              );
             }
 
             let docMatches = [];


### PR DESCRIPTION
Fixes a bug causing the search popover to error. We were incorrectly using `id` instead of `objectID` for an Algolia object.