### PR TITLE
Improve scrollbar gutter in Chrome and FF

### DIFF
--- a/web/app/styles/components/sidebar.scss
+++ b/web/app/styles/components/sidebar.scss
@@ -1,4 +1,4 @@
-/* Create a gutter for the  scrollbar in Firefox */
+/* Customize the scrollbar in Firefox */
 @supports not selector(::-webkit-scrollbar) {
   .sidebar-body {
     @apply pr-4;

--- a/web/app/styles/components/sidebar.scss
+++ b/web/app/styles/components/sidebar.scss
@@ -1,3 +1,10 @@
+/* Create a gutter for the  scrollbar in Firefox */
+@supports not selector(::-webkit-scrollbar) {
+  .sidebar-body {
+    @apply pr-4;
+  }
+}
+
 .sidebar {
   @apply relative z-10 flex max-h-full flex-col pb-4;
 
@@ -123,9 +130,6 @@
         @apply bg-color-palette-neutral-400;
       }
     }
-
-    /* Style the scrollbar Firefox */
-    scrollbar-color: var(--token-color-palette-neutral-300) transparent;
   }
 
   .document-title {

--- a/web/app/styles/components/sidebar.scss
+++ b/web/app/styles/components/sidebar.scss
@@ -2,6 +2,7 @@
 @supports not selector(::-webkit-scrollbar) {
   .sidebar-body {
     @apply pr-4;
+    scrollbar-color: var(--token-color-palette-neutral-300) transparent;
   }
 }
 


### PR DESCRIPTION
Improves the document sidebar scrollbar gutter in Chrome and FF.

When Chrome 121 added support for `scrollbar-width` and `scrollbar-color`, it introduced some visual bugs on Hermes and elsewhere (https://syntackle.com/blog/changes-to-scrollbar-styling-in-chrome-121/). Turns out that when `scrollbar-color` is processed it cancels all webkit-specific scrollbar styles.
 
Now we scope that property more narrowly, and in addition add padding to simulate the wider scroll track.

Current:
![CleanShot 2024-02-29 at 13 57 19](https://github.com/hashicorp-forge/hermes/assets/754957/588b66a1-5ed0-4034-b02c-a8d902a88ffc)

Updated:
![CleanShot 2024-02-29 at 13 57 58](https://github.com/hashicorp-forge/hermes/assets/754957/af9960b8-f285-4695-8688-40a13bf1f02c)

