### PR TITLE
Update FloatingUI package and add `is-dragging` logic

### DIFF
--- a/web/app/components/floating-u-i/index.hbs
+++ b/web/app/components/floating-u-i/index.hbs
@@ -18,6 +18,7 @@
     @anchor={{this.anchor}}
     @id={{this.contentID}}
     @matchAnchorWidth={{@matchAnchorWidth}}
+    @hide={{this.hideContent}}
     ...attributes
   >
     {{yield

--- a/web/package.json
+++ b/web/package.json
@@ -133,7 +133,7 @@
   },
   "dependencies": {
     "@csstools/postcss-sass": "^5.0.1",
-    "@floating-ui/dom": "^1.2.4",
+    "@floating-ui/dom": "^1.6.3",
     "@hashicorp/design-system-components": "^3.1.0",
     "@hashicorp/ember-flight-icons": "^4.0.2",
     "@types/sinon": "^10.0.13",

--- a/web/tests/integration/components/floating-u-i/content-test.ts
+++ b/web/tests/integration/components/floating-u-i/content-test.ts
@@ -1,12 +1,6 @@
 import { module, test, todo } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
-import {
-  TestContext,
-  find,
-  render,
-  rerender,
-  waitUntil,
-} from "@ember/test-helpers";
+import { TestContext, find, render, waitUntil } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import htmlElement from "hermes/utils/html-element";
 import { OffsetOptions } from "@floating-ui/dom";
@@ -298,9 +292,7 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
   test("it runs the passed-in hide action when the anchor is dragged", async function (assert) {
     this.set("class", "");
     this.set("isShown", true);
-
     this.set("spacerIsShown", true);
-
     this.set("hide", () => {
       this.set("isShown", false);
     });
@@ -337,7 +329,7 @@ module("Integration | Component | floating-u-i/content", function (hooks) {
     // Trigger a layout shift
     this.set("spacerIsShown", false);
 
-    // Confirm tht the content is hidden
+    // Confirm that the content is hidden
     await waitUntil(() => {
       return !find(CONTENT_SELECTOR);
     });

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3422,19 +3422,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/core@npm:^1.2.3":
-  version: 1.2.4
-  resolution: "@floating-ui/core@npm:1.2.4"
-  checksum: 1c163ea1804e2b0a28fda6e32efed0e242d0db8081fd24aab9d1cbb100f94a558709231c483bf74bf09a9204ea6e7845813d43b5322ceb6ee63285308f68f65b
+"@floating-ui/core@npm:^1.0.0":
+  version: 1.6.0
+  resolution: "@floating-ui/core@npm:1.6.0"
+  dependencies:
+    "@floating-ui/utils": ^0.2.1
+  checksum: 2e25c53b0c124c5c9577972f8ae21d081f2f7895e6695836a53074463e8c65b47722744d6d2b5a993164936da006a268bcfe87fe68fd24dc235b1cb86bed3127
   languageName: node
   linkType: hard
 
-"@floating-ui/dom@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "@floating-ui/dom@npm:1.2.4"
+"@floating-ui/dom@npm:^1.6.3":
+  version: 1.6.3
+  resolution: "@floating-ui/dom@npm:1.6.3"
   dependencies:
-    "@floating-ui/core": ^1.2.3
-  checksum: 5c24a2e8f04e436390646c8a4431c6cb79e03711fbb0f818b87d613a6be8971bc560a830b702aaa51a0ebc4d0c45deb06f3140c14125dc1ac770365bf66ee903
+    "@floating-ui/core": ^1.0.0
+    "@floating-ui/utils": ^0.2.0
+  checksum: 81cbb18ece3afc37992f436e469e7fabab2e433248e46fff4302d12493a175b0c64310f8a971e6e1eda7218df28ace6b70237b0f3c22fe12a21bba05b5579555
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.0, @floating-ui/utils@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "@floating-ui/utils@npm:0.2.1"
+  checksum: 9ed4380653c7c217cd6f66ae51f20fdce433730dbc77f95b5abfb5a808f5fdb029c6ae249b4e0490a816f2453aa6e586d9a873cd157fdba4690f65628efc6e06
   languageName: node
   linkType: hard
 
@@ -13465,7 +13475,7 @@ __metadata:
     "@csstools/postcss-sass": ^5.0.1
     "@ember/optional-features": ^2.0.0
     "@ember/test-helpers": ^2.6.0
-    "@floating-ui/dom": ^1.2.4
+    "@floating-ui/dom": ^1.6.3
     "@gavant/glint-template-types": ^0.3.6
     "@glimmer/component": ^1.0.4
     "@glimmer/tracking": ^1.0.4


### PR DESCRIPTION
- Updates the FloatingUI package to get the `layoutShift` listener/property that allows us to react to changes in the layout.
- Adds logic to hide a popover when its parent contains the `.is-dragging` class, as can be the case in the forthcoming drag-and-drop UI.
- Resolves some Glint errors in the `content-test` file