### PR TITLE
Improve `PeopleSelect` styles

### DIFF
--- a/web/app/components/inputs/people-select.hbs
+++ b/web/app/components/inputs/people-select.hbs
@@ -21,13 +21,13 @@
   as |value|
 >
   <div class="flex items-center gap-2 overflow-hidden py-1">
-    <Person::Avatar @email={{value}} @size="medium" class="shrink-0" />
-    <div class="w-full">
-      <div class="text-body-100 leading-tight">
+    <Person::Avatar @email={{value}} class="shrink-0" />
+    <div class="w-full min-w-0">
+      <div class="truncate text-body-200 leading-tight">
         {{get-model-attr "person.name" value}}
-      </div>
-      <div class="text-body-100 leading-tight opacity-70">
-        {{get-model-attr "person.email" value}}
+        <span class="ml-0.5 text-body-100 opacity-70">
+          {{get-model-attr "person.email" value}}
+        </span>
       </div>
     </div>
   </div>

--- a/web/app/components/inputs/people-select.hbs
+++ b/web/app/components/inputs/people-select.hbs
@@ -9,7 +9,7 @@
   @calculatePosition={{this.calculatePosition}}
   @renderInPlace={{@renderInPlace}}
   @placeholder="Search for your peers..."
-  @loadingMessage=""
+  @loadingMessage="Loading..."
   @onChange={{@onChange}}
   @onInput={{this.onInput}}
   @onClose={{this.onClose}}

--- a/web/app/components/inputs/people-select.hbs
+++ b/web/app/components/inputs/people-select.hbs
@@ -9,6 +9,7 @@
   @calculatePosition={{this.calculatePosition}}
   @renderInPlace={{@renderInPlace}}
   @placeholder="Search for your peers..."
+  @loadingMessage=""
   @onChange={{@onChange}}
   @onInput={{this.onInput}}
   @onClose={{this.onClose}}

--- a/web/app/components/inputs/people-select.hbs
+++ b/web/app/components/inputs/people-select.hbs
@@ -6,27 +6,27 @@
   @searchField="email"
   @options={{this.people}}
   @selected={{@selected}}
-  @calculatePosition={{this.calculatePosition}}
   @renderInPlace={{@renderInPlace}}
   @placeholder="Search for your peers..."
-  @loadingMessage="Loading..."
   @onChange={{@onChange}}
   @onInput={{this.onInput}}
   @onClose={{this.onClose}}
   @onKeydown={{@onKeydown}}
   @disabled={{@disabled}}
   @selectedItemComponent={{component "multiselect/user-email-image-chip"}}
+  @calculatePosition={{this.calculatePosition}}
+  @loadingMessage="Loading..."
   @eventType="click"
   {{on "click" this.onClick}}
   ...attributes
   as |value|
 >
   <div class="flex items-center gap-2 overflow-hidden py-1">
-    <Person::Avatar @email={{value}} class="shrink-0" />
+    <Person::Avatar @email={{value}} />
     <div class="w-full min-w-0">
       <div class="truncate text-body-200 leading-tight">
         {{get-model-attr "person.name" value}}
-        <span class="ml-0.5 text-body-100 opacity-70">
+        <span class="ml-0.5 text-body-100 text-color-foreground-disabled">
           {{get-model-attr "person.email" value}}
         </span>
       </div>

--- a/web/app/components/inputs/people-select.hbs
+++ b/web/app/components/inputs/people-select.hbs
@@ -6,6 +6,7 @@
   @searchField="email"
   @options={{this.people}}
   @selected={{@selected}}
+  @calculatePosition={{this.calculatePosition}}
   @renderInPlace={{@renderInPlace}}
   @placeholder="Search for your peers..."
   @onChange={{@onChange}}
@@ -14,6 +15,8 @@
   @onKeydown={{@onKeydown}}
   @disabled={{@disabled}}
   @selectedItemComponent={{component "multiselect/user-email-image-chip"}}
+  @eventType="click"
+  {{on "click" this.onClick}}
   ...attributes
   as |value|
 >

