### PR TITLE
Adds summaries back to "Latest Docs"

### DIFF
--- a/web/app/services/latest-docs.ts
+++ b/web/app/services/latest-docs.ts
@@ -43,7 +43,13 @@ export default class LatestDocsService extends Service {
 
     assert("response must exist", response);
 
-    this.index = response.hits as HermesDocument[];
+    this.index = response.hits.map((hit) => {
+      return {
+        ...hit,
+        // We use summary instead of snippet on the dashboard
+        _snippetResult: undefined,
+      };
+    }) as HermesDocument[];
 
     // Load the owner information
     await this.store.maybeFetchPeople.perform(this.index);


### PR DESCRIPTION
Fixes a regression introduced in #607 that caused Latest Docs to show snippets instead of summaries.
