### PR TITLE
Remove background fetch calls to the `recently-viewed` endpoint

### DIFF
--- a/web/app/routes/authenticated/dashboard.ts
+++ b/web/app/routes/authenticated/dashboard.ts
@@ -60,11 +60,7 @@ export default class DashboardRoute extends Route {
       promises.push(this.latestDocs.fetchAll.perform().then(() => {}));
     }
 
-    if (this.recentlyViewed.index) {
-      void this.recentlyViewed.fetchAll.perform();
-    } else {
-      promises.push(this.recentlyViewed.fetchAll.perform());
-    }
+    promises.push(this.recentlyViewed.fetchAll.perform());
 
     const [docsAwaitingReview] = await Promise.all(promises);
 

--- a/web/app/routes/authenticated/document.ts
+++ b/web/app/routes/authenticated/document.ts
@@ -197,12 +197,6 @@ export default class AuthenticatedDocumentRoute extends Route {
 
   afterModel(model: DocumentRouteModel, transition: any) {
     /**
-     * Generally speaking, ensure an up-to-date list of recently viewed docs
-     * by the time the user returns to the dashboard.
-     */
-    void this.recentlyViewed.fetchAll.perform();
-
-    /**
      * Record the document view with the analytics backend.
      */
     void this.fetchSvc.fetch(

--- a/web/app/routes/authenticated/projects/project.ts
+++ b/web/app/routes/authenticated/projects/project.ts
@@ -64,11 +64,6 @@ export default class AuthenticatedProjectsProjectRoute extends Route {
 
   afterModel() {
     /**
-     * Update the recently viewed index in the background.
-     */
-    void this.recentlyViewed.fetchAll.perform();
-
-    /**
      * Set `newModelHasLoaded` false in case it was set true in the model hook.
      */
     schedule("afterRender", () => {

--- a/web/tests/acceptance/authenticated/projects/project-test.ts
+++ b/web/tests/acceptance/authenticated/projects/project-test.ts
@@ -794,6 +794,7 @@ module("Acceptance | authenticated/projects/project", function (hooks) {
 
     await visit("/projects/1");
 
+    await recentlyViewed.fetchAll.perform();
     assert.equal(recentlyViewed.index?.length, 1);
 
     const project = recentlyViewed.index?.[0];


### PR DESCRIPTION
Removes the background fetch calls to the `/recently-viewed` endpoint when viewing a document or project. These once ensured an up-to-date dashboard, but since this method no longer works, they're now useless.