### PR TITLE
People API: Convert `null` result to an empty array

### DIFF
--- a/web/app/serializers/person.ts
+++ b/web/app/serializers/person.ts
@@ -20,6 +20,13 @@ export default class PersonSerializer extends JSONSerializer {
 
     if (requestType === "query") {
       assert("results are expected for query requests", "results" in payload);
+
+      /**
+       * If the results are `null`, return an empty array to show
+       * the "No results found" message in the PeopleSelect.
+       */
+      if (!payload.results) return { data: [] };
+
       const people = payload.results?.map((p: any) => {
         return {
           id: p.emailAddresses[0].value,
@@ -32,7 +39,7 @@ export default class PersonSerializer extends JSONSerializer {
           },
         };
       });
-      return { data: people || [] };
+      return { data: people };
     } else if (requestType === "queryRecord") {
       assert(
         "payload should not be an array of results",

--- a/web/app/serializers/person.ts
+++ b/web/app/serializers/person.ts
@@ -12,7 +12,7 @@ export default class PersonSerializer extends JSONSerializer {
   normalizeResponse(
     _store: DS.Store,
     _primaryModelClass: any,
-    payload: GoogleUser[] | { results: GoogleUser[] },
+    payload: GoogleUser[] | { results: GoogleUser[] | null },
     _id: string | number,
     requestType: string,
   ) {
@@ -20,7 +20,7 @@ export default class PersonSerializer extends JSONSerializer {
 
     if (requestType === "query") {
       assert("results are expected for query requests", "results" in payload);
-      const people = payload.results.map((p: any) => {
+      const people = payload.results?.map((p: any) => {
         return {
           id: p.emailAddresses[0].value,
           type,
@@ -32,7 +32,7 @@ export default class PersonSerializer extends JSONSerializer {
           },
         };
       });
-      return { data: people };
+      return { data: people || [] };
     } else if (requestType === "queryRecord") {
       assert(
         "payload should not be an array of results",

--- a/web/app/serializers/person.ts
+++ b/web/app/serializers/person.ts
@@ -27,7 +27,7 @@ export default class PersonSerializer extends JSONSerializer {
        */
       if (!payload.results) return { data: [] };
 
-      const people = payload.results?.map((p: any) => {
+      const people = payload.results.map((p: any) => {
         return {
           id: p.emailAddresses[0].value,
           type,


### PR DESCRIPTION
Adds logic to convert a `{results: null}` response from Google's People API into an empty array.

This will make the PeopleSelect show a "no results" message instead of logging an error and continuing to show any previously loaded results. 