### PR TITLE
Reset active filters when clicking "See older documents"

### DIFF
--- a/web/app/components/dashboard/latest-docs.hbs
+++ b/web/app/components/dashboard/latest-docs.hbs
@@ -23,7 +23,7 @@
         @iconPosition="trailing"
         @isFullWidth={{true}}
         @route="authenticated.documents"
-        @query={{hash page=2}}
+        @query={{this.query}}
         class="py-3"
       />
     </div>

--- a/web/app/components/dashboard/latest-docs.ts
+++ b/web/app/components/dashboard/latest-docs.ts
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import LatestDocsService from "hermes/services/latest-docs";
 import { HermesDocument } from "hermes/types/document";
 import { inject as service } from "@ember/service";
+import { DEFAULT_FILTERS } from "hermes/services/active-filters";
 
 interface DashboardLatestDocsComponentSignature {}
 
@@ -18,6 +19,17 @@ export default class DashboardLatestDocsComponent extends Component<DashboardLat
 
   protected get docs(): HermesDocument[] | null {
     return this.latestDocs.index;
+  }
+
+  /**
+   * The query of the "See older docs" link.
+   * Resets any active filters and sets the page to 2.
+   */
+  protected get query() {
+    return {
+      ...DEFAULT_FILTERS,
+      page: 2,
+    };
   }
 }
 

--- a/web/tests/integration/components/dashboard/latest-docs-test.ts
+++ b/web/tests/integration/components/dashboard/latest-docs-test.ts
@@ -4,6 +4,7 @@ import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
 import { render, waitFor } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import LatestDocsService from "hermes/services/latest-docs";
+import ActiveFiltersService from "hermes/services/active-filters";
 
 const NO_DOCS_PUBLISHED = "[data-test-no-docs-published]";
 const LATEST_DOC = "[data-test-latest-doc]";
@@ -45,6 +46,14 @@ module("Integration | Component | dashboard/latest-docs", function (hooks) {
   test("it shows a link to the next page of docs if there are more than one page", async function (this: Context, assert) {
     this.server.createList("document", 10);
 
+    const activeFilters = this.owner.lookup(
+      "service:active-filters",
+    ) as ActiveFiltersService;
+
+    activeFilters.update({
+      product: ["Labs"],
+    });
+
     const latestDocs = this.owner.lookup(
       "service:latest-docs",
     ) as LatestDocsService;
@@ -56,7 +65,13 @@ module("Integration | Component | dashboard/latest-docs", function (hooks) {
       <Dashboard::LatestDocs />
     `);
 
-    assert.dom(ALL_DOCS_LINK).exists();
+    assert
+      .dom(ALL_DOCS_LINK)
+      .hasAttribute(
+        "href",
+        "/documents?page=2",
+        "it links to a filter-less second page of docs",
+      );
   });
 
   test("it shows an icon when the fetch task is running", async function (this: Context, assert) {


### PR DESCRIPTION
Makes sure any active filters are reset when clicking the "See older documents" link on the dashboard.