--- a/web/app/components/inputs/people-select.ts
+++ b/web/app/components/inputs/people-select.ts
@@ -146,7 +146,7 @@ export default class InputsPeopleSelectComponent extends Component<InputsPeopleS
 
     switch (horizontalPosition) {
       case HorizontalPosition.Left:
-        left -= 3;
+        left -= 4;
         break;
     }
 

--- a/web/app/components/inputs/people-select.ts
+++ b/web/app/components/inputs/people-select.ts
@@ -19,24 +19,22 @@ export interface GoogleUser {
   photos: { url: string }[];
 }
 
-enum VerticalPosition {
+enum ComputedVerticalPosition {
   Above = "above",
   Below = "below",
-  Auto = "auto",
 }
 
-enum HorizontalPosition {
+enum ComputedHorizontalPosition {
   Left = "left",
   Right = "right",
-  Auto = "auto",
 }
 
 interface CalculatePositionOptions {
-  horizontalPosition: HorizontalPosition;
-  verticalPosition: VerticalPosition;
+  horizontalPosition: ComputedHorizontalPosition;
+  verticalPosition: ComputedVerticalPosition;
   matchTriggerWidth: boolean;
-  previousHorizontalPosition?: HorizontalPosition;
-  previousVerticalPosition?: VerticalPosition;
+  previousHorizontalPosition?: ComputedHorizontalPosition;
+  previousVerticalPosition?: ComputedVerticalPosition;
   renderInPlace: boolean;
   dropdown: any;
 }
@@ -123,35 +121,38 @@ export default class InputsPeopleSelectComponent extends Component<InputsPeopleS
   ) {
     const position = calculatePosition(trigger, content, destination, options);
 
-    const extraOffsetBelow = 3;
+    const extraOffsetLeft = 4;
+    const extraOffsetBelow = 2;
     const extraOffsetAbove = extraOffsetBelow + 2;
 
     const { verticalPosition, horizontalPosition } = position;
 
     console.log("horizontalPosition", horizontalPosition);
 
-    let { top, left } = position.style;
+    let { top, left, width } = position.style;
 
     assert("top must be a number", typeof top === "number");
     assert("left must be a number", typeof left === "number");
+    assert("width must be a number", typeof width === "number");
 
     switch (verticalPosition) {
-      case VerticalPosition.Above:
+      case ComputedVerticalPosition.Above:
         top -= extraOffsetAbove;
         break;
-      case VerticalPosition.Below:
+      case ComputedVerticalPosition.Below:
         top += extraOffsetBelow;
         break;
     }
 
     switch (horizontalPosition) {
-      case HorizontalPosition.Left:
-        left -= 4;
+      case ComputedHorizontalPosition.Left:
+        left -= extraOffsetLeft;
         break;
     }
 
     position.style.top = top;
     position.style.left = left;
+    position.style.width = width + extraOffsetLeft * 2;
     position.style["min-width"] = `320px`;
 
     return position;
@@ -167,11 +168,13 @@ export default class InputsPeopleSelectComponent extends Component<InputsPeopleS
       let retryDelay = INITIAL_RETRY_DELAY;
 
       try {
+        await timeout(500);
         const people = await this.store.query("person", {
           query,
         });
 
         if (people) {
+          console.log("there are people");
           this.people = people
             .map((p: PersonModel) => p.email)
             .filter((email: string) => {
@@ -181,6 +184,7 @@ export default class InputsPeopleSelectComponent extends Component<InputsPeopleS
               );
             });
         } else {
+          console.log("there are no people");
           this.people = [];
         }
         // stop the loop if the query was successful

--- a/web/app/components/inputs/people-select.ts
+++ b/web/app/components/inputs/people-select.ts
@@ -123,16 +123,17 @@ export default class InputsPeopleSelectComponent extends Component<InputsPeopleS
   ) {
     const position = calculatePosition(trigger, content, destination, options);
 
-    const extraOffsetBelow = 4;
+    const extraOffsetBelow = 3;
     const extraOffsetAbove = extraOffsetBelow + 2;
 
-    const { verticalPosition } = position;
+    const { verticalPosition, horizontalPosition } = position;
 
-    console.log("verticalPosition", verticalPosition);
+    console.log("horizontalPosition", horizontalPosition);
 
-    let { top } = position.style;
+    let { top, left } = position.style;
 
     assert("top must be a number", typeof top === "number");
+    assert("left must be a number", typeof left === "number");
 
     switch (verticalPosition) {
       case VerticalPosition.Above:
@@ -143,7 +144,14 @@ export default class InputsPeopleSelectComponent extends Component<InputsPeopleS
         break;
     }
 
+    switch (horizontalPosition) {
+      case HorizontalPosition.Left:
+        left -= 3;
+        break;
+    }
+
     position.style.top = top;
+    position.style.left = left;
     position.style["min-width"] = `320px`;
 
     return position;

--- a/web/app/components/inputs/people-select.ts
+++ b/web/app/components/inputs/people-select.ts
@@ -8,11 +8,37 @@ import FetchService from "hermes/services/fetch";
 import Ember from "ember";
 import StoreService from "hermes/services/store";
 import PersonModel from "hermes/models/person";
+import { Select } from "ember-power-select/components/power-select";
+import { next } from "@ember/runloop";
+import calculatePosition from "ember-basic-dropdown/utils/calculate-position";
+import { assert } from "@ember/debug";
 
 export interface GoogleUser {
   emailAddresses: { value: string }[];
   names: { displayName: string; givenName: string }[];
   photos: { url: string }[];
+}
+
+enum VerticalPosition {
+  Above = "above",
+  Below = "below",
+  Auto = "auto",
+}
+
+enum HorizontalPosition {
+  Left = "left",
+  Right = "right",
+  Auto = "auto",
+}
+
+interface CalculatePositionOptions {
+  horizontalPosition: HorizontalPosition;
+  verticalPosition: VerticalPosition;
+  matchTriggerWidth: boolean;
+  previousHorizontalPosition?: HorizontalPosition;
+  previousVerticalPosition?: VerticalPosition;
+  renderInPlace: boolean;
+  dropdown: any;
 }
 
 interface InputsPeopleSelectComponentSignature {
@@ -41,14 +67,38 @@ export default class InputsPeopleSelectComponent extends Component<InputsPeopleS
   @tracked protected people: string[] = [];
 
   /**
+   * The action to run when the PowerSelect input is clicked.
+   * Prevents the dropdown from opening when the input is empty.
+   */
+  @action protected onClick(e: MouseEvent) {
+    const target = e.target as HTMLElement;
+    const input = target.closest(".ember-power-select-trigger") as HTMLElement;
+
+    if (input) {
+      const value = input.querySelector("input")?.value;
+      if (value === "") {
+        e.stopImmediatePropagation();
+      }
+    }
+  }
+
+  /**
    * An action occurring on every keystroke.
    * Handles cases where the user clears the input,
    * since `onChange` is not called in that case.
    * See: https://ember-power-select.com/docs/custom-search-action
    */
-  @action onInput(inputValue: string) {
+  @action protected onInput(inputValue: string, select: Select) {
     if (inputValue === "") {
       this.people = [];
+
+      /**
+       * Stop the redundant "type to search" message
+       * from appearing when the last character is deleted.
+       */
+      next(() => {
+        select.actions.close();
+      });
     }
   }
 
@@ -58,6 +108,45 @@ export default class InputsPeopleSelectComponent extends Component<InputsPeopleS
    */
   @action onClose() {
     this.people = [];
+  }
+
+  /**
+   * Custom position-calculating function for the dropdown.
+   * Ensures the dropdown is at least 320px wide, instead of 100% of the trigger.
+   * Improves dropdown appearance when the trigger is small, e.g., in the sidebar.
+   */
+  @action protected calculatePosition(
+    trigger: HTMLElement,
+    content: HTMLElement,
+    destination: HTMLElement,
+    options: CalculatePositionOptions,
+  ) {
+    const position = calculatePosition(trigger, content, destination, options);
+
+    const extraOffsetBelow = 4;
+    const extraOffsetAbove = extraOffsetBelow + 2;
+
+    const { verticalPosition } = position;
+
+    console.log("verticalPosition", verticalPosition);
+
+    let { top } = position.style;
+
+    assert("top must be a number", typeof top === "number");
+
+    switch (verticalPosition) {
+      case VerticalPosition.Above:
+        top -= extraOffsetAbove;
+        break;
+      case VerticalPosition.Below:
+        top += extraOffsetBelow;
+        break;
+    }
+
+    position.style.top = top;
+    position.style["min-width"] = `320px`;
+
+    return position;
   }
 
   /**

--- a/web/app/components/inputs/people-select.ts
+++ b/web/app/components/inputs/people-select.ts
@@ -104,7 +104,7 @@ export default class InputsPeopleSelectComponent extends Component<InputsPeopleS
    * The action taken when focus leaves the component.
    * Clears the people list and calls `this.args.onBlur` if it exists.
    */
-  @action onClose() {
+  @action protected onClose() {
     this.people = [];
   }
 
@@ -126,8 +126,6 @@ export default class InputsPeopleSelectComponent extends Component<InputsPeopleS
     const extraOffsetAbove = extraOffsetBelow + 2;
 
     const { verticalPosition, horizontalPosition } = position;
-
-    console.log("horizontalPosition", horizontalPosition);
 
     let { top, left, width } = position.style;
 
@@ -168,13 +166,11 @@ export default class InputsPeopleSelectComponent extends Component<InputsPeopleS
       let retryDelay = INITIAL_RETRY_DELAY;
 
       try {
-        await timeout(500);
         const people = await this.store.query("person", {
           query,
         });
 
         if (people) {
-          console.log("there are people");
           this.people = people
             .map((p: PersonModel) => p.email)
             .filter((email: string) => {
@@ -184,7 +180,6 @@ export default class InputsPeopleSelectComponent extends Component<InputsPeopleS
               );
             });
         } else {
-          console.log("there are no people");
           this.people = [];
         }
         // stop the loop if the query was successful

--- a/web/app/styles/components/multiselect.scss
+++ b/web/app/styles/components/multiselect.scss
@@ -41,7 +41,7 @@
   }
 
   .ember-power-select-trigger-multiple-input {
-    @apply min-w-[80px] text-body-200;
+    @apply min-w-[80px] px-[3px] text-body-200 placeholder:text-color-foreground-disabled;
 
     &::-webkit-search-cancel-button {
       display: none;

--- a/web/app/styles/components/multiselect.scss
+++ b/web/app/styles/components/multiselect.scss
@@ -49,7 +49,7 @@
   }
 
   .ember-power-select-multiple-option {
-    @apply relative inline-flex max-w-full items-center border-0;
+    @apply relative inline-flex max-w-full items-center border-0 text-color-foreground-strong;
 
     // Compensate for the chip padding by setting negative margins.
     // Allows content to maintain its position in both the edit and read-only states.

--- a/web/app/styles/components/multiselect.scss
+++ b/web/app/styles/components/multiselect.scss
@@ -37,11 +37,11 @@
   }
 
   .ember-power-select-multiple-options {
-    @apply flex flex-wrap h-full mr-6;
+    @apply mr-6 flex h-full flex-wrap gap-2.5;
   }
 
   .ember-power-select-trigger-multiple-input {
-    min-width: 80px;
+    @apply min-w-[80px] text-body-200;
 
     &::-webkit-search-cancel-button {
       display: none;
@@ -49,10 +49,14 @@
   }
 
   .ember-power-select-multiple-option {
-    @apply flex items-center px-0 m-0.5 max-w-[100%] relative pr-7 pl-1.5 py-1 border-0;
+    @apply relative inline-flex max-w-full items-center border-0;
+
+    // Compensate for the chip padding by setting negative margins.
+    // Allows content to maintain its position in both the edit and read-only states.
+    @apply -my-1 -ml-[3px] -mr-1 py-1 px-0 pl-[3px] pr-7;
 
     .ember-power-select-multiple-remove-btn {
-      @apply absolute right-1 grid place-items-center h-5 w-5 shrink-0 z-10 rounded-sm text-color-foreground-primary pb-px;
+      @apply absolute right-1 z-10 grid h-5 w-5 shrink-0 place-items-center rounded-sm pb-px text-color-foreground-primary;
 
       &:hover {
         @apply bg-neutral-200;

--- a/web/app/styles/components/sidebar.scss
+++ b/web/app/styles/components/sidebar.scss
@@ -163,7 +163,7 @@
   }
 
   .person-list {
-    @apply w-full space-y-2;
+    @apply grid w-full gap-2.5;
   }
 
   .sidebar-footer {

--- a/web/app/styles/ember-power-select-theme.scss
+++ b/web/app/styles/ember-power-select-theme.scss
@@ -27,7 +27,7 @@ $ember-power-select-opened-border-radius: var(
 
 $ember-power-select-focus-box-shadow: var(--token-elevation-low-box-shadow);
 $ember-power-select-dropdown-box-shadow: var(--token-elevation-low-box-shadow);
-$ember-power-select-option-padding: 7px; // Can't use --token-form-control-padding here.
+$ember-power-select-option-padding: 9px;
 $ember-power-select-focus-outline: 3px solid
   var(--token-color-focus-action-external);
 $ember-power-select-trigger-ltr-padding: 7px 5px;
@@ -50,4 +50,12 @@ $ember-power-select-multiple-option-line-height: 1.3;
 .ember-basic-dropdown-content {
   border: none !important;
   @apply hds-surface-high mt-px;
+}
+
+.ember-power-select-options[role="listbox"] {
+  @apply max-h-[200px];
+}
+
+.ember-power-select-option {
+  @apply py-px;
 }

--- a/web/app/styles/ember-power-select-theme.scss
+++ b/web/app/styles/ember-power-select-theme.scss
@@ -52,11 +52,15 @@ $ember-power-select-multiple-option-line-height: 1.3;
 }
 
 .ember-power-select-options[role="listbox"] {
-  @apply mt-[3px] max-h-[200px];
+  @apply max-h-[200px];
 }
 
 .ember-power-select-option {
   @apply py-px;
+
+  &:first-child {
+    @apply mt-[3px];
+  }
 
   &:last-child {
     @apply mb-[3px];
@@ -65,5 +69,5 @@ $ember-power-select-multiple-option-line-height: 1.3;
 
 .ember-power-select-option--loading-message,
 .ember-power-select-option--no-matches-message {
-  @apply h-7 px-3.5 text-color-foreground-disabled;
+  @apply h-7 px-3.5 text-color-foreground-faint;
 }

--- a/web/app/styles/ember-power-select-theme.scss
+++ b/web/app/styles/ember-power-select-theme.scss
@@ -1,6 +1,5 @@
-@import "ember-basic-dropdown";
+// https://github.com/cibernox/ember-power-select/blob/master/ember-power-select/scss/variables.scss
 
-// ember-power-select
 $ember-power-select-background-color: var(
   --token-form-control-base-surface-color-default
 );
@@ -21,14 +20,19 @@ $ember-power-select-default-border: var(--token-form-control-border-width) solid
 $ember-power-select-default-border-radius: var(
   --token-form-control-border-radius
 );
+
+$ember-power-select-opened-border-radius: var(
+  --token-form-control-border-radius
+);
+
 $ember-power-select-focus-box-shadow: var(--token-elevation-low-box-shadow);
 $ember-power-select-dropdown-box-shadow: var(--token-elevation-low-box-shadow);
 $ember-power-select-option-padding: 7px; // Can't use --token-form-control-padding here.
 $ember-power-select-focus-outline: 3px solid
   var(--token-color-focus-action-external);
-$ember-power-select-trigger-ltr-padding: var(--token-form-control-padding);
-$ember-power-select-trigger-rtl-padding: var(--token-form-control-padding);
-$ember-power-select-multiple-option-padding: 0 7px;
+$ember-power-select-trigger-ltr-padding: 7px 5px;
+$ember-power-select-trigger-rtl-padding: 7px 5px;
+$ember-power-select-multiple-option-padding: 0;
 $ember-power-select-multiple-option-line-height: 1.3;
 
 .ember-basic-dropdown-content {
@@ -42,3 +46,8 @@ $ember-power-select-multiple-option-line-height: 1.3;
 }
 
 @import "ember-power-select";
+
+.ember-basic-dropdown-content {
+  border: none !important;
+  @apply hds-surface-high mt-px;
+}

--- a/web/app/styles/ember-power-select-theme.scss
+++ b/web/app/styles/ember-power-select-theme.scss
@@ -27,7 +27,7 @@ $ember-power-select-opened-border-radius: var(
 
 $ember-power-select-focus-box-shadow: var(--token-elevation-low-box-shadow);
 $ember-power-select-dropdown-box-shadow: var(--token-elevation-low-box-shadow);
-$ember-power-select-option-padding: 9px;
+$ember-power-select-option-padding: 8px;
 $ember-power-select-focus-outline: 3px solid
   var(--token-color-focus-action-external);
 $ember-power-select-trigger-ltr-padding: 7px 5px;

--- a/web/app/styles/ember-power-select-theme.scss
+++ b/web/app/styles/ember-power-select-theme.scss
@@ -9,8 +9,9 @@ $ember-power-select-disabled-background-color: var(
 $ember-power-select-multiple-selection-background-color: var(
   --token-color-palette-neutral-100
 );
+$ember-power-select-highlighted-color: inherit;
 $ember-power-select-highlighted-background: var(
-  --token-color-foreground-action
+  --token-color-surface-interactive-hover
 );
 $ember-power-select-border-color: var(
   --token-form-control-base-border-color-default
@@ -38,10 +39,6 @@ $ember-power-select-multiple-option-line-height: 1.3;
 .ember-basic-dropdown-content {
   .hds-dropdown-list-item--variant-interactive {
     @apply flex items-center px-3;
-
-    &:hover {
-      @apply bg-color-surface-interactive-hover;
-    }
   }
 }
 
@@ -58,4 +55,8 @@ $ember-power-select-multiple-option-line-height: 1.3;
 
 .ember-power-select-option {
   @apply py-px;
+}
+
+.ember-power-select-option--loading-message {
+  @apply text-red-500;
 }

--- a/web/app/styles/ember-power-select-theme.scss
+++ b/web/app/styles/ember-power-select-theme.scss
@@ -37,8 +37,10 @@ $ember-power-select-multiple-option-padding: 0;
 $ember-power-select-multiple-option-line-height: 1.3;
 
 .ember-basic-dropdown-content {
+  @apply min-h-[34px];
+
   .hds-dropdown-list-item--variant-interactive {
-    @apply flex items-center px-3;
+    @apply flex items-center px-2;
   }
 }
 
@@ -50,13 +52,18 @@ $ember-power-select-multiple-option-line-height: 1.3;
 }
 
 .ember-power-select-options[role="listbox"] {
-  @apply max-h-[200px];
+  @apply mt-[3px] max-h-[200px];
 }
 
 .ember-power-select-option {
   @apply py-px;
+
+  &:last-child {
+    @apply mb-[3px];
+  }
 }
 
-.ember-power-select-option--loading-message {
-  @apply text-red-500;
+.ember-power-select-option--loading-message,
+.ember-power-select-option--no-matches-message {
+  @apply h-7 px-3.5 text-color-foreground-disabled;
 }

--- a/web/tests/integration/components/inputs/people-select-test.ts
+++ b/web/tests/integration/components/inputs/people-select-test.ts
@@ -37,8 +37,7 @@ module("Integration | Component | inputs/people-select", function (hooks) {
 
     assert
       .dom(".ember-power-select-option")
-      .exists({ count: 1 })
-      .hasText("Type to search");
+      .doesNotExist('"Type to search" message is hidden');
 
     await fillIn(".ember-power-select-trigger-multiple-input", "u");
 
@@ -115,7 +114,7 @@ module("Integration | Component | inputs/people-select", function (hooks) {
 
     assert
       .dom(".ember-power-select-option--loading-message")
-      .hasText("Loading options...");
+      .hasText("Loading...");
 
     await fillInPromise;
 


### PR DESCRIPTION
- Updates the PeopleSelec to better match our other popover inputs. 
- Widens and properly offsets popover:
![CleanShot 2024-03-06 at 11 27 38](https://github.com/hashicorp-forge/hermes/assets/754957/ee37d7a3-e7c1-426f-8c9a-42d1a96eea49)
- Reduces template movement when entering and existing modes:
 ![CleanShot 2024-03-06 at 11 24 01](https://github.com/hashicorp-forge/hermes/assets/754957/3a984f3b-fbaa-458c-a82b-4ff7eec3736a)
- Removes redundant "Type to search" popover state
- Increases number of people shown before scroll is required