### PR TITLE
Improve undefined `createdTime` handling in `time-ago` helper

### DIFF
--- a/web/app/components/dashboard/recently-viewed/item.ts
+++ b/web/app/components/dashboard/recently-viewed/item.ts
@@ -105,7 +105,7 @@ export default class DashboardRecentlyViewedItemComponent extends Component<Dash
   /**
    * The modified time of the item, whether it's a document or a project.
    */
-  protected get modifiedTime(): number {
+  protected get modifiedTime(): number | undefined {
     if (this.itemIsDoc) {
       return this.doc.modifiedTime || this.doc.createdTime;
     } else {

--- a/web/app/components/related-resources.ts
+++ b/web/app/components/related-resources.ts
@@ -30,7 +30,7 @@ export interface RelatedHermesDocument {
   title: string;
   documentType: string;
   documentNumber: string;
-  createdTime: number;
+  createdTime?: number;
   modifiedTime: number;
   sortOrder: number;
   product: string;

--- a/web/app/helpers/time-ago.ts
+++ b/web/app/helpers/time-ago.ts
@@ -3,7 +3,7 @@ import timeAgo from "hermes/utils/time-ago";
 
 export interface TimeAgoHelperSignature {
   Args: {
-    Positional: [time: number];
+    Positional: [time?: number];
     Named: {
       limitTo24Hours?: boolean;
     };

--- a/web/app/types/document.d.ts
+++ b/web/app/types/document.d.ts
@@ -13,8 +13,9 @@ export interface HermesDocument {
 
   /**
    * A timestamp in seconds. Used for sorting.
+   * Undefined when the doc was created off-app.
    */
-  createdTime: number;
+  createdTime?: number;
 
   /**
    * A timestamp in seconds. Used Translated by the `time-ago` helper

--- a/web/app/utils/time-ago.ts
+++ b/web/app/utils/time-ago.ts
@@ -6,11 +6,13 @@ import parseDate from "./parse-date";
  * Used throughout the app to format document metadata.
  */
 export default function timeAgo(
-  timeInSeconds: number,
+  timeInSeconds?: number,
   options?: {
     limitTo24Hours?: boolean;
   },
 ) {
+  if (!timeInSeconds) return "Unknown date";
+
   const now = Date.now();
   const before = new Date(timeInSeconds * 1000).getTime();
   const elapsed = now - before;

--- a/web/tests/unit/utils/time-ago-test.ts
+++ b/web/tests/unit/utils/time-ago-test.ts
@@ -13,6 +13,7 @@ module("Unit | Utility | time-ago", function () {
     assert.equal("1 minute ago", timeAgo(now - 60));
     assert.equal("5 minutes ago", timeAgo(now - 300));
     assert.equal("6 hours ago", timeAgo(now - 21600));
+    assert.equal("Unknown date", timeAgo(undefined));
 
     assert.equal("2 months ago", timeAgo(now - 5184000));
 


### PR DESCRIPTION
Returns "Unknown date" instead of "NaN" when the document doesn't have a createdTime, such as in the case with Algolia-indexed docs initially created offsite.