### PR TITLE
Move locked doc check in approvals API

### DIFF
--- a/internal/api/v2/approvals.go
+++ b/internal/api/v2/approvals.go
@@ -27,24 +27,6 @@ func ApprovalsHandler(srv server.Server) http.Handler {
 			return
 		}
 
-		// Check if document is locked.
-		locked, err := hcd.IsLocked(docID, srv.DB, srv.GWService, srv.Logger)
-		if err != nil {
-			srv.Logger.Error("error checking document locked status",
-				"error", err,
-				"path", r.URL.Path,
-				"method", r.Method,
-				"doc_id", docID,
-			)
-			http.Error(w, "Error getting document status", http.StatusNotFound)
-			return
-		}
-		// Don't continue if document is locked.
-		if locked {
-			http.Error(w, "Document is locked", http.StatusLocked)
-			return
-		}
-
 		// Get document from database.
 		model := models.Document{
 			GoogleFileID: docID,
@@ -127,6 +109,24 @@ func ApprovalsHandler(srv server.Server) http.Handler {
 			if contains(doc.ChangesRequestedBy, userEmail) {
 				http.Error(w, "Document already has changes requested by user",
 					http.StatusBadRequest)
+				return
+			}
+
+			// Check if document is locked.
+			locked, err := hcd.IsLocked(docID, srv.DB, srv.GWService, srv.Logger)
+			if err != nil {
+				srv.Logger.Error("error checking document locked status",
+					"error", err,
+					"path", r.URL.Path,
+					"method", r.Method,
+					"doc_id", docID,
+				)
+				http.Error(w, "Error getting document status", http.StatusNotFound)
+				return
+			}
+			// Don't continue if document is locked.
+			if locked {
+				http.Error(w, "Document is locked", http.StatusLocked)
 				return
 			}
 
@@ -395,6 +395,24 @@ func ApprovalsHandler(srv server.Server) http.Handler {
 				http.Error(w,
 					"Not authorized as a document approver",
 					http.StatusUnauthorized)
+				return
+			}
+
+			// Check if document is locked.
+			locked, err := hcd.IsLocked(docID, srv.DB, srv.GWService, srv.Logger)
+			if err != nil {
+				srv.Logger.Error("error checking document locked status",
+					"error", err,
+					"path", r.URL.Path,
+					"method", r.Method,
+					"doc_id", docID,
+				)
+				http.Error(w, "Error getting document status", http.StatusNotFound)
+				return
+			}
+			// Don't continue if document is locked.
+			if locked {
+				http.Error(w, "Document is locked", http.StatusLocked)
 				return
 			}
 


### PR DESCRIPTION
This PR moves the locked doc check to individual methods in the `approvals` API. This is to allow the `OPTIONS` method for locked docs - this method is used when group approvals are enabled and will prevent users from viewing locked docs without this change.