### PR TITLE
Declare HdsBadgeCount for use in `.gts` files

### DIFF
--- a/web/types/hds/badge-count.d.ts
+++ b/web/types/hds/badge-count.d.ts
@@ -1,18 +1,22 @@
 // helios.hashicorp.design/components/badge-count?tab=code#component-api
 
-import { ComponentLike } from "@glint/template";
-import { HdsBadgeCountColor, HdsBadgeType } from "hds/_shared";
-import { HdsBadgeCountSize } from "hermes/types/HdsBadgeCountSize";
+declare module "@hashicorp/design-system-components/components/hds/badge-count" {
+  import Component from "@glimmer/component";
+  import { ComponentLike } from "@glint/template";
+  import { HdsBadgeCountColor, HdsBadgeType } from "hds/_shared";
+  import { HdsBadgeCountSize } from "hermes/types/HdsBadgeCountSize";
 
-interface HdsBadgeCountComponentSignature {
-  Element: HTMLDivElement;
-  Args: {
-    text: string;
-    size?: HdsBadgeCountSize;
-    type?: HdsBadgeType;
-    color?: HdsBadgeCountColor;
-  };
+  interface HdsBadgeCountComponentSignature {
+    Element: HTMLDivElement;
+    Args: {
+      text: string;
+      size?: HdsBadgeCountSize;
+      type?: HdsBadgeType;
+      color?: HdsBadgeCountColor;
+    };
+  }
+
+  export type HdsBadgeCountComponent =
+    ComponentLike<HdsBadgeCountComponentSignature>;
+  export default class HdsBadgeCount extends Component<HdsBadgeCountComponentSignature> {}
 }
-
-export type HdsBadgeCountComponent =
-  ComponentLike<HdsBadgeCountComponentSignature>;


### PR DESCRIPTION
Adds boilerplate so we can import `HdsBadgeCount` in `gts` files