### PR TITLE
Fix bug when filtering to an owner not in the top 100

### DIFF
--- a/web/app/components/header/active-filter-list.ts
+++ b/web/app/components/header/active-filter-list.ts
@@ -15,7 +15,6 @@ export default class HeaderActiveFilterListComponent extends Component<HeaderAct
    * "Clear All" button to reset the filters.
    */
   protected defaultQuery = {
-    scope: SearchScope.All,
     docType: [],
     owners: [],
     product: [],

--- a/web/app/components/header/toolbar.ts
+++ b/web/app/components/header/toolbar.ts
@@ -100,7 +100,7 @@ export default class ToolbarComponent extends Component<ToolbarComponentSignatur
    * the statuses from our getter.
    */
   protected get facets() {
-    if (!this.args.facets || Object.keys(this.args.facets ?? 0).length === 0) {
+    if (!this.args.facets || Object.keys(this.args.facets).length === 0) {
       switch (this.args.scope) {
         case SearchScope.Docs:
           return [

--- a/web/app/components/header/toolbar.ts
+++ b/web/app/components/header/toolbar.ts
@@ -100,9 +100,7 @@ export default class ToolbarComponent extends Component<ToolbarComponentSignatur
    * the statuses from our getter.
    */
   protected get facets() {
-    const facetsObjectIsEmpty = Object.keys(this.args.facets ?? 0).length === 0;
-
-    if (facetsObjectIsEmpty) {
+    if (!this.args.facets || Object.keys(this.args.facets ?? 0).length === 0) {
       switch (this.args.scope) {
         case SearchScope.Docs:
           return [
@@ -131,27 +129,25 @@ export default class ToolbarComponent extends Component<ToolbarComponentSignatur
             },
           ];
       }
+    } else {
+      let facetArray: FacetArrayItem[] = [];
+
+      Object.entries(this.args.facets).forEach(([key, value]) => {
+        if (key === FacetName.Status && this.args.scope === SearchScope.Docs) {
+          facetArray.push({ name: key, values: this.statuses });
+        } else {
+          facetArray.push({ name: key as FacetName, values: value });
+        }
+      });
+
+      const order = ["docType", "status", "product", "owners"];
+
+      facetArray.sort((a, b) => {
+        return order.indexOf(a.name) - order.indexOf(b.name);
+      });
+
+      return facetArray;
     }
-
-    assert("facets must exist", this.args.facets);
-
-    let facetArray: FacetArrayItem[] = [];
-
-    Object.entries(this.args.facets).forEach(([key, value]) => {
-      if (key === FacetName.Status && this.args.scope === SearchScope.Docs) {
-        facetArray.push({ name: key, values: this.statuses });
-      } else {
-        facetArray.push({ name: key as FacetName, values: value });
-      }
-    });
-
-    const order = ["docType", "status", "product", "owners"];
-
-    facetArray.sort((a, b) => {
-      return order.indexOf(a.name) - order.indexOf(b.name);
-    });
-
-    return facetArray;
   }
 
   /**

--- a/web/app/services/algolia.ts
+++ b/web/app/services/algolia.ts
@@ -193,7 +193,11 @@ export default class AlgoliaService extends Service {
        * e.g., selection === ["Approved"]
        */
       for (let param of selection) {
-        (facet[param] as FacetDropdownObjectDetails).isSelected = true;
+        const facetParam = facet[param];
+
+        if (facetParam) {
+          facetParam.isSelected = true;
+        }
       }
       /**
        * e.g., facet["Approved"] === { count: 6, isSelected: true }

--- a/web/tests/acceptance/authenticated/results-test.ts
+++ b/web/tests/acceptance/authenticated/results-test.ts
@@ -337,13 +337,15 @@ module("Acceptance | authenticated/results", function (hooks) {
         "the filter is shown in the active filters section with the correct link to remove it",
       );
 
-    assert.dom(CLEAR_ALL_FILTERS_LINK).hasAttribute("href", "/results");
+    assert
+      .dom(CLEAR_ALL_FILTERS_LINK)
+      .hasAttribute("href", "/results?scope=Projects");
 
     assert.dom(PROJECT_LINK).exists({ count: completedProjectCount });
 
     // visit a URL with no results
 
-    await visit("/results?status=%5B%22Archived%22%5D&scope=Projects");
+    await visit("/results?q=qwe123&scope=Projects");
 
     assert.dom(FACET_TOGGLE).exists({ count: 1 }).isDisabled();
     assert.dom(RESULTS_MATCH_COUNT).containsText("0 matches");
@@ -438,7 +440,9 @@ module("Acceptance | authenticated/results", function (hooks) {
         "the filter is shown in the active filters section with the correct link to remove it",
       );
 
-    assert.dom(CLEAR_ALL_FILTERS_LINK).hasAttribute("href", "/results");
+    assert
+      .dom(CLEAR_ALL_FILTERS_LINK)
+      .hasAttribute("href", "/results?scope=Docs");
 
     assert.dom(DOC_LINK).exists({ count: frdCount });
 
@@ -515,7 +519,7 @@ module("Acceptance | authenticated/results", function (hooks) {
       .doesNotExist("the active filters section is hidden");
 
     // visit a URL with no results
-    await visit("/results?docType=%5B%22ZZZZZZZZZ%22%5D&scope=Docs");
+    await visit("/results?q=ZZZZZZZZZ&scope=Docs");
 
     assert.dom(FACET_TOGGLE).exists({ count: 4 });
 


### PR DESCRIPTION
Fixes a regression introduced in #619  (https://github.com/hashicorp-forge/hermes/pull/619/files#diff-3117657bac2de8ce920637bea05185707b14377f151ecabe947a3245417d5fb4L83) where filtering to an owner (by editing the URL) would cause the app to break if the owner's docCount wasn't in the top 100. Also improves the "clear all" button to not alter the current scope.