### PR TITLE
Enable sending an email to users not found in the Google Workspace directory

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -232,6 +232,10 @@ type GoogleWorkspace struct {
 	// create_docs_as_user is true in the auth block, so document notification
 	// settings will be the same as when a user creates their own document.
 	TemporaryDraftsFolder string `hcl:"temporary_drafts_folder,optional"`
+
+	// UserNotFoundEmail is the configuration to send an email when a user is not
+	// found in Google Workspace.
+	UserNotFoundEmail *GoogleWorkspaceUserNotFoundEmail `hcl:"user_not_found_email,block"`
 }
 
 // GoogleWorkspaceOAuth2 is the configuration to use OAuth 2.0 to access Google
@@ -247,6 +251,20 @@ type GoogleWorkspaceOAuth2 struct {
 	// RedirectURI is an authorized redirect URI for the given client_id as
 	// specified in the Google API Console Credentials page.
 	RedirectURI string `hcl:"redirect_uri,optional"`
+}
+
+// GoogleWorkspaceUserNotFoundEmail is the configuration to send an email when a
+// user is not found in Google Workspace.
+type GoogleWorkspaceUserNotFoundEmail struct {
+	// Body is the body of the email.
+	Body string `hcl:"body,optional"`
+
+	// Enabled enables sending an email when a user is not found in Google
+	// Workspace.
+	Enabled bool `hcl:"enabled,optional"`
+
+	// Subject is the subject of the email.
+	Subject string `hcl:"subject,optional"`
 }
 
 // Jira is the configuration for Hermes to work with Jira.


### PR DESCRIPTION
We have encountered rare cases where users may not be found in the Google Workspace directory, which prevents them from logging into Hermes. This PR enables sending an email to these users with custom remediation instructions.

### New config block

```hcl
google_workspace {
  ...
  user_not_found_email {
    body    = "Oh no! :-("
    enabled = true
    subject = "Unable to sign into Hermes"

  }
  ...
}
```