### PR TITLE
Filter inaccessible docs out of Recently Viewed

### DIFF
--- a/web/app/services/recently-viewed.ts
+++ b/web/app/services/recently-viewed.ts
@@ -91,7 +91,7 @@ export default class RecentlyViewedService extends Service {
 
       // Create a placeholder array for the full item promises
       let fullItemPromises: Promise<
-        RecentlyViewedDoc | RecentlyViewedProject
+        RecentlyViewedDoc | RecentlyViewedProject | null
       >[] = [];
 
       // Promise to get each doc and return it in the RecentlyViewedDoc format
@@ -109,7 +109,13 @@ export default class RecentlyViewedService extends Service {
                 doc,
                 ...d,
               };
-            }),
+            })
+            /**
+             * A failed fetch here is likely a deleted or newly private draft.
+             * We return null to filter it out of the array and keep the
+             * widget from breaking.
+             */
+            .catch(() => null),
         );
       });
 
@@ -134,6 +140,7 @@ export default class RecentlyViewedService extends Service {
       // Load doc owners into the store
       await this.store.maybeFetchPeople.perform(
         formattedItems.map((d) => {
+          if (!d) return;
           if ("doc" in d) {
             return d.doc;
           }
@@ -141,7 +148,7 @@ export default class RecentlyViewedService extends Service {
       );
 
       // Update the local array to recompute the getter
-      this._index = formattedItems;
+      this._index = formattedItems.compact();
     } catch (e) {
       // Log an error if the fetch fails
       console.error("Error fetching recently viewed docs", e);

--- a/web/tests/unit/services/recently-viewed-test.ts
+++ b/web/tests/unit/services/recently-viewed-test.ts
@@ -2,6 +2,7 @@ import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
 import RecentlyViewedService from "hermes/services/recently-viewed";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
+import { TEST_USER_2_EMAIL } from "hermes/mirage/utils";
 
 interface Context extends MirageTestContext {
   recentlyViewed: RecentlyViewedService;
@@ -27,6 +28,25 @@ module("Unit | Service | recently-viewed", function (hooks) {
       this.recentlyViewed.index?.length,
       10,
       "the index is populated",
+    );
+  });
+
+  test("it ignores errors when fetching the index", async function (this: Context, assert) {
+    // Create a document that the user does not have access to
+    this.server.create("document", { id: 1, owners: [TEST_USER_2_EMAIL] });
+    this.server.create("recently-viewed-doc", {
+      id: 1,
+    });
+
+    // Create documents that the user has access to
+    this.server.createList("recently-viewed-doc", 5);
+
+    await this.recentlyViewed.fetchAll.perform();
+
+    assert.equal(
+      this.recentlyViewed.index?.length,
+      5,
+      "the inaccessible document is ignored",
     );
   });
 });


### PR DESCRIPTION
Adds error logic to the RecentlyViewed service, fixing an issue where a deleted or private draft would break the dashboard. 