### PR TITLE
Projects pagination: Reset page count when clicking segmented control

### DIFF
--- a/web/app/components/projects/index.hbs
+++ b/web/app/components/projects/index.hbs
@@ -7,7 +7,7 @@
       <LinkTo
         data-test-tab={{status.value}}
         @route="authenticated.projects"
-        @query={{hash status=status.value}}
+        @query={{hash status=status.value page=1}}
         class="hds-button hds-button--color-secondary"
       >
         {{status.label}}

--- a/web/tests/acceptance/authenticated/projects-test.ts
+++ b/web/tests/acceptance/authenticated/projects-test.ts
@@ -180,5 +180,16 @@ module("Acceptance | authenticated/projects", function (hooks) {
     assert
       .dom(getPageTwoButton())
       .hasAttribute("href", "/projects?page=2&status=archived");
+
+    // Click a pagination link
+    await click(getPageTwoButton());
+    assert.equal(currentURL(), "/projects?page=2&status=archived");
+
+    // Assert that the segmented controls have the correct hrefs (no page number)
+    assert.dom(ACTIVE_TAB).hasAttribute("href", "/projects");
+    assert
+      .dom(COMPLETED_TAB)
+      .hasAttribute("href", "/projects?status=completed");
+    assert.dom(ARCHIVED_TAB).hasAttribute("href", "/projects?status=archived");
   });
 });


### PR DESCRIPTION
Fixes a bug in projects pagination where switching between status segments would retain the previous `page` param.