### PR TITLE
Couple of fixes to reviews API

### DIFF
--- a/internal/api/v2/reviews.go
+++ b/internal/api/v2/reviews.go
@@ -116,6 +116,19 @@ func ReviewsHandler(srv server.Server) http.Handler {
 				return
 			}
 
+			// Validate document status.
+			if doc.Status != "WIP" {
+				srv.Logger.Warn("document is not in WIP status",
+					"doc_id", docID,
+					"method", r.Method,
+					"path", r.URL.Path,
+				)
+				http.Error(w,
+					"Cannot create review for a document that is not in WIP status",
+					http.StatusUnprocessableEntity)
+				return
+			}
+
 			// Get latest product number.
 			latestNum, err := models.GetLatestProductNumber(
 				tx, doc.DocType, doc.Product)

--- a/internal/api/v2/reviews.go
+++ b/internal/api/v2/reviews.go
@@ -363,14 +363,7 @@ func ReviewsHandler(srv server.Server) http.Handler {
 			)
 
 			// Create shortcut in hierarchical folder structure.
-			shortcut, err := createShortcut(srv.Config, *doc, srv.GWService)
-			revertFuncs = append(revertFuncs, func() error {
-				if err := srv.GWService.DeleteFile(shortcut.Id); err != nil {
-					return fmt.Errorf("error deleting shortcut: %w", err)
-				}
-
-				return nil
-			})
+			_, err = createShortcut(srv.Config, *doc, srv.GWService)
 			if err != nil {
 				srv.Logger.Error("error creating shortcut",
 					"error", err,


### PR DESCRIPTION
This PR fixes a potential panic if creating a shortcut fails (would result in the shortcut being a nil pointer, which we obviously cannot delete). It also validates that the document status is WIP before allowing creating a review to go through - this could potentially result in multiple reviews for a document (the UI makes this difficult but it was still possible via the API).