### PR TITLE
Add fallback for non-standard doc statuses

### DIFF
--- a/web/app/components/document/status-icon.hbs
+++ b/web/app/components/document/status-icon.hbs
@@ -32,7 +32,7 @@
     />
   {{/if}}
 
-  {{#if (or this.isDraft this.isInReview)}}
+  {{#if this.defaultStrokeIsShown}}
     {{! page stroke }}
     <path
       data-test-default-page-stroke

--- a/web/app/components/document/status-icon.ts
+++ b/web/app/components/document/status-icon.ts
@@ -26,6 +26,21 @@ export default class DocumentStatusIconComponent extends Component<DocumentStatu
   protected get isObsolete() {
     return this.args.status === "Obsolete";
   }
+  /**
+   * Whether the default stroke is shown.
+   * True if the doc is a draft, in review, or in a non-standard state
+   */
+  protected get defaultStrokeIsShown() {
+    if (
+      this.isDraft ||
+      this.isInReview ||
+      (!this.isApproved && !this.isObsolete)
+    ) {
+      return true;
+    } else {
+      return false;
+    }
+  }
 }
 
 declare module "@glint/environment-ember-loose/registry" {

--- a/web/tests/integration/components/document/status-icon-test.ts
+++ b/web/tests/integration/components/document/status-icon-test.ts
@@ -69,5 +69,11 @@ module("Integration | Component | document/status-icon", function (hooks) {
     assert
       .dom(OBSOLETE_PAGE_STROKE)
       .exists("the obsolete state has a custom page stroke");
+
+    status = "Non-Standard";
+    this.set("status", status);
+
+    assert.dom(DEFAULT_PAGE_FILL).exists();
+    assert.dom(DEFAULT_PAGE_STROKE).exists();
   });
 });


### PR DESCRIPTION
Adds a fallback doc icon for non-standard statuses (recently viewed docs).