### PR TITLE
ModalAlertsService refactor

### DIFF
--- a/web/app/components/new/doc-form.ts
+++ b/web/app/components/new/doc-form.ts
@@ -8,7 +8,7 @@ import Ember from "ember";
 import FetchService from "hermes/services/fetch";
 import AuthenticatedUserService from "hermes/services/authenticated-user";
 import RouterService from "@ember/routing/router-service";
-import ModalAlertsService from "hermes/services/modal-alerts";
+import ModalAlertsService, { ModalType } from "hermes/services/modal-alerts";
 import { assert } from "@ember/debug";
 import cleanString from "hermes/utils/clean-string";
 import { ProductArea } from "hermes/services/product-areas";
@@ -227,7 +227,7 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
              * If `create_docs_as_user` is false, show a modal alert
              * explaining the limitations on notifications.
              */
-            this.modalAlerts.setActive.perform("draftCreated");
+            this.modalAlerts.setActive(ModalType.DraftCreated);
           }
         });
     } catch (e) {

--- a/web/app/services/modal-alerts.ts
+++ b/web/app/services/modal-alerts.ts
@@ -2,9 +2,11 @@ import Service, { inject as service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import RouterService from "@ember/routing/router-service";
-import { task, timeout } from "ember-concurrency";
+import { schedule } from "@ember/runloop";
 
-export type ModalType = "draftCreated";
+export enum ModalType {
+  DraftCreated = "draftCreated",
+}
 
 export default class ModalAlertsService extends Service {
   @service declare router: RouterService;
@@ -22,8 +24,13 @@ export default class ModalAlertsService extends Service {
     this.activeModal = null;
   }
 
-  setActive = task(async (modalType: ModalType, delay: number = 0) => {
-    await timeout(delay);
-    this.activeModal = modalType;
-  });
+  /**
+   * The action to activate a modal by name.
+   * Scheduled `afterRender` to work on cross-route transitions
+   */
+  @action setActive(modalType: ModalType) {
+    schedule("afterRender", () => {
+      this.activeModal = modalType;
+    });
+  }
 }

--- a/web/app/services/recently-viewed.ts
+++ b/web/app/services/recently-viewed.ts
@@ -91,7 +91,7 @@ export default class RecentlyViewedService extends Service {
 
       // Create a placeholder array for the full item promises
       let fullItemPromises: Promise<
-        RecentlyViewedDoc | RecentlyViewedProject
+        RecentlyViewedDoc | RecentlyViewedProject | null
       >[] = [];
 
       // Promise to get each doc and return it in the RecentlyViewedDoc format
@@ -109,7 +109,13 @@ export default class RecentlyViewedService extends Service {
                 doc,
                 ...d,
               };
-            }),
+            })
+            /**
+             * A failed fetch here is likely a deleted or newly private draft.
+             * We return null to filter it out of the array and keep the
+             * widget from breaking.
+             */
+            .catch(() => null),
         );
       });
 
