### PR TITLE
Make doc owners clickable

### DIFF
--- a/web/app/components/doc/tile-medium.hbs
+++ b/web/app/components/doc/tile-medium.hbs
@@ -16,7 +16,7 @@
         data-test-document-owner-avatar
         tabindex="-1"
         @route="authenticated.documents"
-        @query={{this.ownerQuery}}
+        @query={{get-owner-query owner}}
         disabled={{not owner}}
       >
         <Person::Avatar
@@ -65,7 +65,7 @@
               tabindex="-1"
               data-test-document-owner-name
               @route="authenticated.documents"
-              @query={{this.ownerQuery}}
+              @query={{get-owner-query owner}}
               disabled={{not owner}}
               class="underline-on-hover inline-block"
             >

--- a/web/app/components/doc/tile-medium.ts
+++ b/web/app/components/doc/tile-medium.ts
@@ -64,18 +64,6 @@ export default class DocTileMediumComponent extends Component<DocTileMediumCompo
       return this.args.doc._snippetResult?.content.value;
     }
   }
-  /**
-   * The query parameters for the doc-owner LinkTos.
-   * Sets the "owners" filter to the owner of the document,
-   * and default values for the rest.
-   */
-  protected get ownerQuery() {
-    return {
-      ...DEFAULT_FILTERS,
-      owners: this.args.doc.owners,
-      page: 1,
-    };
-  }
 }
 
 declare module "@glint/environment-ember-loose/registry" {

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -248,9 +248,16 @@
       </div>
 
       {{! Owner }}
-      <div class="space-y-2">
-        <Document::Sidebar::SectionHeader @title="Owner" />
-        <Person @email={{get @document.owners 0}} />
+      <div class="flex flex-col items-start">
+        <Document::Sidebar::SectionHeader @title="Owner" class="mb-2" />
+        <LinkTo
+          data-test-owner-link
+          @route="authenticated.documents"
+          @query={{get-owner-query (get @document.owners 0)}}
+          class="underlined-link grid"
+        >
+          <Person @email={{get @document.owners 0}} />
+        </LinkTo>
       </div>
 
       {{! Contributors }}

--- a/web/app/components/person/index.hbs
+++ b/web/app/components/person/index.hbs
@@ -1,5 +1,5 @@
 {{#unless this.isHidden}}
-  <div class="flex w-full space-x-2" ...attributes>
+  <div class="flex w-full min-w-0 space-x-2" ...attributes>
     <div class="relative shrink-0">
       <Person::Avatar @size="small" @email={{@email}} />
       {{#if this.badgeIsShown}}

--- a/web/app/components/table/row.hbs
+++ b/web/app/components/table/row.hbs
@@ -42,8 +42,15 @@
     </div>
   </td>
   <td data-test-table-row-owner-cell class="owner">
-    <div class="inner">
-      <Person @email={{get @doc.owners 0}} />
+    <div class="inner flex flex-col items-start">
+      <LinkTo
+        data-test-owner-link
+        @route="authenticated.documents"
+        @query={{get-owner-query (get @doc.owners 0)}}
+        class="underlined-link grid"
+      >
+        <Person @email={{get @doc.owners 0}} />
+      </LinkTo>
     </div>
   </td>
   <td class="time">

--- a/web/app/helpers/get-owner-query.ts
+++ b/web/app/helpers/get-owner-query.ts
@@ -1,0 +1,33 @@
+import Helper from "@ember/component/helper";
+import { DEFAULT_FILTERS } from "hermes/services/active-filters";
+
+interface GetOwnerQueryHelperSignature {
+  Args: {
+    Positional: [email: string | undefined];
+  };
+  Return: Record<string, unknown>;
+}
+/**
+ * Generates a query hash filtering to a specific owner.
+ * Used in templates to make owners clickable.
+ */
+export default class GetOwnerQueryHelper extends Helper<GetOwnerQueryHelperSignature> {
+  compute(positional: GetOwnerQueryHelperSignature["Args"]["Positional"]) {
+    const owner = positional[0];
+    if (owner) {
+      return {
+        ...DEFAULT_FILTERS,
+        owners: [owner],
+        page: 1,
+      };
+    } else {
+      return {};
+    }
+  }
+}
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry {
+    "get-owner-query": typeof GetOwnerQueryHelper;
+  }
+}

--- a/web/tests/acceptance/authenticated/document-test.ts
+++ b/web/tests/acceptance/authenticated/document-test.ts
@@ -66,6 +66,8 @@ const TOGGLE_SELECT = "[data-test-x-dropdown-list-toggle-select]";
 
 const DISABLED_FOOTER_H5 = "[data-test-disabled-footer-h5]";
 
+const OWNER_LINK = "[data-test-owner-link]";
+
 const EDITABLE_FIELD_READ_VALUE = "[data-test-editable-field-read-value]";
 const EDITABLE_PRODUCT_AREA_SELECTOR =
   "[data-test-document-product-area-editable]";
@@ -191,6 +193,21 @@ module("Acceptance | authenticated/document", function (hooks) {
 
     assert.dom(DOC_STATUS_TOGGLE).doesNotExist();
     assert.dom(DOC_STATUS).hasText("WIP", "label exists but isn't clickable");
+  });
+
+  test("the owner is clickable", async function (this: AuthenticatedDocumentRouteTestContext, assert) {
+    this.server.create("document", {
+      objectID: 1,
+    });
+
+    await visit("/document/1");
+
+    assert
+      .dom(OWNER_LINK)
+      .hasAttribute(
+        "href",
+        `/documents?owners=%5B%22${encodeURIComponent(TEST_USER_EMAIL)}%22%5D`,
+      );
   });
 
   test("you can change a draft's product area", async function (this: AuthenticatedDocumentRouteTestContext, assert) {

--- a/web/tests/acceptance/authenticated/documents-test.ts
+++ b/web/tests/acceptance/authenticated/documents-test.ts
@@ -5,6 +5,7 @@ import { authenticateSession } from "ember-simple-auth/test-support";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { getPageTitle } from "ember-page-title/test-support";
 import { FacetLabel } from "hermes/helpers/get-facet-label";
+import { TEST_USER_EMAIL } from "hermes/mirage/utils";
 
 const TABLE_HEADER_CREATED_SELECTOR =
   "[data-test-sortable-table-header][data-test-attribute=createdTime]";
@@ -13,6 +14,7 @@ const DROPDOWN_ITEM = "[data-test-facet-dropdown-link]";
 const DOC_LINK = "[data-test-document-link]";
 const ACTIVE_FILTER_LINK = "[data-test-active-filter-link]";
 const CLEAR_ALL_LINK = "[data-test-clear-all-filters-link]";
+const OWNER_LINK = "[data-test-owner-link]";
 
 interface AuthenticatedDocumentsRouteTestContext extends MirageTestContext {}
 module("Acceptance | authenticated/documents", function (hooks) {
@@ -83,6 +85,19 @@ module("Acceptance | authenticated/documents", function (hooks) {
     await click(ACTIVE_FILTER_LINK);
 
     assert.dom(DOC_LINK).exists({ count: 4 });
+  });
+
+  test("owners are clickable", async function (this: AuthenticatedDocumentsRouteTestContext, assert) {
+    this.server.create("document");
+
+    await visit("/documents");
+
+    assert
+      .dom(OWNER_LINK)
+      .hasAttribute(
+        "href",
+        `/documents?owners=%5B%22${encodeURIComponent(TEST_USER_EMAIL)}%22%5D`,
+      );
   });
 
   /**

--- a/web/tests/integration/helpers/get-owner-query-test.ts
+++ b/web/tests/integration/helpers/get-owner-query-test.ts
@@ -1,0 +1,37 @@
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+import { TestContext, render, rerender } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import { TEST_USER_EMAIL } from "hermes/mirage/utils";
+
+interface Context extends TestContext {
+  email?: string;
+}
+
+module("Integration | Helper | get-owner-query", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("it generates the correct href", async function (this: Context, assert) {
+    const email = TEST_USER_EMAIL;
+    this.set("email", email);
+
+    await render<Context>(hbs`
+      <LinkTo
+        @route="authenticated.documents"
+        @query={{get-owner-query this.email}}
+      >
+        Click
+      </LinkTo>
+    `);
+
+    const encodedEmail = encodeURIComponent(email);
+
+    assert
+      .dom("a")
+      .hasAttribute("href", `/documents?owners=%5B%22${encodedEmail}%22%5D`);
+
+    this.set("email", undefined);
+
+    assert.dom("a").hasAttribute("href", "/documents");
+  });
+});


### PR DESCRIPTION
Makes doc owners clickable site-wide instead of only the DocTileMedium component.