### PR TITLE
Fix CSS on `/my` route (Firefox)

### DIFF
--- a/web/app/styles/routes/my.scss
+++ b/web/app/styles/routes/my.scss
@@ -1,7 +1,7 @@
 .my {
   .hds-table {
     td {
-      @apply h-12 py-0 pr-10;
+      @apply py-0 pr-10;
 
       > .inner {
         @apply overflow-hidden;


### PR DESCRIPTION
Removes an unintended height style that was causing table rows to crop on Firefox.

Current:
![CleanShot 2024-03-05 at 10 47 50](https://github.com/hashicorp-forge/hermes/assets/754957/c89a5646-c749-4f24-b0ab-c2ee439ec562)


Intended:
![CleanShot 2024-03-05 at 10 47 29](https://github.com/hashicorp-forge/hermes/assets/754957/5ac8e6b6-4e0e-4dec-8d4a-9bb71b9bbded)