### PR TITLE
Show group approvers in "Request review" modal

### DIFF
--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -769,7 +769,7 @@
               <Inputs::PeopleSelect
                 @includeGroups={{true}}
                 @renderInPlace={{true}}
-                @selected={{this.approvers}}
+                @selected={{this.allApprovers}}
                 @onChange={{this.updateApprovers}}
                 @disabled={{M.taskIsRunning}}
                 class="mb-0"

--- a/web/tests/acceptance/authenticated/document-test.ts
+++ b/web/tests/acceptance/authenticated/document-test.ts
@@ -772,9 +772,6 @@ module("Acceptance | authenticated/document", function (hooks) {
 
     assert.dom(DOC_STATUS).hasText("WIP");
 
-    // Add a group approver before publishing
-    await click(APPROVERS_SELECTOR);
-
     await click(SIDEBAR_PUBLISH_FOR_REVIEW_BUTTON_SELECTOR);
 
     assert.dom(PUBLISH_FOR_REVIEW_MODAL_SELECTOR).exists();

--- a/web/tests/acceptance/authenticated/document-test.ts
+++ b/web/tests/acceptance/authenticated/document-test.ts
@@ -74,6 +74,7 @@ const TRANSFER_OWNERSHIP_MODAL = "[data-test-transfer-ownership-modal]";
 const OWNERSHIP_TRANSFERRED_MODAL = "[data-test-ownership-transferred-modal]";
 const TRANSFERRING_DOC = "[data-test-transferring-doc]";
 const SELECT_NEW_OWNER_LABEL = "[data-test-select-new-owner-label]";
+const MODAL_PEOPLE_SELECT = "dialog [data-test-people-select]";
 const PEOPLE_SELECT_INPUT = ".ember-power-select-trigger-multiple-input";
 const PEOPLE_SELECT_OPTION =
   ".ember-power-select-option:not(.ember-power-select-option--no-matches-message)";
@@ -771,12 +772,15 @@ module("Acceptance | authenticated/document", function (hooks) {
 
     assert.dom(DOC_STATUS).hasText("WIP");
 
+    // Add a group approver before publishing
+    await click(APPROVERS_SELECTOR);
+
     await click(SIDEBAR_PUBLISH_FOR_REVIEW_BUTTON_SELECTOR);
 
     assert.dom(PUBLISH_FOR_REVIEW_MODAL_SELECTOR).exists();
 
     // Add an approver
-    await click("dialog [data-test-people-select]");
+    await click(MODAL_PEOPLE_SELECT);
 
     await fillIn(
       ".ember-power-select-trigger-multiple-input",
@@ -1806,5 +1810,10 @@ module("Acceptance | authenticated/document", function (hooks) {
     const doc = this.server.schema.document.find(1).attrs;
 
     assert.true(doc.approverGroups.includes(email));
+
+    // assert that it also appears in the people select on the Request Review modal
+    await click(SIDEBAR_PUBLISH_FOR_REVIEW_BUTTON_SELECTOR);
+
+    assert.dom(MODAL_PEOPLE_SELECT).containsText(name);
   });
 });

--- a/web/tests/acceptance/authenticated/document-test.ts
+++ b/web/tests/acceptance/authenticated/document-test.ts
@@ -1808,9 +1808,10 @@ module("Acceptance | authenticated/document", function (hooks) {
 
     assert.true(doc.approverGroups.includes(email));
 
-    // assert that it also appears in the people select on the Request Review modal
     await click(SIDEBAR_PUBLISH_FOR_REVIEW_BUTTON_SELECTOR);
 
-    assert.dom(MODAL_PEOPLE_SELECT).containsText(name);
+    assert
+      .dom(MODAL_PEOPLE_SELECT)
+      .containsText(name, "the modal PeopleSelect includes groups");
   });
 });


### PR DESCRIPTION
Fixes a bug causing newly added group approvers to be omitted from the "Request review" modal.