### PR TITLE
Add/apply `wrap-anywhere` utility class to snippets

### DIFF
--- a/web/app/components/doc/tile-medium.hbs
+++ b/web/app/components/doc/tile-medium.hbs
@@ -96,7 +96,7 @@
           {{#if (or this.snippet @doc.summary)}}
             <p
               data-test-document-summary
-              class="mt-2.5 text-body-300
+              class="mt-2.5 text-body-300 wrap-anywhere
                 {{if this.snippet 'line-clamp line-clamp-2'}}"
             >
               {{#if this.snippet}}

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,3 +1,5 @@
+const plugin = require("tailwindcss/plugin");
+
 module.exports = {
   content: ["./app/**/*.{html,js,hbs,gts}"],
   theme: {
@@ -193,7 +195,15 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [
+    plugin(function ({ addUtilities }) {
+      addUtilities({
+        ".wrap-anywhere": {
+          "overflow-wrap": "anywhere",
+        },
+      });
+    }),
+  ],
   corePlugins: {
     // Disable Tailwind's preflight to prevent clashes
     // with @hashicorp/design-system-components


### PR DESCRIPTION
Adds a `wrap-anywhere` utility class to Tailwind and applies it to the document snippet field to prevent long strings (e.g., URLs) from breaking the component layout. 