### PR TITLE
Clean up document status filter

### DIFF
--- a/web/app/components/header/toolbar.ts
+++ b/web/app/components/header/toolbar.ts
@@ -133,7 +133,10 @@ export default class ToolbarComponent extends Component<ToolbarComponentSignatur
       let facetArray: FacetArrayItem[] = [];
 
       Object.entries(this.args.facets).forEach(([key, value]) => {
-        if (key === FacetName.Status && this.args.scope === SearchScope.Docs) {
+        if (
+          key === FacetName.Status &&
+          this.args.scope !== SearchScope.Projects
+        ) {
           facetArray.push({ name: key, values: this.statuses });
         } else {
           facetArray.push({ name: key as FacetName, values: value });

--- a/web/tests/integration/components/header/toolbar-test.ts
+++ b/web/tests/integration/components/header/toolbar-test.ts
@@ -62,7 +62,6 @@ module("Integration | Component | header/toolbar", function (hooks) {
 
     await render<ToolbarTestContext>(hbs`
       <Header::Toolbar @scope={{this.scope}} @facets={{this.facets}} />
-    // Close and reopn
     `);
 
     await click(STATUS_TOGGLE);

--- a/web/tests/integration/components/header/toolbar-test.ts
+++ b/web/tests/integration/components/header/toolbar-test.ts
@@ -15,6 +15,7 @@ const OWNER_TOGGLE = `[data-test-facet-dropdown-trigger="${FacetLabel.Owners}"]`
 const DROPDOWN_ITEM = "[data-test-facet-dropdown-link]";
 const POPOVER = "[data-test-facet-dropdown-popover]";
 const CHECK = "[data-test-x-dropdown-list-checkable-item-check]";
+const LIST_ITEM_VALUE = "[data-test-x-dropdown-list-item-value]";
 
 const FACETS = {
   docType: {
@@ -61,16 +62,43 @@ module("Integration | Component | header/toolbar", function (hooks) {
 
     await render<ToolbarTestContext>(hbs`
       <Header::Toolbar @scope={{this.scope}} @facets={{this.facets}} />
+    // Close and reopn
     `);
 
-    await click("[data-test-facet-dropdown-trigger='Status']");
+    await click(STATUS_TOGGLE);
+
+    const docFilters = [
+      "Approved",
+      "In-Review",
+      "In Review",
+      "Obsolete",
+      "WIP",
+    ];
 
     assert.deepEqual(
-      findAll("[data-test-x-dropdown-list-item-value]")?.map(
-        (el) => el.textContent?.trim(),
-      ),
-      ["Approved", "In-Review", "In Review", "Obsolete", "WIP"],
+      findAll(LIST_ITEM_VALUE)?.map((el) => el.textContent?.trim()),
+      docFilters,
       "Unsupported statuses are filtered out",
+    );
+
+    // Close and reopen (changing the scope closes the dropdown)
+    this.set("scope", SearchScope.Projects);
+    await click(STATUS_TOGGLE);
+
+    assert.deepEqual(
+      findAll(LIST_ITEM_VALUE)?.map((el) => el.textContent?.trim()),
+      STATUS_NAMES,
+      "All statuses are shown when the scope is not 'Docs'",
+    );
+
+    // Close and reopen
+    this.set("scope", undefined);
+    await click(STATUS_TOGGLE);
+
+    assert.deepEqual(
+      findAll(LIST_ITEM_VALUE)?.map((el) => el.textContent?.trim()),
+      docFilters,
+      "All statuses are shown when the scope is not defined",
     );
   });
 


### PR DESCRIPTION
Fixes a regression (#619) causing non-standard statuses to appear in the filter dropdown.