### PR TITLE
Validate signer for AWS ALB header

### DIFF
--- a/configs/config.hcl
+++ b/configs/config.hcl
@@ -210,6 +210,9 @@ okta {
 
   // disabled disables Okta authorization.
   disabled = true
+
+  // jwt_signer is the trusted signer for the ALB JWT header.
+  jwt_signer = ""
 }
 
 // postgres configures PostgreSQL as the app database.

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -144,6 +144,9 @@ func (c *Command) Run(args []string) int {
 			cfg.Okta.Disabled = true
 		}
 	}
+	if val, ok := os.LookupEnv("HERMES_SERVER_OKTA_JWT_SIGNER"); ok {
+		cfg.Okta.JWTSigner = val
+	}
 	if c.flagOktaDisabled {
 		cfg.Okta.Disabled = true
 	}
@@ -191,6 +194,10 @@ func (c *Command) Run(args []string) int {
 		}
 		if cfg.Okta.ClientID == "" {
 			c.UI.Error("error initializing server: Okta client ID is required")
+			return 1
+		}
+		if cfg.Okta.JWTSigner == "" {
+			c.UI.Error("error initializing server: Okta JWT signer is required")
 			return 1
 		}
 	}


### PR DESCRIPTION
This PR adds validation for the `signer` field in the JWT header from an AWS ALB. The trusted signer can be set via the Hermes config file or a `HERMES_SERVER_OKTA_JWT_SIGNER` environment variable.