### PR TITLE
Improve types on `/documents`

### DIFF
--- a/web/app/components/header/toolbar.ts
+++ b/web/app/components/header/toolbar.ts
@@ -45,7 +45,7 @@ export type ActiveFilters = {
 
 interface ToolbarComponentSignature {
   Args: {
-    facets?: FacetDropdownGroups;
+    facets?: Partial<FacetDropdownGroups>;
   };
 }
 

--- a/web/app/controllers/authenticated/documents.ts
+++ b/web/app/controllers/authenticated/documents.ts
@@ -10,7 +10,7 @@ export default class AuthenticatedDocumentsController extends Controller {
   owners = [];
   page = 1;
   product = [];
-  sortBy = "dateDesc";
+  sortBy = SortByValue.DateDesc;
   status = [];
 
   declare model: ModelFrom<AuthenticatedDocumentsRoute>;

--- a/web/app/routes/authenticated/documents.ts
+++ b/web/app/routes/authenticated/documents.ts
@@ -49,7 +49,8 @@ export default class AuthenticatedDocumentsRoute extends Route {
       this.algolia.getDocResults.perform(searchIndex, params),
     ]);
 
-    const hits = (results as { hits?: HermesDocument[] }).hits;
+    const typedResults = results as SearchResponse<HermesDocument>;
+    const hits = typedResults.hits;
 
     if (hits) {
       // Load owner information
@@ -58,6 +59,10 @@ export default class AuthenticatedDocumentsRoute extends Route {
 
     this.activeFilters.update(params);
 
-    return { facets, results, sortedBy };
+    return {
+      facets,
+      results: typedResults,
+      sortedBy,
+    };
   }
 }

--- a/web/app/services/algolia.ts
+++ b/web/app/services/algolia.ts
@@ -10,6 +10,7 @@ import { SearchOptions, SearchResponse } from "@algolia/client-search";
 import { assert } from "@ember/debug";
 import ConfigService from "./config";
 import {
+  FacetDropdownGroups,
   FacetDropdownObjectDetails,
   FacetRecord,
   FacetRecords,
@@ -117,7 +118,9 @@ export default class AlgoliaService extends Service {
    * Iterates over the keys of a facet object and transforms the `count` value
    * into a `FacetDropdownObjectDetails` object with `count` and `selected` properties.
    */
-  mapStatefulFacetKeys = (facetObject: AlgoliaFacetsObject): FacetRecords => {
+  mapStatefulFacetKeys = (
+    facetObject: AlgoliaFacetsObject,
+  ): Partial<FacetDropdownGroups> => {
     /**
      * e.g., facetObject === {
      *  owners: {

--- a/web/app/templates/authenticated/documents.hbs
+++ b/web/app/templates/authenticated/documents.hbs
@@ -1,11 +1,11 @@
 {{page-title "All Docs"}}
 
-<Header::Toolbar @facets={{@model.facets}} />
+<Header::Toolbar @facets={{this.model.facets}} />
 
 <Documents::Table
-  @docs={{@model.results.hits}}
-  @nbPages={{@model.results.nbPages}}
-  @currentPage={{(add @model.results.page 1)}}
+  @docs={{this.model.results.hits}}
+  @nbPages={{this.model.results.nbPages}}
+  @currentPage={{(add this.model.results.page 1)}}
   @sortDirection={{this.sortDirection}}
   @currentSort="createdTime"
 />


### PR DESCRIPTION
Improves the types on the Documents route to fix a few Glint errors.