### PR TITLE
Reset document created date when publishing a doc

### DIFF
--- a/internal/api/v2/reviews.go
+++ b/internal/api/v2/reviews.go
@@ -160,6 +160,11 @@ func ReviewsHandler(srv server.Server) http.Handler {
 				return
 			}
 
+			// Reset the document creation time to the current time of publish.
+			now := time.Now()
+			doc.Created = now.Format("Jan 2, 2006")
+			doc.CreatedTime = now.Unix()
+
 			// Set the document number.
 			nextDocNum := latestNum + 1
 			doc.DocNumber = fmt.Sprintf("%s-%03d",
@@ -459,6 +464,7 @@ func ReviewsHandler(srv server.Server) http.Handler {
 				}
 				return
 			}
+			d.DocumentCreatedAt = now // Reset to document published time.
 			d.Status = models.InReviewDocumentStatus
 			d.DocumentNumber = nextDocNum
 			d.DocumentModifiedAt = modifiedTime

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -281,7 +281,7 @@ func NewFromDatabaseModel(
 	doc.Contributors = contributors
 
 	// Created.
-	doc.Created = model.CreatedAt.Format("Jan 2, 2006")
+	doc.Created = model.DocumentCreatedAt.Format("Jan 2, 2006")
 
 	// CreatedTime.
 	doc.CreatedTime = model.DocumentCreatedAt.Unix()


### PR DESCRIPTION
This PR resets the created date of a document when it is published to make dashboards more accurate, etc. (sometimes documents can hang around in WIP status for a while and it can be confusing to not see them reflected in the front of the dashboard after being published).