### PR TITLE
Resolve "failed to load related resources" message on non-app-created docs

### DIFF
--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -281,6 +281,7 @@
       {{! Related resources }}
       <div>
         <Document::Sidebar::RelatedResources
+          @docWasCreatedOffApp={{not @document.appCreated}}
           @editingIsDisabled={{this.editingIsDisabled}}
           @documentIsDraft={{this.isDraft}}
           @productArea={{@document.product}}

--- a/web/app/components/document/sidebar/related-resources.hbs
+++ b/web/app/components/document/sidebar/related-resources.hbs
@@ -13,6 +13,8 @@
       @title={{@headerTitle}}
       @titleTooltipText={{this.titleTooltipText}}
       @buttonIsHidden={{this.sectionHeaderButtonIsHidden}}
+      @buttonIsDisabled={{@docWasCreatedOffApp}}
+      @disabledButtonTooltipText="Only docs created in Hermes can add related resources"
       @buttonAction={{rr.showModal}}
     />
   </:header>

--- a/web/app/components/document/sidebar/related-resources.ts
+++ b/web/app/components/document/sidebar/related-resources.ts
@@ -5,10 +5,9 @@ import { inject as service } from "@ember/service";
 import FetchService from "hermes/services/fetch";
 import ConfigService from "hermes/services/config";
 import AlgoliaService from "hermes/services/algolia";
-import { restartableTask, task, timeout } from "ember-concurrency";
+import { restartableTask, task } from "ember-concurrency";
 import { next, schedule } from "@ember/runloop";
 import htmlElement from "hermes/utils/html-element";
-import Ember from "ember";
 import {
   RelatedExternalLink,
   RelatedHermesDocument,
@@ -32,6 +31,7 @@ export interface DocumentSidebarRelatedResourcesComponentArgs {
   itemLimit?: number;
   modalInputPlaceholder: string;
   documentIsDraft?: boolean;
+  docWasCreatedOffApp?: boolean;
   editingIsDisabled?: boolean;
   scrollContainer: HTMLElement;
 }
@@ -208,6 +208,8 @@ export default class DocumentSidebarRelatedResourcesComponent extends Component<
    * On error, triggers the "retry" design.
    */
   protected loadRelatedResources = task(async () => {
+    if (this.args.docWasCreatedOffApp) return;
+
     try {
       const resources = await this.fetchSvc
         .fetch(

--- a/web/tests/acceptance/authenticated/document-test.ts
+++ b/web/tests/acceptance/authenticated/document-test.ts
@@ -100,7 +100,8 @@ const PEOPLE_SELECT_REMOVE_BUTTON_SELECTOR =
   ".ember-power-select-multiple-remove-btn";
 
 const PROJECT_LINK = "[data-test-project-link]";
-const ADD_TO_PROJECT_BUTTON = "[data-test-projects-section-header] button";
+const ADD_TO_PROJECT_BUTTON =
+  "[data-test-section-header-button-for='Projects']";
 const ADD_TO_PROJECT_MODAL = "[data-test-add-to-or-create-project-modal]";
 const PROJECT_OPTION = "[data-test-project-option]";
 
@@ -1116,10 +1117,12 @@ module("Acceptance | authenticated/document", function (hooks) {
     assert
       .dom(`${APPROVERS_SELECTOR} ${EDITABLE_FIELD_READ_VALUE}`)
       .exists("read-only approvers list");
-    assert
-      .dom(ADD_RELATED_DOCUMENT_OPTION_SELECTOR)
-      .doesNotExist("no add related resource option");
 
+    assert
+      .dom(ADD_RELATED_RESOURCE_BUTTON_SELECTOR)
+      .hasAttribute("aria-disabled");
+
+    assert.dom(ADD_TO_PROJECT_BUTTON).hasAttribute("aria-disabled");
     assert.dom(PRODUCT_SELECT_SELECTOR).doesNotExist("no product select");
     assert.dom(DRAFT_VISIBILITY_TOGGLE_SELECTOR).doesNotExist();
 


### PR DESCRIPTION
Improves related resource handling for non-app-created docs. We currently process this as a fetch error and show a "retry" button that never works. Now we show an empty/disabled state consistent with other inputs.