@@ -134,6 +140,7 @@ export default class RecentlyViewedService extends Service {
       // Load doc owners into the store
       await this.store.maybeFetchPeople.perform(
         formattedItems.map((d) => {
+          if (!d) return;
           if ("doc" in d) {
             return d.doc;
           }
@@ -141,7 +148,7 @@ export default class RecentlyViewedService extends Service {
       );
 
       // Update the local array to recompute the getter
-      this._index = formattedItems;
+      this._index = formattedItems.compact();
     } catch (e) {
       // Log an error if the fetch fails
       console.error("Error fetching recently viewed docs", e);

--- a/web/tests/integration/components/modals/index-test.ts
+++ b/web/tests/integration/components/modals/index-test.ts
@@ -2,20 +2,20 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
 import { render, rerender } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import ModalAlertsService from "hermes/services/modal-alerts";
+import ModalAlertsService, { ModalType } from "hermes/services/modal-alerts";
 
 module("Integration | Component | modals", function (hooks) {
   setupRenderingTest(hooks);
 
   test("it conditionally renders modals", async function (assert) {
     let modalAlerts = this.owner.lookup(
-      "service:modal-alerts"
+      "service:modal-alerts",
     ) as ModalAlertsService;
 
     await render(hbs`{{! @glint-nocheck }}<Modals />`);
 
     assert.dom("dialog").doesNotExist();
-    await modalAlerts.setActive.perform("draftCreated");
+    modalAlerts.setActive(ModalType.DraftCreated);
 
     await rerender();
     assert.dom("dialog").exists("draftCreated modal shown");

--- a/web/tests/unit/services/modal-alerts-test.ts
+++ b/web/tests/unit/services/modal-alerts-test.ts
@@ -1,6 +1,7 @@
 import { module, test, todo } from "qunit";
 import { setupTest } from "ember-qunit";
 import ModalAlertsService, { ModalType } from "hermes/services/modal-alerts";
+import { waitFor, waitUntil } from "@ember/test-helpers";
 
 module("Unit | Service | modal-alerts", function (hooks) {
   setupTest(hooks);
@@ -13,7 +14,8 @@ module("Unit | Service | modal-alerts", function (hooks) {
     assert.equal(modalAlerts.activeModal, null);
 
     modalAlerts.setActive(ModalType.DraftCreated);
-    assert.equal(modalAlerts.activeModal, ModalType.DraftCreated);
+
+    await waitUntil(() => modalAlerts.activeModal === ModalType.DraftCreated);
 
     modalAlerts.close();
 

--- a/web/tests/unit/services/modal-alerts-test.ts
+++ b/web/tests/unit/services/modal-alerts-test.ts
@@ -1,26 +1,22 @@
 import { module, test, todo } from "qunit";
 import { setupTest } from "ember-qunit";
-import ModalAlertsService from "hermes/services/modal-alerts";
+import ModalAlertsService, { ModalType } from "hermes/services/modal-alerts";
 
 module("Unit | Service | modal-alerts", function (hooks) {
   setupTest(hooks);
 
   test("can set or close an active modal", async function (assert) {
     const modalAlerts = this.owner.lookup(
-      "service:modal-alerts"
+      "service:modal-alerts",
     ) as ModalAlertsService;
 
     assert.equal(modalAlerts.activeModal, null);
 
-    await modalAlerts.setActive.perform("draftCreated");
-    assert.equal(modalAlerts.activeModal, "draftCreated");
+    modalAlerts.setActive(ModalType.DraftCreated);
+    assert.equal(modalAlerts.activeModal, ModalType.DraftCreated);
 
     modalAlerts.close();
 
     assert.equal(modalAlerts.activeModal, null);
-  });
-
-  todo("can set an active modal with a delay", async function (assert) {
-    assert.equal(true, false);
   });
 });

--- a/web/tests/unit/services/recently-viewed-test.ts
+++ b/web/tests/unit/services/recently-viewed-test.ts
@@ -2,6 +2,7 @@ import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
 import RecentlyViewedService from "hermes/services/recently-viewed";
 import { MirageTestContext, setupMirage } from "ember-cli-mirage/test-support";
+import { TEST_USER_2_EMAIL } from "hermes/mirage/utils";
 
 interface Context extends MirageTestContext {
   recentlyViewed: RecentlyViewedService;
@@ -27,6 +28,25 @@ module("Unit | Service | recently-viewed", function (hooks) {
       this.recentlyViewed.index?.length,
       10,
       "the index is populated",
+    );
+  });
+
+  test("it ignores errors when fetching the index", async function (this: Context, assert) {
+    // Create a document that the user does not have access to
+    this.server.create("document", { id: 1, owners: [TEST_USER_2_EMAIL] });
+    this.server.create("recently-viewed-doc", {
+      id: 1,
+    });
+
+    // Create documents that the user has access to
+    this.server.createList("recently-viewed-doc", 5);
+
+    await this.recentlyViewed.fetchAll.perform();
+
+    assert.equal(
+      this.recentlyViewed.index?.length,
+      5,
+      "the inaccessible document is ignored",
     );
   });
 });


### PR DESCRIPTION
Converts string ModalTypes to enums. Refactors the `setActive` action to fix a flicker when hiding and immediately showing another modal.